### PR TITLE
Update Closure Compiler to v20190106

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -2917,6 +2917,7 @@ exports.tests = [
         res : {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
           ie11: false,

--- a/environments.json
+++ b/environments.json
@@ -181,6 +181,30 @@
     "short": "Closure 2018.11",
     "family": "Closure",
     "platformtype": "compiler",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "closure20181210": {
+    "full": "Closure Compiler v20181210",
+    "short": "Closure 2018.12",
+    "family": "Closure",
+    "platformtype": "compiler",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "closure20190106": {
+    "full": "Closure Compiler v20190106",
+    "short": "Closure 2019.01",
+    "family": "Closure",
+    "platformtype": "compiler",
     "obsolete": false,
     "test_suites": [
       "es6",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -138,7 +138,9 @@
 <th class="platform closure20180910 compiler obsolete" data-browser="closure20180910"><a href="#closure20180910" class="browser-name"><abbr title="Closure Compiler v20180910">Closure 2018.09</abbr></a></th>
 <th class="platform closure20181008 compiler obsolete" data-browser="closure20181008"><a href="#closure20181008" class="browser-name"><abbr title="Closure Compiler v20181008">Closure 2018.10</abbr></a></th>
 <th class="platform closure20181028 compiler obsolete" data-browser="closure20181028"><a href="#closure20181028" class="browser-name"><abbr title="Closure Compiler v20181028">Closure 2018.10</abbr></a></th>
-<th class="platform closure20181125 compiler" data-browser="closure20181125"><a href="#closure20181125" class="browser-name"><abbr title="Closure Compiler v20181125">Closure 2018.11</abbr></a></th>
+<th class="platform closure20181125 compiler obsolete" data-browser="closure20181125"><a href="#closure20181125" class="browser-name"><abbr title="Closure Compiler v20181125">Closure 2018.11</abbr></a></th>
+<th class="platform closure20181210 compiler obsolete" data-browser="closure20181210"><a href="#closure20181210" class="browser-name"><abbr title="Closure Compiler v20181210">Closure 2018.12</abbr></a></th>
+<th class="platform closure20190106 compiler" data-browser="closure20190106"><a href="#closure20190106" class="browser-name"><abbr title="Closure Compiler v20190106">Closure 2019.01</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_7corejs2 compiler obsolete" data-browser="typescript2_7corejs2"><a href="#typescript2_7corejs2" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_8corejs2 compiler obsolete" data-browser="typescript2_8corejs2"><a href="#typescript2_8corejs2" class="browser-name"><abbr title="TypeScript 2.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -215,7 +217,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="89">2016 features</td>
+      <tr class="category"><td colspan="91">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -232,7 +234,9 @@
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20181125" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20190106" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -323,7 +327,9 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -414,7 +420,9 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -510,7 +518,9 @@ return true;
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -598,7 +608,9 @@ return true;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20181125" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20190106" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">3/3</td>
@@ -693,7 +705,9 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -806,7 +820,9 @@ return 24;
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -902,7 +918,9 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -975,7 +993,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="samsung7_2">Yes</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="89">2016 misc</td>
+<tr class="category"><td colspan="91">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -1002,7 +1020,9 @@ return true;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1106,7 +1126,9 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -1202,7 +1224,9 @@ return true;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1294,7 +1318,9 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -1387,7 +1413,9 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -1485,7 +1513,9 @@ return passed;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1585,7 +1615,9 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1658,7 +1690,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes obsolete" data-browser="samsung7_2">Yes</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="89">2017 features</td>
+<tr class="category"><td colspan="91">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1675,7 +1707,9 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="closure20181125" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="closure20190106" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">4/4</td>
@@ -1769,7 +1803,9 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1867,7 +1903,9 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1966,7 +2004,9 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2060,7 +2100,9 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2148,7 +2190,9 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20181125" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20190106" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -2244,7 +2288,9 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2340,7 +2386,9 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2428,7 +2476,9 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20181125" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20190106" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -2519,7 +2569,9 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -2610,7 +2662,9 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -2698,7 +2752,9 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td class="tally" data-browser="closure20181125" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
+<td class="tally" data-browser="closure20190106" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
@@ -2800,7 +2856,9 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -2902,7 +2960,9 @@ p.catch(function(result) {
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -2994,7 +3054,9 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -3086,7 +3148,9 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3184,7 +3248,9 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3284,7 +3350,9 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3376,7 +3444,9 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -3473,7 +3543,9 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3565,7 +3637,9 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -3667,7 +3741,9 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3769,7 +3845,9 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3869,7 +3947,9 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3962,7 +4042,9 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4053,7 +4135,9 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4153,7 +4237,9 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4241,7 +4327,9 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/17</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/17</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/17</td>
@@ -4332,7 +4420,9 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4423,7 +4513,9 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4514,7 +4606,9 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4605,7 +4699,9 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4696,7 +4792,9 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4787,7 +4885,9 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4878,7 +4978,9 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4969,7 +5071,9 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5060,7 +5164,9 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5151,7 +5257,9 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5242,7 +5350,9 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5333,7 +5443,9 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5424,7 +5536,9 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5515,7 +5629,9 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5606,7 +5722,9 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5697,7 +5815,9 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5788,7 +5908,9 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5861,7 +5983,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="samsung7_2">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
 <td class="no" data-browser="samsung8_2">No<a href="#chr-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 </tr>
-<tr class="category"><td colspan="89">2017 misc</td>
+<tr class="category"><td colspan="91">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets (ES 2017 semantics)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-duplictate-ownkeys-updated-note"><sup>[22]</sup></a></span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -5886,7 +6008,9 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5980,7 +6104,9 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6074,7 +6200,9 @@ return (function(){
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6147,7 +6275,7 @@ return (function(){
 <td class="yes obsolete" data-browser="samsung7_2">Yes</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="89">2017 annex b</td>
+<tr class="category"><td colspan="91">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -6164,7 +6292,9 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -6260,7 +6390,9 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6357,7 +6489,9 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6454,7 +6588,9 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6550,7 +6686,9 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6647,7 +6785,9 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6744,7 +6884,9 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6842,7 +6984,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6940,7 +7084,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7039,7 +7185,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7135,7 +7283,9 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7230,7 +7380,9 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7328,7 +7480,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7426,7 +7580,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7525,7 +7681,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7621,7 +7779,9 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7716,7 +7876,9 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7804,7 +7966,9 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -7899,7 +8063,9 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7994,7 +8160,9 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8094,7 +8262,9 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8194,7 +8364,9 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8286,7 +8458,9 @@ return i === 0;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8359,7 +8533,7 @@ return i === 0;
 <td class="yes obsolete" data-browser="samsung7_2">Yes</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="89">2018 features</td>
+<tr class="category"><td colspan="91">2018 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -8376,7 +8550,9 @@ return i === 0;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="closure20181125" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="closure20190106" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -8468,7 +8644,9 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -8561,7 +8739,9 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -8649,7 +8829,9 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20181125" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20190106" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">3/3</td>
@@ -8766,7 +8948,9 @@ function check() {
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8875,7 +9059,9 @@ function check() {
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8986,7 +9172,9 @@ function check() {
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9078,7 +9266,9 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -9176,7 +9366,9 @@ return result.groups.year === &apos;2016&apos;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9268,7 +9460,9 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9360,7 +9554,9 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9448,7 +9644,9 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20181125" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20190106" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -9546,7 +9744,9 @@ iterator.next().then(function(step){
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -9654,7 +9854,9 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -9727,7 +9929,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no obsolete" data-browser="samsung7_2">No</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="89">2018 misc</td>
+<tr class="category"><td colspan="91">2018 misc</td>
 </tr>
 <tr significance="0.25"><td id="test-template_literal_revision"><span><a class="anchor" href="#test-template_literal_revision">&#xA7;</a><a href="https://github.com/tc39/proposal-template-literal-revision">template literal revision</a></span><script data-source="
 function tag(strings, a) {
@@ -9754,7 +9956,9 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
-<td class="yes" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9827,7 +10031,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no flagged obsolete" data-browser="samsung7_2">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="89">2019 misc</td>
+<tr class="category"><td colspan="91">2019 misc</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://tc39.github.io/proposal-optional-catch-binding/">optional catch binding</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/3</td>
@@ -9844,7 +10048,9 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">3/3</td>
@@ -9941,7 +10147,9 @@ return false;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -10039,7 +10247,9 @@ return false;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -10142,7 +10352,9 @@ return it.next().value;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -10220,17 +10432,19 @@ return it.next().value;
 <td class="tally" data-browser="babel6corejs2" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="closure20180319" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="closure20180402" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="closure20180506" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="closure20180610" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="closure20180716" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="closure20180805" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="closure20180910" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="closure20181008" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="closure20181028" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally" data-browser="closure20190106" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/3</td>
@@ -10321,7 +10535,9 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -10412,7 +10628,9 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -10493,17 +10711,19 @@ return Symbol().description === undefined;
 <td class="no" data-browser="babel6corejs2">No</td>
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
-<td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="yes obsolete" data-browser="closure">Yes</td>
+<td class="yes obsolete" data-browser="closure20180319">Yes</td>
+<td class="yes obsolete" data-browser="closure20180402">Yes</td>
+<td class="yes obsolete" data-browser="closure20180506">Yes</td>
+<td class="yes obsolete" data-browser="closure20180610">Yes</td>
+<td class="yes obsolete" data-browser="closure20180716">Yes</td>
+<td class="yes obsolete" data-browser="closure20180805">Yes</td>
+<td class="yes obsolete" data-browser="closure20180910">Yes</td>
+<td class="yes obsolete" data-browser="closure20181008">Yes</td>
+<td class="yes obsolete" data-browser="closure20181028">Yes</td>
+<td class="yes obsolete" data-browser="closure20181125">Yes</td>
+<td class="yes obsolete" data-browser="closure20181210">Yes</td>
+<td class="yes" data-browser="closure20190106">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -10591,7 +10811,9 @@ return Symbol().description === undefined;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/7</td>
@@ -10684,7 +10906,9 @@ return fn + &apos;&apos; === str;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10776,7 +11000,9 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10868,7 +11094,9 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10960,7 +11188,9 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -11052,7 +11282,9 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -11144,7 +11376,9 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -11236,7 +11470,9 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -11324,7 +11560,9 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -11415,7 +11653,9 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -11506,7 +11746,9 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -144,7 +144,9 @@
 <th class="platform closure20180910 compiler obsolete" data-browser="closure20180910"><a href="#closure20180910" class="browser-name"><abbr title="Closure Compiler v20180910">Closure 2018.09</abbr></a></th>
 <th class="platform closure20181008 compiler obsolete" data-browser="closure20181008"><a href="#closure20181008" class="browser-name"><abbr title="Closure Compiler v20181008">Closure 2018.10</abbr></a></th>
 <th class="platform closure20181028 compiler obsolete" data-browser="closure20181028"><a href="#closure20181028" class="browser-name"><abbr title="Closure Compiler v20181028">Closure 2018.10</abbr></a></th>
-<th class="platform closure20181125 compiler" data-browser="closure20181125"><a href="#closure20181125" class="browser-name"><abbr title="Closure Compiler v20181125">Closure 2018.11</abbr></a></th>
+<th class="platform closure20181125 compiler obsolete" data-browser="closure20181125"><a href="#closure20181125" class="browser-name"><abbr title="Closure Compiler v20181125">Closure 2018.11</abbr></a></th>
+<th class="platform closure20181210 compiler obsolete" data-browser="closure20181210"><a href="#closure20181210" class="browser-name"><abbr title="Closure Compiler v20181210">Closure 2018.12</abbr></a></th>
+<th class="platform closure20190106 compiler" data-browser="closure20190106"><a href="#closure20190106" class="browser-name"><abbr title="Closure Compiler v20190106">Closure 2019.01</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_7corejs2 compiler obsolete" data-browser="typescript2_7corejs2"><a href="#typescript2_7corejs2" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_8corejs2 compiler obsolete" data-browser="typescript2_8corejs2"><a href="#typescript2_8corejs2" class="browser-name"><abbr title="TypeScript 2.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -219,7 +221,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="87">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="89">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-string_trimming"><span><a class="anchor" href="#test-string_trimming">&#xA7;</a><a href="https://github.com/tc39/proposal-string-left-right-trim">string trimming</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -236,7 +238,9 @@
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">4/4</td>
@@ -325,7 +329,9 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -414,7 +420,9 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -503,7 +511,9 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -592,7 +602,9 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -678,7 +690,9 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -769,7 +783,9 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -864,7 +880,9 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -963,7 +981,9 @@ return a === &apos;1a2b&apos;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -1049,7 +1069,9 @@ return a === &apos;1a2b&apos;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -1141,7 +1163,9 @@ return new C().x === &apos;x&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -1239,7 +1263,9 @@ return new C(42).x() === 42;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1334,7 +1360,9 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1420,7 +1448,9 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -1512,7 +1542,9 @@ return C.x === &apos;x&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -1607,7 +1639,9 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1693,7 +1727,9 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -1782,7 +1818,9 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -1873,7 +1911,9 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -1959,7 +1999,9 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/8</td>
@@ -2048,7 +2090,9 @@ return (1n + 2n) === 3n;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2137,7 +2181,9 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2226,7 +2272,9 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2315,7 +2363,9 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2407,7 +2457,9 @@ return view[0] === -0x8000000000000000n;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2499,7 +2551,9 @@ return view[0] === 0n;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2588,7 +2642,9 @@ return typeof DataView.prototype.getBigInt64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2677,7 +2733,9 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2767,7 +2825,9 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -2857,7 +2917,9 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2928,7 +2990,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no obsolete" data-browser="samsung7_2">No</td>
 <td class="no" data-browser="samsung8_2">No</td>
 </tr>
-<tr class="category"><td colspan="87">Draft (stage 2)</td>
+<tr class="category"><td colspan="89">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -2954,7 +3016,9 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3040,7 +3104,9 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/1</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/1</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">1/1</td>
@@ -3137,7 +3203,9 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -3229,7 +3297,9 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3322,7 +3392,9 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3408,7 +3480,9 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/4</td>
@@ -3503,7 +3577,9 @@ try {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3602,7 +3678,9 @@ try {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3696,7 +3774,9 @@ try {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3790,7 +3870,9 @@ try {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3880,7 +3962,9 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -3966,7 +4050,9 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/7</td>
@@ -4058,7 +4144,9 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -4151,7 +4239,9 @@ return set.size === 3
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -4243,7 +4333,9 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -4335,7 +4427,9 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -4424,7 +4518,9 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -4513,7 +4609,9 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -4602,7 +4700,9 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -4688,7 +4788,9 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -4780,7 +4882,9 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4872,7 +4976,9 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4943,7 +5049,7 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="samsung7_2">No</td>
 <td class="no" data-browser="samsung8_2">No</td>
 </tr>
-<tr class="category"><td colspan="87">Proposal (stage 1)</td>
+<tr class="category"><td colspan="89">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="https://github.com/tc39/proposal-do-expressions">do expressions</a></span><script data-source="
 return do {
@@ -4966,7 +5072,9 @@ return do {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5052,7 +5160,9 @@ return do {
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">7/7</td>
@@ -5141,7 +5251,9 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5230,7 +5342,9 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5319,7 +5433,9 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5418,7 +5534,9 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5508,7 +5626,9 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5597,7 +5717,9 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5686,7 +5808,9 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5776,7 +5900,9 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5868,7 +5994,9 @@ return Math.signbit(-0) === false
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -5954,7 +6082,9 @@ return Math.signbit(-0) === false
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">7/7</td>
@@ -6045,7 +6175,9 @@ return Math.clamp(2, 4, 6) === 4
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6134,7 +6266,9 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6224,7 +6358,9 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6313,7 +6449,9 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6402,7 +6540,9 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6492,7 +6632,9 @@ return Math.radians(90) === Math.PI / 2
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6581,7 +6723,9 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6667,7 +6811,9 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">7/7</td>
@@ -6756,7 +6902,9 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6845,7 +6993,9 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -6936,7 +7086,9 @@ return score === 1;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7032,7 +7184,9 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7128,7 +7282,9 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7224,7 +7380,9 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7320,7 +7478,9 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7406,7 +7566,9 @@ Promise.try(function() {
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">8/8</td>
@@ -7498,7 +7660,9 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7592,7 +7756,9 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7684,7 +7850,9 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7776,7 +7944,9 @@ return C.has(3) + C.has(4);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7868,7 +8038,9 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -7962,7 +8134,9 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8054,7 +8228,9 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8146,7 +8322,9 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -8247,7 +8425,9 @@ return result === &apos;Hello, hello!&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8340,7 +8520,9 @@ return 123i === &apos;string123number123&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8426,7 +8608,9 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/3</td>
@@ -8517,7 +8701,9 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8608,7 +8794,9 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8699,7 +8887,9 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8792,7 +8982,9 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8878,7 +9070,9 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/12</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/12</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/12</td>
@@ -8971,7 +9165,9 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9064,7 +9260,9 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9157,7 +9355,9 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9250,7 +9450,9 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9343,7 +9545,9 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9436,7 +9640,9 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9529,7 +9735,9 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9625,7 +9833,9 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9719,7 +9929,9 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9812,7 +10024,9 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9905,7 +10119,9 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9998,7 +10214,9 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10084,7 +10302,9 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/8</td>
@@ -10173,7 +10393,9 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10262,7 +10484,9 @@ return Object.isFrozen([# 42 #]);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10351,7 +10575,9 @@ return Object.isSealed({| foo: 42 |});
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10440,7 +10666,9 @@ return Object.isSealed([| 42 |]);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10537,7 +10765,9 @@ try {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10635,7 +10865,9 @@ try {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10732,7 +10964,9 @@ try {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10830,7 +11064,9 @@ try {
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10919,7 +11155,9 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -11013,7 +11251,9 @@ return results.length === 3
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -11099,7 +11339,9 @@ return results.length === 3
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -11188,7 +11430,9 @@ return [1, 2, 3].lastItem === 3;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -11277,7 +11521,9 @@ return [1, 2, 3].lastIndex === 2;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -11363,7 +11609,9 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/26</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/26</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/26</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/26</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/26</td>
@@ -11457,7 +11705,9 @@ return map.size === 2
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -11549,7 +11799,9 @@ return map.size === 2
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -11642,7 +11894,9 @@ return map.size === 2
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -11731,7 +11985,9 @@ return new Map([[1, 4], [2, 5], [3, 6]]).every(it =&gt; typeof it == &apos;numbe
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -11823,7 +12079,9 @@ return map.size === 2
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -11912,7 +12170,9 @@ return new Map([[1, 2], [2, 3], [3, 4]]).find(it =&gt; it % 2) === 3;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -12001,7 +12261,9 @@ return new Map([[1, 2], [2, 3], [3, 4]]).findKey(it =&gt; it % 2) === 2;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -12091,7 +12353,9 @@ return new Map([[1, 2], [2, NaN]]).includes(2)
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -12181,7 +12445,9 @@ return new Map([[1, 2], [2, NaN]]).keyOf(2) === 1
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -12274,7 +12540,9 @@ return map.size === 3
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -12367,7 +12635,9 @@ return map.size === 3
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -12460,7 +12730,9 @@ return map.size === 3
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -12549,7 +12821,9 @@ return new Map([[&apos;a&apos;, 1], [&apos;b&apos;, 2], [&apos;c&apos;, 3], ]).r
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -12638,7 +12912,9 @@ return new Map([[1, 4], [2, 5], [3, 6]]).some(it =&gt; it % 2);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -12731,7 +13007,9 @@ return set.size === 3
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -12824,7 +13102,9 @@ return set.deleteAll(2, 3) === true
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -12913,7 +13193,9 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -13005,7 +13287,9 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -13094,7 +13378,9 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -13183,7 +13469,9 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -13276,7 +13564,9 @@ return set.size === 3
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -13365,7 +13655,9 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -13454,7 +13746,9 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -13552,7 +13846,9 @@ return !map.has(a)
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -13650,7 +13946,9 @@ return set.has(a)
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -13748,7 +14046,9 @@ return !set.has(a)
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -13848,7 +14148,9 @@ Promise.allSettled([
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -13945,7 +14247,9 @@ return second === gen2.next().value;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -14031,7 +14335,9 @@ return second === gen2.next().value;
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20181125" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -14120,7 +14426,9 @@ return Number.fromString(&apos;42&apos;) === 42;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[7]</sup></a></td>
@@ -14209,7 +14517,9 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181125">No</td>
+<td class="no obsolete" data-browser="closure20181210">No</td>
+<td class="no" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -14280,7 +14590,7 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="no obsolete" data-browser="samsung7_2">No</td>
 <td class="no" data-browser="samsung8_2">No</td>
 </tr>
-<tr class="category"><td colspan="87">Strawman (stage 0)</td>
+<tr class="category"><td colspan="89">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14297,7 +14607,9 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14388,7 +14700,9 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14478,7 +14792,9 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14567,7 +14883,9 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -14653,7 +14971,9 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -14743,7 +15063,9 @@ return f();
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14832,7 +15154,9 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14926,7 +15250,9 @@ return Array.isArray(arr)
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15026,7 +15352,9 @@ return target === C.prototype
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -15122,7 +15450,9 @@ return (@inverse function(it){
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15208,7 +15538,9 @@ return (@inverse function(it){
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -15299,7 +15631,9 @@ return Reflect.isCallable(function(){})
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15390,7 +15724,9 @@ return Reflect.isConstructor(function(){})
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15476,7 +15812,9 @@ return Reflect.isConstructor(function(){})
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -15565,7 +15903,9 @@ return typeof Zone == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15654,7 +15994,9 @@ return &apos;current&apos; in Zone;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15743,7 +16085,9 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15832,7 +16176,9 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15921,7 +16267,9 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16010,7 +16358,9 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16099,7 +16449,9 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16185,7 +16537,9 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -16280,7 +16634,9 @@ return (function f(n){
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16382,7 +16738,9 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16468,7 +16826,9 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -16559,7 +16919,9 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16651,7 +17013,9 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16722,7 +17086,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="samsung7_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="samsung8_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="87">Pre-strawman</td>
+<tr class="category"><td colspan="89">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -16739,7 +17103,9 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
@@ -16828,7 +17194,9 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -16917,7 +17285,9 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -17006,7 +17376,9 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -17095,7 +17467,9 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -17184,7 +17558,9 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -17273,7 +17649,9 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -17362,7 +17740,9 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -17451,7 +17831,9 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
@@ -17540,7 +17922,9 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[5]</sup></a></td>


### PR DESCRIPTION
No updates for compat-table in recent two versions.
It has passed Symbol.prototype.description undefined test for a long time.