### PR TITLE
Firefox Nightly supports DataView.prototype.getBigInt64 and DataView.prototype.getBigUint64

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -2114,6 +2114,7 @@ exports.tests = [
       */},
       res: {
         firefox52: false,
+        firefox67: firefox.bigint,
         chrome67: true,
         graalvm: true,
       },
@@ -2125,6 +2126,7 @@ exports.tests = [
       */},
       res: {
         firefox52: false,
+        firefox67: firefox.bigint,
         chrome67: true,
         graalvm: true,
       },

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -1309,7 +1309,7 @@ return new C().x() === 42;
 <td class="tally" data-browser="firefox64" data-tally="0">0/8</td>
 <td class="tally" data-browser="firefox65" data-tally="0">0/8</td>
 <td class="tally unstable" data-browser="firefox66" data-tally="0">0/8</td>
-<td class="tally unstable" data-browser="firefox67" data-tally="0" data-flagged-tally="0.5">0/8</td>
+<td class="tally unstable" data-browser="firefox67" data-tally="0" data-flagged-tally="0.75">0/8</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="chrome64" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="chrome65" data-tally="0">0/8</td>
@@ -1959,7 +1959,7 @@ return typeof DataView.prototype.getBigInt64 === &apos;function&apos;;
 <td class="no" data-browser="firefox64">No</td>
 <td class="no" data-browser="firefox65">No</td>
 <td class="no unstable" data-browser="firefox66">No</td>
-<td class="no unstable" data-browser="firefox67">No</td>
+<td class="no flagged unstable" data-browser="firefox67">Flag<a href="#firefox-bigint-note"><sup>[10]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome64">No</td>
 <td class="no obsolete" data-browser="chrome65">No</td>
@@ -2051,7 +2051,7 @@ return typeof DataView.prototype.getBigUint64 === &apos;function&apos;;
 <td class="no" data-browser="firefox64">No</td>
 <td class="no" data-browser="firefox65">No</td>
 <td class="no unstable" data-browser="firefox66">No</td>
-<td class="no unstable" data-browser="firefox67">No</td>
+<td class="no flagged unstable" data-browser="firefox67">Flag<a href="#firefox-bigint-note"><sup>[10]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome64">No</td>
 <td class="no obsolete" data-browser="chrome65">No</td>


### PR DESCRIPTION
We can wait until https://bugzilla.mozilla.org/show_bug.cgi?id=1531293 will be fixed and add `firefox67: true` instead of `firefox67: firefox.bigint` for these two and another supported BigInt features or merge this PR as is for now