### PR TITLE
Update Closure Compiler to v20190215

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -2356,7 +2356,11 @@ exports.tests = [
         res: {
           babel6corejs2: true,
           closure: true,
-          closure20181028: false,
+          closure20181028: {
+            val: false,
+            note_id: 'closure-object-assign',
+            note_html: 'Requires native support for <code>Object.assign</code>',
+          },
           typescript2_1corejs2: true,
           jsx: true,
           ie11: false,
@@ -2383,6 +2387,10 @@ exports.tests = [
         res: {
           babel6corejs2: true,
           closure: true,
+          closure20190121: {
+            val: false,
+            note_id: 'closure-object-assign',
+          },
           jsx: true,
           ie11: false,
           firefox2: false,
@@ -2778,6 +2786,7 @@ exports.tests = [
         */},
         res: {
           babel7corejs2: true,
+          closure20190215: true,
           typescript2_5corejs2: true,
           ie11: false,
           firefox2: false,
@@ -2807,6 +2816,7 @@ exports.tests = [
         */},
         res: {
           babel7corejs2: true,
+          closure20190215: true,
           typescript2_5corejs2: true,
           ie11: false,
           firefox2: false,
@@ -2841,6 +2851,7 @@ exports.tests = [
         */},
         res: {
           babel7corejs2: true,
+          closure20190215: true,
           typescript2_5corejs2: true,
           ie11: false,
           firefox2: false,
@@ -3083,6 +3094,7 @@ exports.tests = [
           return eval("'\u2028'") === "\u2028";
         */},
         res : {
+          closure20190215: true,
           ie11: false,
           firefox2: false,
           firefox61: false,
@@ -3099,6 +3111,7 @@ exports.tests = [
           return eval("'\u2029'") === "\u2029";
         */},
         res : {
+          closure20190215: true,
           ie11: false,
           firefox2: false,
           firefox61: false,

--- a/data-es6.js
+++ b/data-es6.js
@@ -18659,6 +18659,7 @@ exports.tests = [
       res: {
         ejs: true,
         babel6corejs2: babel.corejs,
+        closure20190215: true,
         typescript1corejs2: typescript.corejs,
         tr: true,
         es6shim: true,

--- a/environments.json
+++ b/environments.json
@@ -205,6 +205,30 @@
     "short": "Closure 2019.01",
     "family": "Closure",
     "platformtype": "compiler",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "closure20190121": {
+    "full": "Closure Compiler v20190121",
+    "short": "Closure 2019.01",
+    "family": "Closure",
+    "platformtype": "compiler",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "closure20190215": {
+    "full": "Closure Compiler v20190215",
+    "short": "Closure 2019.02",
+    "family": "Closure",
+    "platformtype": "compiler",
     "obsolete": false,
     "test_suites": [
       "es6",

--- a/environments.json
+++ b/environments.json
@@ -73,7 +73,7 @@
     "short": "Closure 2018.03",
     "family": "Closure",
     "platformtype": "compiler",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -85,7 +85,7 @@
     "short": "Closure 2018.04",
     "family": "Closure",
     "platformtype": "compiler",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -97,7 +97,7 @@
     "short": "Closure 2018.05",
     "family": "Closure",
     "platformtype": "compiler",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -109,7 +109,7 @@
     "short": "Closure 2018.06",
     "family": "Closure",
     "platformtype": "compiler",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -121,7 +121,7 @@
     "short": "Closure 2018.07",
     "family": "Closure",
     "platformtype": "compiler",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -133,7 +133,7 @@
     "short": "Closure 2018.08",
     "family": "Closure",
     "platformtype": "compiler",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -129,12 +129,6 @@
 <th class="platform babel7corejs2 compiler" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler unstable" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform closure compiler obsolete" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure 2018.02</abbr></a></th>
-<th class="platform closure20180319 compiler obsolete" data-browser="closure20180319"><a href="#closure20180319" class="browser-name"><abbr title="Closure Compiler v20180319">Closure 2018.03</abbr></a></th>
-<th class="platform closure20180402 compiler obsolete" data-browser="closure20180402"><a href="#closure20180402" class="browser-name"><abbr title="Closure Compiler v20180402">Closure 2018.04</abbr></a></th>
-<th class="platform closure20180506 compiler obsolete" data-browser="closure20180506"><a href="#closure20180506" class="browser-name"><abbr title="Closure Compiler v20180506">Closure 2018.05</abbr></a></th>
-<th class="platform closure20180610 compiler obsolete" data-browser="closure20180610"><a href="#closure20180610" class="browser-name"><abbr title="Closure Compiler v20180610">Closure 2018.06</abbr></a></th>
-<th class="platform closure20180716 compiler obsolete" data-browser="closure20180716"><a href="#closure20180716" class="browser-name"><abbr title="Closure Compiler v20180716">Closure 2018.07</abbr></a></th>
-<th class="platform closure20180805 compiler obsolete" data-browser="closure20180805"><a href="#closure20180805" class="browser-name"><abbr title="Closure Compiler v20180805">Closure 2018.08</abbr></a></th>
 <th class="platform closure20180910 compiler obsolete" data-browser="closure20180910"><a href="#closure20180910" class="browser-name"><abbr title="Closure Compiler v20180910">Closure 2018.09</abbr></a></th>
 <th class="platform closure20181008 compiler obsolete" data-browser="closure20181008"><a href="#closure20181008" class="browser-name"><abbr title="Closure Compiler v20181008">Closure 2018.10</abbr></a></th>
 <th class="platform closure20181028 compiler obsolete" data-browser="closure20181028"><a href="#closure20181028" class="browser-name"><abbr title="Closure Compiler v20181028">Closure 2018.10</abbr></a></th>
@@ -224,7 +218,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="98">2016 features</td>
+      <tr class="category"><td colspan="92">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -232,12 +226,6 @@
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">3/3</td>
@@ -332,12 +320,6 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -432,12 +414,6 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -537,12 +513,6 @@ return true;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -634,12 +604,6 @@ return true;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -738,12 +702,6 @@ return [1, 2, 3].includes(1)
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -860,12 +818,6 @@ return 24;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -965,12 +917,6 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -1056,7 +1002,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="samsung7_2">Yes</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="98">2016 misc</td>
+<tr class="category"><td colspan="92">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -1074,12 +1020,6 @@ return true;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -1187,12 +1127,6 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -1292,12 +1226,6 @@ return true;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -1393,12 +1321,6 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -1495,12 +1417,6 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -1602,12 +1518,6 @@ return passed;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -1711,12 +1621,6 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -1802,7 +1706,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes obsolete" data-browser="samsung7_2">Yes</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="98">2017 features</td>
+<tr class="category"><td colspan="92">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1810,12 +1714,6 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
@@ -1913,12 +1811,6 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -2020,12 +1912,6 @@ return Array.isArray(e)
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -2128,12 +2014,6 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -2231,12 +2111,6 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -2328,12 +2202,6 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
@@ -2433,12 +2301,6 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -2538,12 +2400,6 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -2635,12 +2491,6 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
@@ -2735,12 +2585,6 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -2835,12 +2679,6 @@ return Math.min(1,2,3,) === 1;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -2932,12 +2770,6 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0.2" style="background-color:hsl(24,77%,50%)">3/15</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
@@ -3043,12 +2875,6 @@ p.then(function(result) {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -3154,12 +2980,6 @@ p.catch(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -3255,12 +3075,6 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -3356,12 +3170,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -3463,12 +3271,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -3572,12 +3374,6 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -3673,12 +3469,6 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -3779,12 +3569,6 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -3880,12 +3664,6 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -3991,12 +3769,6 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -4102,12 +3874,6 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -4211,12 +3977,6 @@ p.then(function(result) {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -4313,12 +4073,6 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -4413,12 +4167,6 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -4522,12 +4270,6 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -4619,12 +4361,6 @@ p.then(function(result) {
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/17</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/17</td>
@@ -4719,12 +4455,6 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -4819,12 +4549,6 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -4919,12 +4643,6 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5019,12 +4737,6 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5119,12 +4831,6 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5219,12 +4925,6 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5319,12 +5019,6 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5419,12 +5113,6 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5519,12 +5207,6 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5619,12 +5301,6 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5719,12 +5395,6 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5819,12 +5489,6 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5919,12 +5583,6 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6019,12 +5677,6 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6119,12 +5771,6 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6219,12 +5865,6 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6319,12 +5959,6 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6410,7 +6044,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="samsung7_2">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
 <td class="no" data-browser="samsung8_2">No<a href="#chr-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 </tr>
-<tr class="category"><td colspan="98">2017 misc</td>
+<tr class="category"><td colspan="92">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets (ES 2017 semantics)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-duplictate-ownkeys-updated-note"><sup>[22]</sup></a></span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -6426,12 +6060,6 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6529,12 +6157,6 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6632,12 +6254,6 @@ return (function(){
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6723,7 +6339,7 @@ return (function(){
 <td class="yes obsolete" data-browser="samsung7_2">Yes</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="98">2017 annex b</td>
+<tr class="category"><td colspan="92">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -6731,12 +6347,6 @@ return (function(){
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -6836,12 +6446,6 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -6942,12 +6546,6 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7048,12 +6646,6 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7153,12 +6745,6 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7259,12 +6845,6 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7365,12 +6945,6 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7472,12 +7046,6 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7579,12 +7147,6 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7687,12 +7249,6 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7792,12 +7348,6 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -7896,12 +7446,6 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8003,12 +7547,6 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8110,12 +7648,6 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8218,12 +7750,6 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8323,12 +7849,6 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8427,12 +7947,6 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8524,12 +8038,6 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -8628,12 +8136,6 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8732,12 +8234,6 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8841,12 +8337,6 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8950,12 +8440,6 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9051,12 +8535,6 @@ return i === 0;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9142,7 +8620,7 @@ return i === 0;
 <td class="yes obsolete" data-browser="samsung7_2">Yes</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="98">2018 features</td>
+<tr class="category"><td colspan="92">2018 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -9150,12 +8628,6 @@ return i === 0;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -9251,12 +8723,6 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="no obsolete" data-browser="closure20181028">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
@@ -9353,12 +8819,6 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180319">Yes</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -9450,12 +8910,6 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">3/3</td>
@@ -9576,12 +9030,6 @@ function check() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -9694,12 +9142,6 @@ function check() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -9814,12 +9256,6 @@ function check() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="yes obsolete" data-browser="closure20180402">Yes</td>
-<td class="yes obsolete" data-browser="closure20180506">Yes</td>
-<td class="yes obsolete" data-browser="closure20180610">Yes</td>
-<td class="yes obsolete" data-browser="closure20180716">Yes</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -9915,12 +9351,6 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -10022,12 +9452,6 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -10123,12 +9547,6 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -10224,12 +9642,6 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -10321,12 +9733,6 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
@@ -10428,12 +9834,6 @@ iterator.next().then(function(step){
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -10545,12 +9945,6 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -10636,7 +10030,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no obsolete" data-browser="samsung7_2">No</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="98">2018 misc</td>
+<tr class="category"><td colspan="92">2018 misc</td>
 </tr>
 <tr significance="0.25"><td id="test-template_literal_revision"><span><a class="anchor" href="#test-template_literal_revision">&#xA7;</a><a href="https://github.com/tc39/proposal-template-literal-revision">template literal revision</a></span><script data-source="
 function tag(strings, a) {
@@ -10654,12 +10048,6 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
@@ -10745,7 +10133,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no flagged obsolete" data-browser="samsung7_2">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="98">2019 features</td>
+<tr class="category"><td colspan="92">2019 features</td>
 </tr>
 <tr significance="0.25"><td id="test-Object.fromEntries"><span><a class="anchor" href="#test-Object.fromEntries">&#xA7;</a><a href="https://github.com/tc39/proposal-object-from-entries">Object.fromEntries</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var object = Object.fromEntries(new Map([[&apos;foo&apos;, 42], [&apos;bar&apos;, 23]]));
@@ -10757,12 +10145,6 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -10854,12 +10236,6 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/4</td>
@@ -10954,12 +10330,6 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11054,12 +10424,6 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11154,12 +10518,6 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11254,12 +10612,6 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11351,12 +10703,6 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
@@ -11451,12 +10797,6 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11553,12 +10893,6 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11654,12 +10988,6 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11745,7 +11073,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="no obsolete" data-browser="samsung7_2">No</td>
 <td class="no" data-browser="samsung8_2">No</td>
 </tr>
-<tr class="category"><td colspan="98">2019 misc</td>
+<tr class="category"><td colspan="92">2019 misc</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://tc39.github.io/proposal-optional-catch-binding/">optional catch binding</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/3</td>
@@ -11753,12 +11081,6 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
@@ -11859,12 +11181,6 @@ return false;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11966,12 +11282,6 @@ return false;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12078,12 +11388,6 @@ return it.next().value;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12175,12 +11479,6 @@ return it.next().value;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
@@ -12275,12 +11573,6 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12375,12 +11667,6 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12476,12 +11762,6 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12573,12 +11853,6 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
@@ -12675,12 +11949,6 @@ return fn + &apos;&apos; === str;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12776,12 +12044,6 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12877,12 +12139,6 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12978,12 +12234,6 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13079,12 +12329,6 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13180,12 +12424,6 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13281,12 +12519,6 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13378,12 +12610,6 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
@@ -13478,12 +12704,6 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13578,12 +12798,6 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13679,12 +12893,6 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -140,7 +140,9 @@
 <th class="platform closure20181028 compiler obsolete" data-browser="closure20181028"><a href="#closure20181028" class="browser-name"><abbr title="Closure Compiler v20181028">Closure 2018.10</abbr></a></th>
 <th class="platform closure20181125 compiler obsolete" data-browser="closure20181125"><a href="#closure20181125" class="browser-name"><abbr title="Closure Compiler v20181125">Closure 2018.11</abbr></a></th>
 <th class="platform closure20181210 compiler obsolete" data-browser="closure20181210"><a href="#closure20181210" class="browser-name"><abbr title="Closure Compiler v20181210">Closure 2018.12</abbr></a></th>
-<th class="platform closure20190106 compiler" data-browser="closure20190106"><a href="#closure20190106" class="browser-name"><abbr title="Closure Compiler v20190106">Closure 2019.01</abbr></a></th>
+<th class="platform closure20190106 compiler obsolete" data-browser="closure20190106"><a href="#closure20190106" class="browser-name"><abbr title="Closure Compiler v20190106">Closure 2019.01</abbr></a></th>
+<th class="platform closure20190121 compiler obsolete" data-browser="closure20190121"><a href="#closure20190121" class="browser-name"><abbr title="Closure Compiler v20190121">Closure 2019.01</abbr></a></th>
+<th class="platform closure20190215 compiler" data-browser="closure20190215"><a href="#closure20190215" class="browser-name"><abbr title="Closure Compiler v20190215">Closure 2019.02</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_7corejs2 compiler obsolete" data-browser="typescript2_7corejs2"><a href="#typescript2_7corejs2" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_8corejs2 compiler obsolete" data-browser="typescript2_8corejs2"><a href="#typescript2_8corejs2" class="browser-name"><abbr title="TypeScript 2.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -222,7 +224,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="96">2016 features</td>
+      <tr class="category"><td colspan="98">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -241,7 +243,9 @@
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20190106" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20190215" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -339,7 +343,9 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -437,7 +443,9 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -540,7 +548,9 @@ return true;
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -635,7 +645,9 @@ return true;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20190106" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20190215" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">3/3</td>
@@ -737,7 +749,9 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -857,7 +871,9 @@ return 24;
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -960,7 +976,9 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1038,7 +1056,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="samsung7_2">Yes</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="96">2016 misc</td>
+<tr class="category"><td colspan="98">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -1067,7 +1085,9 @@ return true;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1178,7 +1198,9 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -1281,7 +1303,9 @@ return true;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1380,7 +1404,9 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -1480,7 +1506,9 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -1585,7 +1613,9 @@ return passed;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1692,7 +1722,9 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1770,7 +1802,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes obsolete" data-browser="samsung7_2">Yes</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="96">2017 features</td>
+<tr class="category"><td colspan="98">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/4</td>
@@ -1789,7 +1821,9 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="closure20190106" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="closure20190215" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">4/4</td>
@@ -1890,7 +1924,9 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1995,7 +2031,9 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2101,7 +2139,9 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2202,7 +2242,9 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2297,7 +2339,9 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20190106" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20190215" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -2400,7 +2444,9 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2503,7 +2549,9 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2598,7 +2646,9 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20190106" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20190215" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -2696,7 +2746,9 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -2794,7 +2846,9 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -2889,7 +2943,9 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
-<td class="tally" data-browser="closure20190106" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
+<td class="tally" data-browser="closure20190215" data-tally="0.6" style="background-color:hsl(72,59%,50%)">9/15</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.5333333333333333" style="background-color:hsl(64,62%,50%)">8/15</td>
@@ -2998,7 +3054,9 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3107,7 +3165,9 @@ p.catch(function(result) {
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3206,7 +3266,9 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -3305,7 +3367,9 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3410,7 +3474,9 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3517,7 +3583,9 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3616,7 +3684,9 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -3720,7 +3790,9 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3819,7 +3891,9 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -3928,7 +4002,9 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4037,7 +4113,9 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4144,7 +4222,9 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4244,7 +4324,9 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4342,7 +4424,9 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4449,7 +4533,9 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4544,7 +4630,9 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/17</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/17</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/17</td>
@@ -4642,7 +4730,9 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4740,7 +4830,9 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4838,7 +4930,9 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4936,7 +5030,9 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5034,7 +5130,9 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5132,7 +5230,9 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5230,7 +5330,9 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5328,7 +5430,9 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5426,7 +5530,9 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5524,7 +5630,9 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5622,7 +5730,9 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5720,7 +5830,9 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5818,7 +5930,9 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5916,7 +6030,9 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6014,7 +6130,9 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6112,7 +6230,9 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6210,7 +6330,9 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6288,7 +6410,7 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no flagged obsolete" data-browser="samsung7_2">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
 <td class="no" data-browser="samsung8_2">No<a href="#chr-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 </tr>
-<tr class="category"><td colspan="96">2017 misc</td>
+<tr class="category"><td colspan="98">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets (ES 2017 semantics)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#proxy-duplictate-ownkeys-updated-note"><sup>[22]</sup></a></span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
@@ -6315,7 +6437,9 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6416,7 +6540,9 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6517,7 +6643,9 @@ return (function(){
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6595,7 +6723,7 @@ return (function(){
 <td class="yes obsolete" data-browser="samsung7_2">Yes</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="96">2017 annex b</td>
+<tr class="category"><td colspan="98">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -6614,7 +6742,9 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -6717,7 +6847,9 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6821,7 +6953,9 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6925,7 +7059,9 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7028,7 +7164,9 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7132,7 +7270,9 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7236,7 +7376,9 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7341,7 +7483,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7446,7 +7590,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7552,7 +7698,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7655,7 +7803,9 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7757,7 +7907,9 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7862,7 +8014,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7967,7 +8121,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8073,7 +8229,9 @@ return foo() === &quot;bar&quot;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8176,7 +8334,9 @@ return true;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8278,7 +8438,9 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8373,7 +8535,9 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -8475,7 +8639,9 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8577,7 +8743,9 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8684,7 +8852,9 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8791,7 +8961,9 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8890,7 +9062,9 @@ return i === 0;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8968,7 +9142,7 @@ return i === 0;
 <td class="yes obsolete" data-browser="samsung7_2">Yes</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="96">2018 features</td>
+<tr class="category"><td colspan="98">2018 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -8987,7 +9161,9 @@ return i === 0;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="closure20190106" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -9083,10 +9259,12 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes obsolete" data-browser="closure20180805">Yes</td>
 <td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
-<td class="no obsolete" data-browser="closure20181028">No</td>
-<td class="no obsolete" data-browser="closure20181125">No</td>
-<td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20181028">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="closure20181125">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="closure20181210">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190106">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="closure20190215">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -9186,7 +9364,9 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="closure20190215">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -9281,7 +9461,9 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20190106" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20190215" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">3/3</td>
@@ -9405,7 +9587,9 @@ function check() {
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9461,8 +9645,8 @@ function check() {
 <td class="no obsolete" data-browser="node7_6">No</td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
-<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
+<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
 <td class="yes" data-browser="node10_9">Yes</td>
@@ -9521,7 +9705,9 @@ function check() {
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9577,8 +9763,8 @@ function check() {
 <td class="no obsolete" data-browser="node7_6">No</td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
-<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
+<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
 <td class="yes" data-browser="node10_9">Yes</td>
@@ -9639,7 +9825,9 @@ function check() {
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9695,8 +9883,8 @@ function check() {
 <td class="no obsolete" data-browser="node7_6">No</td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
-<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
+<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
 <td class="yes" data-browser="node10_9">Yes</td>
@@ -9738,7 +9926,9 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -9843,7 +10033,9 @@ return result.groups.year === &apos;2016&apos;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9942,7 +10134,9 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10041,7 +10235,9 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10136,7 +10332,9 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20190106" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20190215" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -10241,7 +10439,9 @@ iterator.next().then(function(step){
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -10356,7 +10556,9 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -10434,7 +10636,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="no obsolete" data-browser="samsung7_2">No</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="96">2018 misc</td>
+<tr class="category"><td colspan="98">2018 misc</td>
 </tr>
 <tr significance="0.25"><td id="test-template_literal_revision"><span><a class="anchor" href="#test-template_literal_revision">&#xA7;</a><a href="https://github.com/tc39/proposal-template-literal-revision">template literal revision</a></span><script data-source="
 function tag(strings, a) {
@@ -10463,7 +10665,9 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
-<td class="yes" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190106">Yes</td>
+<td class="yes obsolete" data-browser="closure20190121">Yes</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10541,7 +10745,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no flagged obsolete" data-browser="samsung7_2">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="96">2019 features</td>
+<tr class="category"><td colspan="98">2019 features</td>
 </tr>
 <tr significance="0.25"><td id="test-Object.fromEntries"><span><a class="anchor" href="#test-Object.fromEntries">&#xA7;</a><a href="https://github.com/tc39/proposal-object-from-entries">Object.fromEntries</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var object = Object.fromEntries(new Map([[&apos;foo&apos;, 42], [&apos;bar&apos;, 23]]));
@@ -10564,14 +10768,16 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="yes unstable" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -10659,7 +10865,9 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">4/4</td>
@@ -10757,7 +10965,9 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10855,7 +11065,9 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10953,7 +11165,9 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10972,7 +11186,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no obsolete" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox58">No</td>
 <td class="no obsolete" data-browser="firefox59">No</td>
-<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[26]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
 <td class="yes obsolete" data-browser="firefox62">Yes</td>
 <td class="yes obsolete" data-browser="firefox63">Yes</td>
@@ -11051,7 +11265,9 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11070,7 +11286,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox58">No</td>
 <td class="no obsolete" data-browser="firefox59">No</td>
-<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[26]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
 <td class="yes obsolete" data-browser="firefox62">Yes</td>
 <td class="yes obsolete" data-browser="firefox63">Yes</td>
@@ -11129,7 +11345,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no obsolete" data-browser="samsung7_2">No</td>
 <td class="no" data-browser="samsung8_2">No</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="test-Array.prototype.{flat,_flatMap}"><span><a class="anchor" href="#test-Array.prototype.{flat,_flatMap}">&#xA7;</a><a href="https://tc39.github.io/proposal-flatMap/">Array.prototype.{flat, flatMap}</a><a href="#flatten-compat-issue-note"><sup>[27]</sup></a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-Array.prototype.{flat,_flatMap}"><span><a class="anchor" href="#test-Array.prototype.{flat,_flatMap}">&#xA7;</a><a href="https://tc39.github.io/proposal-flatMap/">Array.prototype.{flat, flatMap}</a><a href="#flatten-compat-issue-note"><sup>[28]</sup></a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel6corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -11146,7 +11362,9 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -11244,14 +11462,16 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="yes unstable" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -11262,9 +11482,9 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no unstable" data-browser="edge19">No</td>
 <td class="no obsolete" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox58">No</td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#ffox-flatten-note"><sup>[28]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#ffox-flatten-note"><sup>[28]</sup></a></td>
-<td class="no obsolete" data-browser="firefox61">No<a href="#ffox-flatten-note"><sup>[28]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#ffox-flatten-note"><sup>[29]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#ffox-flatten-note"><sup>[29]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#ffox-flatten-note"><sup>[29]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox62">Yes</td>
 <td class="yes obsolete" data-browser="firefox63">Yes</td>
 <td class="yes" data-browser="firefox64">Yes</td>
@@ -11344,7 +11564,9 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11362,9 +11584,9 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no unstable" data-browser="edge19">No</td>
 <td class="no obsolete" data-browser="firefox52">No</td>
 <td class="no obsolete" data-browser="firefox58">No</td>
-<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[26]</sup></a></td>
-<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[26]</sup></a></td>
-<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[26]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox62">Yes</td>
 <td class="yes obsolete" data-browser="firefox63">Yes</td>
 <td class="yes" data-browser="firefox64">Yes</td>
@@ -11443,14 +11665,16 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="yes unstable" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -11521,7 +11745,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="no obsolete" data-browser="samsung7_2">No</td>
 <td class="no" data-browser="samsung8_2">No</td>
 </tr>
-<tr class="category"><td colspan="96">2019 misc</td>
+<tr class="category"><td colspan="98">2019 misc</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://tc39.github.io/proposal-optional-catch-binding/">optional catch binding</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/3</td>
@@ -11540,7 +11764,9 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20190215" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">3/3</td>
@@ -11644,7 +11870,9 @@ return false;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -11749,7 +11977,9 @@ return false;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -11859,7 +12089,9 @@ return it.next().value;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -11954,7 +12186,9 @@ return it.next().value;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/3</td>
@@ -12052,14 +12286,16 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="yes unstable" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -12150,14 +12386,16 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="yes unstable" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -12249,14 +12487,16 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
-<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="yes unstable" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="no" data-browser="es7shim">No</td>
 <td class="no" data-browser="ie11">No</td>
@@ -12344,7 +12584,9 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/7</td>
@@ -12444,7 +12686,9 @@ return fn + &apos;&apos; === str;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12543,7 +12787,9 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12642,7 +12888,9 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12741,7 +12989,9 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12840,7 +13090,9 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12939,7 +13191,9 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -13038,7 +13292,9 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -13133,7 +13389,9 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190215" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -13231,7 +13489,9 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -13329,7 +13589,9 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="yes" data-browser="closure20190215">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -13428,7 +13690,9 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -13510,7 +13774,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="chrome-experimental-note">  <sup>[4]</sup> The feature have to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="babel-core-js-note">  <sup>[5]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="typescript-downlevel-iteration-note">  <sup>[9]</sup> Requires the <code>downlevelIteration</code> compile option.</p><p id="strict-fn-non-strict-params-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[12]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[13]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="babel-regenerator-note">  <sup>[14]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="edge-experimental-flag-note">  <sup>[15]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="edg-shared-memory-spectre-note">  <sup>[16]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="firefox-developer-note">  <sup>[17]</sup> The feature is available only in Firefox Developer Edition and Firefox Nightly builds.</p><p id="fx-shared-memory-spectre-note">  <sup>[18]</sup> The feature was <a href="https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.  It can be enabled via <code>javascript.options.shared_memory</code> setting under <code>about:config</code></p><p id="chr-shared-memory-spectre-note">  <sup>[19]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="sf-shared-memory-spectre-note">  <sup>[20]</sup> The feature was <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-sharedmem-note">  <sup>[21]</sup> The feature have to be enabled via &quot;Experimental enabled SharedArrayBuffer support in JavaScript.&quot; setting under <code>about:flags</code></p><p id="proxy-duplictate-ownkeys-updated-note">  <sup>[22]</sup> The behaviour of the Proxy &#x201C;ownKeys&#x201D; handler in presence of duplicate keys has been <a href="https://github.com/tc39/ecma262/issues/833">modified later</a>.</p><p id="chrome-harmony-note">  <sup>[23]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="chrome-promise-note">  <sup>[24]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-promise-finally&quot;</code> flag</p><p id="typescript-es6-note">  <sup>[25]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="firefox-nightly-note">  <sup>[26]</sup> The feature is available only in Firefox Nightly builds.</p><p id="flatten-compat-issue-note">  <sup>[27]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="ffox-flatten-note">  <sup>[28]</sup> Older Firefox Nightly builds support only the obsolete draft function name <code>Array.prototype.flatten()</code>.</p></div>
+    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="chrome-experimental-note">  <sup>[4]</sup> The feature have to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="babel-core-js-note">  <sup>[5]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="typescript-downlevel-iteration-note">  <sup>[9]</sup> Requires the <code>downlevelIteration</code> compile option.</p><p id="strict-fn-non-strict-params-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[12]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[13]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="babel-regenerator-note">  <sup>[14]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="edge-experimental-flag-note">  <sup>[15]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="edg-shared-memory-spectre-note">  <sup>[16]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="firefox-developer-note">  <sup>[17]</sup> The feature is available only in Firefox Developer Edition and Firefox Nightly builds.</p><p id="fx-shared-memory-spectre-note">  <sup>[18]</sup> The feature was <a href="https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.  It can be enabled via <code>javascript.options.shared_memory</code> setting under <code>about:config</code></p><p id="chr-shared-memory-spectre-note">  <sup>[19]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="sf-shared-memory-spectre-note">  <sup>[20]</sup> The feature was <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-sharedmem-note">  <sup>[21]</sup> The feature have to be enabled via &quot;Experimental enabled SharedArrayBuffer support in JavaScript.&quot; setting under <code>about:flags</code></p><p id="proxy-duplictate-ownkeys-updated-note">  <sup>[22]</sup> The behaviour of the Proxy &#x201C;ownKeys&#x201D; handler in presence of duplicate keys has been <a href="https://github.com/tc39/ecma262/issues/833">modified later</a>.</p><p id="chrome-harmony-note">  <sup>[23]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="closure-object-assign-note">  <sup>[24]</sup> Requires native support for <code>Object.assign</code></p><p id="chrome-promise-note">  <sup>[25]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-promise-finally&quot;</code> flag</p><p id="typescript-es6-note">  <sup>[26]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="firefox-nightly-note">  <sup>[27]</sup> The feature is available only in Firefox Nightly builds.</p><p id="flatten-compat-issue-note">  <sup>[28]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="ffox-flatten-note">  <sup>[29]</sup> Older Firefox Nightly builds support only the obsolete draft function name <code>Array.prototype.flatten()</code>.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -146,7 +146,9 @@
 <th class="platform closure20181028 compiler obsolete" data-browser="closure20181028"><a href="#closure20181028" class="browser-name"><abbr title="Closure Compiler v20181028">Closure 2018.10</abbr></a></th>
 <th class="platform closure20181125 compiler obsolete" data-browser="closure20181125"><a href="#closure20181125" class="browser-name"><abbr title="Closure Compiler v20181125">Closure 2018.11</abbr></a></th>
 <th class="platform closure20181210 compiler obsolete" data-browser="closure20181210"><a href="#closure20181210" class="browser-name"><abbr title="Closure Compiler v20181210">Closure 2018.12</abbr></a></th>
-<th class="platform closure20190106 compiler" data-browser="closure20190106"><a href="#closure20190106" class="browser-name"><abbr title="Closure Compiler v20190106">Closure 2019.01</abbr></a></th>
+<th class="platform closure20190106 compiler obsolete" data-browser="closure20190106"><a href="#closure20190106" class="browser-name"><abbr title="Closure Compiler v20190106">Closure 2019.01</abbr></a></th>
+<th class="platform closure20190121 compiler obsolete" data-browser="closure20190121"><a href="#closure20190121" class="browser-name"><abbr title="Closure Compiler v20190121">Closure 2019.01</abbr></a></th>
+<th class="platform closure20190215 compiler" data-browser="closure20190215"><a href="#closure20190215" class="browser-name"><abbr title="Closure Compiler v20190215">Closure 2019.02</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_7corejs2 compiler obsolete" data-browser="typescript2_7corejs2"><a href="#typescript2_7corejs2" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_8corejs2 compiler obsolete" data-browser="typescript2_8corejs2"><a href="#typescript2_8corejs2" class="browser-name"><abbr title="TypeScript 2.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -226,7 +228,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="94">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="96">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-globalThis"><span><a class="anchor" href="#test-globalThis">&#xA7;</a><a href="https://github.com/tc39/proposal-global">globalThis</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -245,7 +247,9 @@
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -343,7 +347,9 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -445,7 +451,9 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -551,7 +559,9 @@ return a === &apos;1a2b&apos;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -644,7 +654,9 @@ return a === &apos;1a2b&apos;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -743,7 +755,9 @@ return new C().x === &apos;x&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -848,7 +862,9 @@ return new C(42).x() === 42;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -950,7 +966,9 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1043,7 +1061,9 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -1142,7 +1162,9 @@ return C.x === &apos;x&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -1244,7 +1266,9 @@ return new C().x() === 42;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1337,7 +1361,9 @@ return new C().x() === 42;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/8</td>
@@ -1433,7 +1459,9 @@ return (1n + 2n) === 3n;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1529,7 +1557,9 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1625,7 +1655,9 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1721,7 +1753,9 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1820,7 +1854,9 @@ return view[0] === -0x8000000000000000n;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1919,7 +1955,9 @@ return view[0] === 0n;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2015,7 +2053,9 @@ return typeof DataView.prototype.getBigInt64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2111,7 +2151,9 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2204,7 +2246,9 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -2306,7 +2350,9 @@ return RegExp.lastMatch === 'x';
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2410,7 +2456,9 @@ return true;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2486,7 +2534,7 @@ return true;
 <td class="yes obsolete" data-browser="samsung7_2">Yes</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="94">Draft (stage 2)</td>
+<tr class="category"><td colspan="96">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -2514,7 +2562,9 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2607,7 +2657,9 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/1</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/1</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">1/1</td>
@@ -2711,7 +2763,9 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -2810,7 +2864,9 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2910,7 +2966,9 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3003,7 +3061,9 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/4</td>
@@ -3105,7 +3165,9 @@ try {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3211,7 +3273,9 @@ try {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3312,7 +3376,9 @@ try {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3413,7 +3479,9 @@ try {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3510,7 +3578,9 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -3603,7 +3673,9 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/7</td>
@@ -3702,7 +3774,9 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -3802,7 +3876,9 @@ return set.size === 3
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -3901,7 +3977,9 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4000,7 +4078,9 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4096,7 +4176,9 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4192,7 +4274,9 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4288,7 +4372,9 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4381,7 +4467,9 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -4480,7 +4568,9 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4579,7 +4669,9 @@ return buffer1.byteLength === 0
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4686,7 +4778,9 @@ Promise.allSettled([
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4762,7 +4856,7 @@ Promise.allSettled([
 <td class="no obsolete" data-browser="samsung7_2">No</td>
 <td class="no" data-browser="samsung8_2">No</td>
 </tr>
-<tr class="category"><td colspan="94">Proposal (stage 1)</td>
+<tr class="category"><td colspan="96">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="https://github.com/tc39/proposal-do-expressions">do expressions</a></span><script data-source="
 return do {
@@ -4787,7 +4881,9 @@ return do {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4880,7 +4976,9 @@ return do {
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">7/7</td>
@@ -4976,7 +5074,9 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5072,7 +5172,9 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5168,7 +5270,9 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5274,7 +5378,9 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5371,7 +5477,9 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5467,7 +5575,9 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5563,7 +5673,9 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5660,7 +5772,9 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5759,7 +5873,9 @@ return Math.signbit(-0) === false
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5852,7 +5968,9 @@ return Math.signbit(-0) === false
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">7/7</td>
@@ -5950,7 +6068,9 @@ return Math.clamp(2, 4, 6) === 4
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6046,7 +6166,9 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6143,7 +6265,9 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6239,7 +6363,9 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6335,7 +6461,9 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6432,7 +6560,9 @@ return Math.radians(90) === Math.PI / 2
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6528,7 +6658,9 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6621,7 +6753,9 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">7/7</td>
@@ -6717,7 +6851,9 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6813,7 +6949,9 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6911,7 +7049,9 @@ return score === 1;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7014,7 +7154,9 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7117,7 +7259,9 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7220,7 +7364,9 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7323,7 +7469,9 @@ Promise.try(function() {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7416,7 +7564,9 @@ Promise.try(function() {
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">8/8</td>
@@ -7515,7 +7665,9 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7616,7 +7768,9 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7715,7 +7869,9 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7814,7 +7970,9 @@ return C.has(3) + C.has(4);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7913,7 +8071,9 @@ return C.get(A) + C.get(B) === 3;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8014,7 +8174,9 @@ return C.get(A) + C.get(B) === 5;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8113,7 +8275,9 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8212,7 +8376,9 @@ return C.has(A) + C.has(B);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8320,7 +8486,9 @@ return result === &apos;Hello, hello!&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8420,7 +8588,9 @@ return 123i === &apos;string123number123&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8513,7 +8683,9 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/3</td>
@@ -8611,7 +8783,9 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8709,7 +8883,9 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8807,7 +8983,9 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8907,7 +9085,9 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9000,7 +9180,9 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/12</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/12</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/12</td>
@@ -9100,7 +9282,9 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9200,7 +9384,9 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9300,7 +9486,9 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9400,7 +9588,9 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9500,7 +9690,9 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9600,7 +9792,9 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9700,7 +9894,9 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9803,7 +9999,9 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9904,7 +10102,9 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10004,7 +10204,9 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10104,7 +10306,9 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10204,7 +10408,9 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10297,7 +10503,9 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/8</td>
@@ -10393,7 +10601,9 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10489,7 +10699,9 @@ return Object.isFrozen([# 42 #]);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10585,7 +10797,9 @@ return Object.isSealed({| foo: 42 |});
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10681,7 +10895,9 @@ return Object.isSealed([| 42 |]);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10785,7 +11001,9 @@ try {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10890,7 +11108,9 @@ try {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10994,7 +11214,9 @@ try {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -11099,7 +11321,9 @@ try {
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -11195,7 +11419,9 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11296,7 +11522,9 @@ return results.length === 3
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11389,7 +11617,9 @@ return results.length === 3
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -11485,7 +11715,9 @@ return [1, 2, 3].lastItem === 3;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11581,7 +11813,9 @@ return [1, 2, 3].lastIndex === 2;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11674,7 +11908,9 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/26</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/26</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/26</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/26</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/26</td>
@@ -11775,7 +12011,9 @@ return map.size === 2
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11874,7 +12112,9 @@ return map.size === 2
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11974,7 +12214,9 @@ return map.size === 2
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12070,7 +12312,9 @@ return new Map([[1, 4], [2, 5], [3, 6]]).every(it =&gt; typeof it == &apos;numbe
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12169,7 +12413,9 @@ return map.size === 2
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12265,7 +12511,9 @@ return new Map([[1, 2], [2, 3], [3, 4]]).find(it =&gt; it % 2) === 3;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12361,7 +12609,9 @@ return new Map([[1, 2], [2, 3], [3, 4]]).findKey(it =&gt; it % 2) === 2;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12458,7 +12708,9 @@ return new Map([[1, 2], [2, NaN]]).includes(2)
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12555,7 +12807,9 @@ return new Map([[1, 2], [2, NaN]]).keyOf(2) === 1
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12655,7 +12909,9 @@ return map.size === 3
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12755,7 +13011,9 @@ return map.size === 3
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12855,7 +13113,9 @@ return map.size === 3
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12951,7 +13211,9 @@ return new Map([[&apos;a&apos;, 1], [&apos;b&apos;, 2], [&apos;c&apos;, 3], ]).r
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13047,7 +13309,9 @@ return new Map([[1, 4], [2, 5], [3, 6]]).some(it =&gt; it % 2);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13147,7 +13411,9 @@ return set.size === 3
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13247,7 +13513,9 @@ return set.deleteAll(2, 3) === true
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13343,7 +13611,9 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13442,7 +13712,9 @@ return set.size === 2
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13538,7 +13810,9 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13634,7 +13908,9 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13734,7 +14010,9 @@ return set.size === 3
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13830,7 +14108,9 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13926,7 +14206,9 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -14031,7 +14313,9 @@ return !map.has(a)
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -14136,7 +14420,9 @@ return set.has(a)
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -14241,7 +14527,9 @@ return !set.has(a)
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -14345,7 +14633,9 @@ return second === gen2.next().value;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -14438,7 +14728,9 @@ return second === gen2.next().value;
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190106" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -14534,7 +14826,9 @@ return Number.fromString(&apos;42&apos;) === 42;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -14630,7 +14924,9 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
-<td class="no" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190106">No</td>
+<td class="no obsolete" data-browser="closure20190121">No</td>
+<td class="no" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -14706,7 +15002,7 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="no obsolete" data-browser="samsung7_2">No</td>
 <td class="no" data-browser="samsung8_2">No</td>
 </tr>
-<tr class="category"><td colspan="94">Strawman (stage 0)</td>
+<tr class="category"><td colspan="96">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14725,7 +15021,9 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14823,7 +15121,9 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14920,7 +15220,9 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15016,7 +15318,9 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -15109,7 +15413,9 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -15206,7 +15512,9 @@ return f();
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15302,7 +15610,9 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15403,7 +15713,9 @@ return Array.isArray(arr)
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15510,7 +15822,9 @@ return target === C.prototype
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -15613,7 +15927,9 @@ return (@inverse function(it){
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15706,7 +16022,9 @@ return (@inverse function(it){
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -15804,7 +16122,9 @@ return Reflect.isCallable(function(){})
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15902,7 +16222,9 @@ return Reflect.isConstructor(function(){})
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15995,7 +16317,9 @@ return Reflect.isConstructor(function(){})
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -16091,7 +16415,9 @@ return typeof Zone == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16187,7 +16513,9 @@ return &apos;current&apos; in Zone;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16283,7 +16611,9 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16379,7 +16709,9 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16475,7 +16807,9 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16571,7 +16905,9 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16667,7 +17003,9 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16760,7 +17098,9 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -16862,7 +17202,9 @@ return (function f(n){
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16971,7 +17313,9 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -17064,7 +17408,9 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -17162,7 +17508,9 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -17261,7 +17609,9 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -17363,7 +17713,9 @@ Promise.any([
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no needs-polyfill-or-native obsolete not-applicable" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete not-applicable" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete not-applicable" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -17439,7 +17791,7 @@ Promise.any([
 <td class="no obsolete not-applicable" data-browser="samsung7_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="samsung8_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="94">Pre-strawman</td>
+<tr class="category"><td colspan="96">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -17458,7 +17810,9 @@ Promise.any([
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
@@ -17554,7 +17908,9 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17650,7 +18006,9 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17746,7 +18104,9 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17842,7 +18202,9 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17938,7 +18300,9 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -18034,7 +18398,9 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -18130,7 +18496,9 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -18226,7 +18594,9 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -18322,7 +18692,9 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -135,12 +135,6 @@
 <th class="platform babel7corejs2 compiler" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler unstable" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform closure compiler obsolete" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure 2018.02</abbr></a></th>
-<th class="platform closure20180319 compiler obsolete" data-browser="closure20180319"><a href="#closure20180319" class="browser-name"><abbr title="Closure Compiler v20180319">Closure 2018.03</abbr></a></th>
-<th class="platform closure20180402 compiler obsolete" data-browser="closure20180402"><a href="#closure20180402" class="browser-name"><abbr title="Closure Compiler v20180402">Closure 2018.04</abbr></a></th>
-<th class="platform closure20180506 compiler obsolete" data-browser="closure20180506"><a href="#closure20180506" class="browser-name"><abbr title="Closure Compiler v20180506">Closure 2018.05</abbr></a></th>
-<th class="platform closure20180610 compiler obsolete" data-browser="closure20180610"><a href="#closure20180610" class="browser-name"><abbr title="Closure Compiler v20180610">Closure 2018.06</abbr></a></th>
-<th class="platform closure20180716 compiler obsolete" data-browser="closure20180716"><a href="#closure20180716" class="browser-name"><abbr title="Closure Compiler v20180716">Closure 2018.07</abbr></a></th>
-<th class="platform closure20180805 compiler obsolete" data-browser="closure20180805"><a href="#closure20180805" class="browser-name"><abbr title="Closure Compiler v20180805">Closure 2018.08</abbr></a></th>
 <th class="platform closure20180910 compiler obsolete" data-browser="closure20180910"><a href="#closure20180910" class="browser-name"><abbr title="Closure Compiler v20180910">Closure 2018.09</abbr></a></th>
 <th class="platform closure20181008 compiler obsolete" data-browser="closure20181008"><a href="#closure20181008" class="browser-name"><abbr title="Closure Compiler v20181008">Closure 2018.10</abbr></a></th>
 <th class="platform closure20181028 compiler obsolete" data-browser="closure20181028"><a href="#closure20181028" class="browser-name"><abbr title="Closure Compiler v20181028">Closure 2018.10</abbr></a></th>
@@ -228,7 +222,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="96">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="90">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-globalThis"><span><a class="anchor" href="#test-globalThis">&#xA7;</a><a href="https://github.com/tc39/proposal-global">globalThis</a></span></td>
 <td class="tally" data-browser="tr" data-tally="0">0/2</td>
@@ -236,12 +230,6 @@
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
@@ -336,12 +324,6 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -440,12 +422,6 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -548,12 +524,6 @@ return a === &apos;1a2b&apos;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -643,12 +613,6 @@ return a === &apos;1a2b&apos;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
@@ -744,12 +708,6 @@ return new C().x === &apos;x&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -851,12 +809,6 @@ return new C(42).x() === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -955,12 +907,6 @@ return new C().x() === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -1050,12 +996,6 @@ return new C().x() === 42;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
@@ -1151,12 +1091,6 @@ return C.x === &apos;x&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -1255,12 +1189,6 @@ return new C().x() === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -1350,12 +1278,6 @@ return new C().x() === 42;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/8</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
@@ -1448,12 +1370,6 @@ return (1n + 2n) === 3n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -1546,12 +1462,6 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -1644,12 +1554,6 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -1742,12 +1646,6 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -1843,12 +1741,6 @@ return view[0] === -0x8000000000000000n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -1944,12 +1836,6 @@ return view[0] === 0n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -2042,12 +1928,6 @@ return typeof DataView.prototype.getBigInt64 === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -2140,12 +2020,6 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -2235,12 +2109,6 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
@@ -2339,12 +2207,6 @@ return RegExp.lastMatch === 'x';
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -2445,12 +2307,6 @@ return true;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -2534,7 +2390,7 @@ return true;
 <td class="yes obsolete" data-browser="samsung7_2">Yes</td>
 <td class="yes" data-browser="samsung8_2">Yes</td>
 </tr>
-<tr class="category"><td colspan="96">Draft (stage 2)</td>
+<tr class="category"><td colspan="90">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/Generator%20metaproperty.md">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -2551,12 +2407,6 @@ return result === &apos;tromple&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -2646,12 +2496,6 @@ return result === &apos;tromple&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/1</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/1</td>
@@ -2752,12 +2596,6 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no" data-browser="babel7corejs2">No<a href="#babel-decorators-legacy-note"><sup>[11]</sup></a></td>
 <td class="no unstable" data-browser="babel7corejs3">No<a href="#babel-decorators-legacy-note"><sup>[11]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -2853,12 +2691,6 @@ return typeof Realm === &quot;function&quot;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -2955,12 +2787,6 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -3050,12 +2876,6 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/4</td>
@@ -3154,12 +2974,6 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -3262,12 +3076,6 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -3365,12 +3173,6 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -3468,12 +3270,6 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -3567,12 +3363,6 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -3662,12 +3452,6 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
@@ -3763,12 +3547,6 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -3865,12 +3643,6 @@ return set.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -3966,12 +3738,6 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -4067,12 +3833,6 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -4165,12 +3925,6 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -4263,12 +4017,6 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -4361,12 +4109,6 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -4456,12 +4198,6 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
@@ -4557,12 +4293,6 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -4658,12 +4388,6 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -4767,12 +4491,6 @@ Promise.allSettled([
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -4856,7 +4574,7 @@ Promise.allSettled([
 <td class="no obsolete" data-browser="samsung7_2">No</td>
 <td class="no" data-browser="samsung8_2">No</td>
 </tr>
-<tr class="category"><td colspan="96">Proposal (stage 1)</td>
+<tr class="category"><td colspan="90">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="https://github.com/tc39/proposal-do-expressions">do expressions</a></span><script data-source="
 return do {
@@ -4870,12 +4588,6 @@ return do {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -4965,12 +4677,6 @@ return do {
 <td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
@@ -5063,12 +4769,6 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5161,12 +4861,6 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5259,12 +4953,6 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5367,12 +5055,6 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5466,12 +5148,6 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5564,12 +5240,6 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5662,12 +5332,6 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5761,12 +5425,6 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5862,12 +5520,6 @@ return Math.signbit(-0) === false
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -5957,12 +5609,6 @@ return Math.signbit(-0) === false
 <td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
@@ -6057,12 +5703,6 @@ return Math.clamp(2, 4, 6) === 4
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6155,12 +5795,6 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6254,12 +5888,6 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6352,12 +5980,6 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6450,12 +6072,6 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6549,12 +6165,6 @@ return Math.radians(90) === Math.PI / 2
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6647,12 +6257,6 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6742,12 +6346,6 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
@@ -6840,12 +6438,6 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -6938,12 +6530,6 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -7038,12 +6624,6 @@ return score === 1;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -7143,12 +6723,6 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -7248,12 +6822,6 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -7353,12 +6921,6 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -7458,12 +7020,6 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -7553,12 +7109,6 @@ Promise.try(function() {
 <td class="tally" data-browser="babel7corejs2" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
@@ -7654,12 +7204,6 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -7757,12 +7301,6 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -7858,12 +7396,6 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -7959,12 +7491,6 @@ return C.has(3) + C.has(4);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -8060,12 +7586,6 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -8163,12 +7683,6 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -8264,12 +7778,6 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -8365,12 +7873,6 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -8475,12 +7977,6 @@ return result === &apos;Hello, hello!&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -8577,12 +8073,6 @@ return 123i === &apos;string123number123&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -8672,12 +8162,6 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
@@ -8772,12 +8256,6 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -8872,12 +8350,6 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -8972,12 +8444,6 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -9074,12 +8540,6 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -9169,12 +8629,6 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/12</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/12</td>
@@ -9271,12 +8725,6 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -9373,12 +8821,6 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -9475,12 +8917,6 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -9577,12 +9013,6 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -9679,12 +9109,6 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -9781,12 +9205,6 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -9883,12 +9301,6 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -9988,12 +9400,6 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -10091,12 +9497,6 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -10193,12 +9593,6 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -10295,12 +9689,6 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -10397,12 +9785,6 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -10492,12 +9874,6 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/8</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
@@ -10590,12 +9966,6 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -10688,12 +10058,6 @@ return Object.isFrozen([# 42 #]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -10786,12 +10150,6 @@ return Object.isSealed({| foo: 42 |});
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -10884,12 +10242,6 @@ return Object.isSealed([| 42 |]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -10990,12 +10342,6 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11097,12 +10443,6 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11203,12 +10543,6 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11310,12 +10644,6 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11408,12 +10736,6 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11511,12 +10833,6 @@ return results.length === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11606,12 +10922,6 @@ return results.length === 3
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
@@ -11704,12 +11014,6 @@ return [1, 2, 3].lastItem === 3;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11802,12 +11106,6 @@ return [1, 2, 3].lastIndex === 2;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -11897,12 +11195,6 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/26</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">26/26</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/26</td>
@@ -12000,12 +11292,6 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12101,12 +11387,6 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12203,12 +11483,6 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12301,12 +11575,6 @@ return new Map([[1, 4], [2, 5], [3, 6]]).every(it =&gt; typeof it == &apos;numbe
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12402,12 +11670,6 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12500,12 +11762,6 @@ return new Map([[1, 2], [2, 3], [3, 4]]).find(it =&gt; it % 2) === 3;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12598,12 +11854,6 @@ return new Map([[1, 2], [2, 3], [3, 4]]).findKey(it =&gt; it % 2) === 2;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12697,12 +11947,6 @@ return new Map([[1, 2], [2, NaN]]).includes(2)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12796,12 +12040,6 @@ return new Map([[1, 2], [2, NaN]]).keyOf(2) === 1
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -12898,12 +12136,6 @@ return map.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13000,12 +12232,6 @@ return map.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13102,12 +12328,6 @@ return map.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13200,12 +12420,6 @@ return new Map([[&apos;a&apos;, 1], [&apos;b&apos;, 2], [&apos;c&apos;, 3], ]).r
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13298,12 +12512,6 @@ return new Map([[1, 4], [2, 5], [3, 6]]).some(it =&gt; it % 2);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13400,12 +12608,6 @@ return set.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13502,12 +12704,6 @@ return set.deleteAll(2, 3) === true
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13600,12 +12796,6 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13701,12 +12891,6 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13799,12 +12983,6 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13897,12 +13075,6 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -13999,12 +13171,6 @@ return set.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -14097,12 +13263,6 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -14195,12 +13355,6 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -14302,12 +13456,6 @@ return !map.has(a)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -14409,12 +13557,6 @@ return set.has(a)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -14516,12 +13658,6 @@ return !set.has(a)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -14622,12 +13758,6 @@ return second === gen2.next().value;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -14717,12 +13847,6 @@ return second === gen2.next().value;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180319" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180402" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180506" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180610" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180716" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180805" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
@@ -14815,12 +13939,6 @@ return Number.fromString(&apos;42&apos;) === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -14913,12 +14031,6 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180319">No</td>
-<td class="no obsolete" data-browser="closure20180402">No</td>
-<td class="no obsolete" data-browser="closure20180506">No</td>
-<td class="no obsolete" data-browser="closure20180610">No</td>
-<td class="no obsolete" data-browser="closure20180716">No</td>
-<td class="no obsolete" data-browser="closure20180805">No</td>
 <td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
@@ -15002,7 +14114,7 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="no obsolete" data-browser="samsung7_2">No</td>
 <td class="no" data-browser="samsung8_2">No</td>
 </tr>
-<tr class="category"><td colspan="96">Strawman (stage 0)</td>
+<tr class="category"><td colspan="90">Strawman (stage 0)</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -15010,12 +14122,6 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -15110,12 +14216,6 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15209,12 +14309,6 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15307,12 +14401,6 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15402,12 +14490,6 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -15501,12 +14583,6 @@ return f();
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15599,12 +14675,6 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15702,12 +14772,6 @@ return Array.isArray(arr)
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15811,12 +14875,6 @@ return target === C.prototype
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15916,12 +14974,6 @@ return (@inverse function(it){
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16011,12 +15063,6 @@ return (@inverse function(it){
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -16111,12 +15157,6 @@ return Reflect.isCallable(function(){})
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16211,12 +15251,6 @@ return Reflect.isConstructor(function(){})
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16306,12 +15340,6 @@ return Reflect.isConstructor(function(){})
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -16404,12 +15432,6 @@ return typeof Zone == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16502,12 +15524,6 @@ return &apos;current&apos; in Zone;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16600,12 +15616,6 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16698,12 +15708,6 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16796,12 +15800,6 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16894,12 +15892,6 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16992,12 +15984,6 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -17087,12 +16073,6 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -17191,12 +16171,6 @@ return (function f(n){
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -17302,12 +16276,6 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -17397,12 +16365,6 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -17497,12 +16459,6 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -17598,12 +16554,6 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -17702,12 +16652,6 @@ Promise.any([
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -17791,7 +16735,7 @@ Promise.any([
 <td class="no obsolete not-applicable" data-browser="samsung7_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="samsung8_2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 </tr>
-<tr class="category"><td colspan="96">Pre-strawman</td>
+<tr class="category"><td colspan="90">Pre-strawman</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -17799,12 +16743,6 @@ Promise.any([
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -17897,12 +16835,6 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -17995,12 +16927,6 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -18093,12 +17019,6 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -18191,12 +17111,6 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -18289,12 +17203,6 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -18387,12 +17295,6 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -18485,12 +17387,6 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -18583,12 +17479,6 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -18681,12 +17571,6 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180319" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180402" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180506" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180610" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180716" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180805" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>


### PR DESCRIPTION
v20190121

- degrade: ES2018 object spread properties

v20190215

- support: ES2019 optional catch binding
- support: ES2019 JSON superset
- support: ES6 Math.hypot

https://github.com/google/closure-compiler/wiki/Releases#february-15-2019-v20190215