### PR TITLE
Add test for TemplateStrings caching

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -5461,6 +5461,11 @@ exports.tests = [
     {
       name: 'TemplateStrings call site caching',
       exec: function () {/*
+        // Safari 12 sometimes garbage collects the cached TemplateStrings,
+        // even when the call site is still alive.
+        // This is almost impossible to write a test case for, but we can test
+        // the general semantics.
+        // https://bugs.webkit.org/show_bug.cgi?id=190756
         function strings(array) {
           return array;
         }

--- a/data-es6.js
+++ b/data-es6.js
@@ -5458,6 +5458,43 @@ exports.tests = [
         graalvm: true,
       },
     },
+    {
+      name: 'TemplateStrings call site caching',
+      exec: function () {/*
+        function strings(array) {
+          return array;
+        }
+        function getStrings() {
+          return strings`foo`;
+        }
+        var original = getStrings();
+        var other = strings`foo`;
+        return original === getStrings() && original !== other;
+      */},
+      res: {
+        tr: true,
+        babel6corejs2: true,
+        es6tr: true,
+        jsx: true,
+        ejs: true,
+        closure: true,
+        typescript1corejs2: true,
+        edge12: true,
+        firefox2: false,
+        firefox34: true,
+        opera10_50: false,
+        chrome41: true,
+        safari9: true,
+        safari12: false,
+        node4: true,
+        xs6: true,
+        jxa: true,
+        duktape2_0: false,
+        nashorn9: true,
+        nashorn10: true,
+        graalvm: true,
+      },
+    },
   ],
 },
 {


### PR DESCRIPTION
Safari 12 has a [bug](https://bugs.webkit.org/show_bug.cgi?id=190756) that breaks caching of `TemplateStrings`.

Test case: https://jsbin.com/leyusas/10/edit?js,console

Unfortunately, it's a memory GC bug, so it's very difficult to write a test that would catch this.

Re: https://github.com/babel/babel/pull/9584