### PR TITLE
Update Closure Compiler to v20190301

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -2920,6 +2920,7 @@ exports.tests = [
         res : {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure20190301: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
           ie11: false,
@@ -2942,6 +2943,7 @@ exports.tests = [
         res : {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure20190301: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
           ie11: false,
@@ -3354,6 +3356,7 @@ exports.tests = [
         res: {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure20190301: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
           ie11: false,
@@ -3383,6 +3386,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure20190301: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
           firefox2: false,

--- a/data-es6.js
+++ b/data-es6.js
@@ -11671,6 +11671,7 @@ exports.tests = [
       res: {
         babel6corejs2: babel.corejs,
         closure: true,
+        closure20190301: false,
         typescript1corejs2: typescript.corejs,
         ejs: true,
         es6shim: true,
@@ -16111,6 +16112,7 @@ exports.tests = [
       res: {
         tr: true,
         babel6corejs2: babel.corejs,
+        closure20190301: true,
         typescript1corejs2: typescript.corejs,
         edge12: true,
         firefox2: false,
@@ -19868,6 +19870,7 @@ exports.tests = [
       res: {
         babel6corejs2: babel.corejs,
         closure: true,
+        closure20190301: false,
         typescript1corejs2: typescript.corejs,
         es6shim: true,
         edge12: true,

--- a/environments.json
+++ b/environments.json
@@ -145,7 +145,7 @@
     "short": "Closure 2018.09",
     "family": "Closure",
     "platformtype": "compiler",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -227,6 +227,18 @@
   "closure20190215": {
     "full": "Closure Compiler v20190215",
     "short": "Closure 2019.02",
+    "family": "Closure",
+    "platformtype": "compiler",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "closure20190301": {
+    "full": "Closure Compiler v20190301",
+    "short": "Closure 2019.03",
     "family": "Closure",
     "platformtype": "compiler",
     "obsolete": false,

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -129,14 +129,14 @@
 <th class="platform babel7corejs2 compiler" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler unstable" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform closure compiler obsolete" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure 2018.02</abbr></a></th>
-<th class="platform closure20180910 compiler obsolete" data-browser="closure20180910"><a href="#closure20180910" class="browser-name"><abbr title="Closure Compiler v20180910">Closure 2018.09</abbr></a></th>
 <th class="platform closure20181008 compiler obsolete" data-browser="closure20181008"><a href="#closure20181008" class="browser-name"><abbr title="Closure Compiler v20181008">Closure 2018.10</abbr></a></th>
 <th class="platform closure20181028 compiler obsolete" data-browser="closure20181028"><a href="#closure20181028" class="browser-name"><abbr title="Closure Compiler v20181028">Closure 2018.10</abbr></a></th>
 <th class="platform closure20181125 compiler obsolete" data-browser="closure20181125"><a href="#closure20181125" class="browser-name"><abbr title="Closure Compiler v20181125">Closure 2018.11</abbr></a></th>
 <th class="platform closure20181210 compiler obsolete" data-browser="closure20181210"><a href="#closure20181210" class="browser-name"><abbr title="Closure Compiler v20181210">Closure 2018.12</abbr></a></th>
 <th class="platform closure20190106 compiler obsolete" data-browser="closure20190106"><a href="#closure20190106" class="browser-name"><abbr title="Closure Compiler v20190106">Closure 2019.01</abbr></a></th>
 <th class="platform closure20190121 compiler obsolete" data-browser="closure20190121"><a href="#closure20190121" class="browser-name"><abbr title="Closure Compiler v20190121">Closure 2019.01</abbr></a></th>
-<th class="platform closure20190215 compiler" data-browser="closure20190215"><a href="#closure20190215" class="browser-name"><abbr title="Closure Compiler v20190215">Closure 2019.02</abbr></a></th>
+<th class="platform closure20190215 compiler obsolete" data-browser="closure20190215"><a href="#closure20190215" class="browser-name"><abbr title="Closure Compiler v20190215">Closure 2019.02</abbr></a></th>
+<th class="platform closure20190301 compiler" data-browser="closure20190301"><a href="#closure20190301" class="browser-name"><abbr title="Closure Compiler v20190301">Closure 2019.03</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_7corejs2 compiler obsolete" data-browser="typescript2_7corejs2"><a href="#typescript2_7corejs2" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_8corejs2 compiler obsolete" data-browser="typescript2_8corejs2"><a href="#typescript2_8corejs2" class="browser-name"><abbr title="TypeScript 2.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -226,14 +226,14 @@
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20190215" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20190301" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -320,14 +320,14 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -414,14 +414,14 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -513,14 +513,14 @@ return true;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -604,14 +604,14 @@ return true;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20190215" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20190301" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">3/3</td>
@@ -702,14 +702,14 @@ return [1, 2, 3].includes(1)
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -818,14 +818,14 @@ return 24;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -917,14 +917,14 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1020,14 +1020,14 @@ return true;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1127,14 +1127,14 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -1226,14 +1226,14 @@ return true;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1321,14 +1321,14 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -1417,14 +1417,14 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -1518,14 +1518,14 @@ return passed;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1621,14 +1621,14 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1714,14 +1714,14 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="closure20190215" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="closure20190301" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">4/4</td>
@@ -1811,14 +1811,14 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1912,14 +1912,14 @@ return Array.isArray(e)
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2014,14 +2014,14 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2111,14 +2111,14 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2202,14 +2202,14 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20190215" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20190301" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -2301,14 +2301,14 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2400,14 +2400,14 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2491,14 +2491,14 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20190215" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20190301" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -2585,14 +2585,14 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -2679,14 +2679,14 @@ return Math.min(1,2,3,) === 1;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -2770,14 +2770,14 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
-<td class="tally" data-browser="closure20190215" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally" data-browser="closure20190301" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
@@ -2875,14 +2875,14 @@ p.then(function(result) {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -2980,14 +2980,14 @@ p.catch(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3075,14 +3075,14 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -3170,14 +3170,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3271,14 +3271,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3374,14 +3374,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3469,14 +3469,14 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -3569,14 +3569,14 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3664,14 +3664,14 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -3769,14 +3769,14 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3874,14 +3874,14 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3979,14 +3979,14 @@ var p = new C().a();
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4082,14 +4082,14 @@ p.then(function(result) {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4178,14 +4178,14 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4272,14 +4272,14 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4375,14 +4375,14 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown unstable" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4466,14 +4466,14 @@ p.then(function(result) {
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/17</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/17</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/17</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/17</td>
@@ -4560,14 +4560,14 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4654,14 +4654,14 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4748,14 +4748,14 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4842,14 +4842,14 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4936,14 +4936,14 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5030,14 +5030,14 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5124,14 +5124,14 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5218,14 +5218,14 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5312,14 +5312,14 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5406,14 +5406,14 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5500,14 +5500,14 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5594,14 +5594,14 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5688,14 +5688,14 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5782,14 +5782,14 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5876,14 +5876,14 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5970,14 +5970,14 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6064,14 +6064,14 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6165,14 +6165,14 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6262,14 +6262,14 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6359,14 +6359,14 @@ return (function(){
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6452,14 +6452,14 @@ return (function(){
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -6551,14 +6551,14 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6651,14 +6651,14 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6751,14 +6751,14 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6850,14 +6850,14 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6950,14 +6950,14 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7050,14 +7050,14 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7151,14 +7151,14 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7252,14 +7252,14 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7354,14 +7354,14 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7453,14 +7453,14 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7551,14 +7551,14 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7652,14 +7652,14 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7753,14 +7753,14 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7855,14 +7855,14 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7954,14 +7954,14 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8052,14 +8052,14 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8143,14 +8143,14 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -8241,14 +8241,14 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8339,14 +8339,14 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8442,14 +8442,14 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8545,14 +8545,14 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8640,14 +8640,14 @@ return i === 0;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8733,14 +8733,14 @@ return i === 0;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -8828,14 +8828,14 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="no obsolete" data-browser="closure20181028">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20181125">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20181210">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190106">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="closure20190215">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190215">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="closure20190301">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -8924,14 +8924,14 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="closure20190215">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190215">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="closure20190301">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -9015,14 +9015,14 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20190215" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20190301" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">3/3</td>
@@ -9135,14 +9135,14 @@ function check() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9247,14 +9247,14 @@ function check() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9361,14 +9361,14 @@ function check() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9456,14 +9456,14 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -9557,14 +9557,14 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9652,14 +9652,14 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9747,14 +9747,14 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9838,14 +9838,14 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20190215" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20190301" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -9939,14 +9939,14 @@ iterator.next().then(function(step){
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -10050,14 +10050,14 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20180910">Yes</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -10153,14 +10153,14 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10250,14 +10250,14 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -10341,14 +10341,14 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">4/4</td>
@@ -10435,14 +10435,14 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10529,14 +10529,14 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10623,14 +10623,14 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10717,14 +10717,14 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10808,14 +10808,14 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20190301" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -10902,14 +10902,14 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -10998,14 +10998,14 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11093,14 +11093,14 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -11186,14 +11186,14 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20190215" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20190301" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">3/3</td>
@@ -11286,14 +11286,14 @@ return false;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -11387,14 +11387,14 @@ return false;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -11493,14 +11493,14 @@ return it.next().value;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -11584,14 +11584,14 @@ return it.next().value;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20190301" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/3</td>
@@ -11678,14 +11678,14 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -11772,14 +11772,14 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -11867,14 +11867,14 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -11958,14 +11958,14 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/7</td>
@@ -12054,14 +12054,14 @@ return fn + &apos;&apos; === str;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12149,14 +12149,14 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12244,14 +12244,14 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12339,14 +12339,14 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12434,14 +12434,14 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12529,14 +12529,14 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12624,14 +12624,14 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12715,14 +12715,14 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190215" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20190301" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -12809,14 +12809,14 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12903,14 +12903,14 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="yes" data-browser="closure20190215">Yes</td>
+<td class="yes obsolete" data-browser="closure20190215">Yes</td>
+<td class="yes" data-browser="closure20190301">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12998,14 +12998,14 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -135,14 +135,14 @@
 <th class="platform babel7corejs2 compiler" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler unstable" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform closure compiler obsolete" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure 2018.02</abbr></a></th>
-<th class="platform closure20180910 compiler obsolete" data-browser="closure20180910"><a href="#closure20180910" class="browser-name"><abbr title="Closure Compiler v20180910">Closure 2018.09</abbr></a></th>
 <th class="platform closure20181008 compiler obsolete" data-browser="closure20181008"><a href="#closure20181008" class="browser-name"><abbr title="Closure Compiler v20181008">Closure 2018.10</abbr></a></th>
 <th class="platform closure20181028 compiler obsolete" data-browser="closure20181028"><a href="#closure20181028" class="browser-name"><abbr title="Closure Compiler v20181028">Closure 2018.10</abbr></a></th>
 <th class="platform closure20181125 compiler obsolete" data-browser="closure20181125"><a href="#closure20181125" class="browser-name"><abbr title="Closure Compiler v20181125">Closure 2018.11</abbr></a></th>
 <th class="platform closure20181210 compiler obsolete" data-browser="closure20181210"><a href="#closure20181210" class="browser-name"><abbr title="Closure Compiler v20181210">Closure 2018.12</abbr></a></th>
 <th class="platform closure20190106 compiler obsolete" data-browser="closure20190106"><a href="#closure20190106" class="browser-name"><abbr title="Closure Compiler v20190106">Closure 2019.01</abbr></a></th>
 <th class="platform closure20190121 compiler obsolete" data-browser="closure20190121"><a href="#closure20190121" class="browser-name"><abbr title="Closure Compiler v20190121">Closure 2019.01</abbr></a></th>
-<th class="platform closure20190215 compiler" data-browser="closure20190215"><a href="#closure20190215" class="browser-name"><abbr title="Closure Compiler v20190215">Closure 2019.02</abbr></a></th>
+<th class="platform closure20190215 compiler obsolete" data-browser="closure20190215"><a href="#closure20190215" class="browser-name"><abbr title="Closure Compiler v20190215">Closure 2019.02</abbr></a></th>
+<th class="platform closure20190301 compiler" data-browser="closure20190301"><a href="#closure20190301" class="browser-name"><abbr title="Closure Compiler v20190301">Closure 2019.03</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_7corejs2 compiler obsolete" data-browser="typescript2_7corejs2"><a href="#typescript2_7corejs2" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_8corejs2 compiler obsolete" data-browser="typescript2_8corejs2"><a href="#typescript2_8corejs2" class="browser-name"><abbr title="TypeScript 2.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -230,14 +230,14 @@
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -324,14 +324,14 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -422,14 +422,14 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -524,14 +524,14 @@ return a === &apos;1a2b&apos;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -613,14 +613,14 @@ return a === &apos;1a2b&apos;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -708,14 +708,14 @@ return new C().x === &apos;x&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -809,14 +809,14 @@ return new C(42).x() === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -907,14 +907,14 @@ return new C().x() === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -996,14 +996,14 @@ return new C().x() === 42;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -1091,14 +1091,14 @@ return C.x === &apos;x&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -1189,14 +1189,14 @@ return new C().x() === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1278,14 +1278,14 @@ return new C().x() === 42;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/8</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/8</td>
@@ -1370,14 +1370,14 @@ return (1n + 2n) === 3n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1462,14 +1462,14 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1554,14 +1554,14 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1646,14 +1646,14 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1741,14 +1741,14 @@ return view[0] === -0x8000000000000000n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1836,14 +1836,14 @@ return view[0] === 0n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1931,14 +1931,14 @@ return view.getBigInt64(0) === 1n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2026,14 +2026,14 @@ return view.getBigUint64(0) === 1n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2115,14 +2115,14 @@ return view.getBigUint64(0) === 1n;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -2213,14 +2213,14 @@ return RegExp.lastMatch === 'x';
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2313,14 +2313,14 @@ return true;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2413,14 +2413,14 @@ return result === &apos;tromple&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2502,14 +2502,14 @@ return result === &apos;tromple&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/1</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/1</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/1</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">1/1</td>
@@ -2602,14 +2602,14 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no" data-browser="babel7corejs2">No<a href="#babel-decorators-legacy-note"><sup>[11]</sup></a></td>
 <td class="no unstable" data-browser="babel7corejs3">No<a href="#babel-decorators-legacy-note"><sup>[11]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -2697,14 +2697,14 @@ return typeof Realm === &quot;function&quot;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2793,14 +2793,14 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2882,14 +2882,14 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/4</td>
@@ -2980,14 +2980,14 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3082,14 +3082,14 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3179,14 +3179,14 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3276,14 +3276,14 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3369,14 +3369,14 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -3458,14 +3458,14 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/7</td>
@@ -3553,14 +3553,14 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -3649,14 +3649,14 @@ return set.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -3744,14 +3744,14 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -3839,14 +3839,14 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -3931,14 +3931,14 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4023,14 +4023,14 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4115,14 +4115,14 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4204,14 +4204,14 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -4299,14 +4299,14 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4394,14 +4394,14 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4497,14 +4497,14 @@ Promise.allSettled([
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4594,14 +4594,14 @@ return do {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4683,14 +4683,14 @@ return do {
 <td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">7/7</td>
@@ -4775,14 +4775,14 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -4867,14 +4867,14 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -4959,14 +4959,14 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5061,14 +5061,14 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5154,14 +5154,14 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5246,14 +5246,14 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5338,14 +5338,14 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5431,14 +5431,14 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5526,14 +5526,14 @@ return Math.signbit(-0) === false
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5615,14 +5615,14 @@ return Math.signbit(-0) === false
 <td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">7/7</td>
@@ -5709,14 +5709,14 @@ return Math.clamp(2, 4, 6) === 4
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5801,14 +5801,14 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5894,14 +5894,14 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5986,14 +5986,14 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6078,14 +6078,14 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6171,14 +6171,14 @@ return Math.radians(90) === Math.PI / 2
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6263,14 +6263,14 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6352,14 +6352,14 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">7/7</td>
@@ -6444,14 +6444,14 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6536,14 +6536,14 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6630,14 +6630,14 @@ return score === 1;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6729,14 +6729,14 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6828,14 +6828,14 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6927,14 +6927,14 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7026,14 +7026,14 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7115,14 +7115,14 @@ Promise.try(function() {
 <td class="tally" data-browser="babel7corejs2" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">8/8</td>
@@ -7210,14 +7210,14 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7307,14 +7307,14 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7402,14 +7402,14 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7497,14 +7497,14 @@ return C.has(3) + C.has(4);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7592,14 +7592,14 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7689,14 +7689,14 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7784,14 +7784,14 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7879,14 +7879,14 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7983,14 +7983,14 @@ return result === &apos;Hello, hello!&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8079,14 +8079,14 @@ return 123i === &apos;string123number123&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8168,14 +8168,14 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/3</td>
@@ -8262,14 +8262,14 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8356,14 +8356,14 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8450,14 +8450,14 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8546,14 +8546,14 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8635,14 +8635,14 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/12</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/12</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/12</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/12</td>
@@ -8731,14 +8731,14 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8827,14 +8827,14 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8923,14 +8923,14 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9019,14 +9019,14 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9115,14 +9115,14 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9211,14 +9211,14 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9307,14 +9307,14 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9406,14 +9406,14 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9503,14 +9503,14 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9599,14 +9599,14 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9695,14 +9695,14 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9791,14 +9791,14 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9880,14 +9880,14 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/8</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/8</td>
@@ -9972,14 +9972,14 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10064,14 +10064,14 @@ return Object.isFrozen([# 42 #]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10156,14 +10156,14 @@ return Object.isSealed({| foo: 42 |});
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10248,14 +10248,14 @@ return Object.isSealed([| 42 |]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10348,14 +10348,14 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10449,14 +10449,14 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10549,14 +10549,14 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10650,14 +10650,14 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10742,14 +10742,14 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -10839,14 +10839,14 @@ return results.length === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -10928,14 +10928,14 @@ return results.length === 3
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -11020,14 +11020,14 @@ return [1, 2, 3].lastItem === 3;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11112,14 +11112,14 @@ return [1, 2, 3].lastIndex === 2;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11201,14 +11201,14 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/26</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="1">26/26</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/26</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/26</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/26</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/26</td>
@@ -11298,14 +11298,14 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11393,14 +11393,14 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11489,14 +11489,14 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11581,14 +11581,14 @@ return new Map([[1, 4], [2, 5], [3, 6]]).every(it =&gt; typeof it == &apos;numbe
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11676,14 +11676,14 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11768,14 +11768,14 @@ return new Map([[1, 2], [2, 3], [3, 4]]).find(it =&gt; it % 2) === 3;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11860,14 +11860,14 @@ return new Map([[1, 2], [2, 3], [3, 4]]).findKey(it =&gt; it % 2) === 2;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11953,14 +11953,14 @@ return new Map([[1, 2], [2, NaN]]).includes(2)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12046,14 +12046,14 @@ return new Map([[1, 2], [2, NaN]]).keyOf(2) === 1
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12142,14 +12142,14 @@ return map.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12238,14 +12238,14 @@ return map.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12334,14 +12334,14 @@ return map.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12426,14 +12426,14 @@ return new Map([[&apos;a&apos;, 1], [&apos;b&apos;, 2], [&apos;c&apos;, 3], ]).r
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12518,14 +12518,14 @@ return new Map([[1, 4], [2, 5], [3, 6]]).some(it =&gt; it % 2);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12614,14 +12614,14 @@ return set.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12710,14 +12710,14 @@ return set.deleteAll(2, 3) === true
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12802,14 +12802,14 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12897,14 +12897,14 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12989,14 +12989,14 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13081,14 +13081,14 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13177,14 +13177,14 @@ return set.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13269,14 +13269,14 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13361,14 +13361,14 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13462,14 +13462,14 @@ return !map.has(a)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13563,14 +13563,14 @@ return set.has(a)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13664,14 +13664,14 @@ return !set.has(a)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13764,14 +13764,14 @@ return second === gen2.next().value;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13853,14 +13853,14 @@ return second === gen2.next().value;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="babel7corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20180910" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190215" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -13945,14 +13945,14 @@ return Number.fromString(&apos;42&apos;) === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes unstable" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -14037,14 +14037,14 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no unstable" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20180910">No</td>
 <td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no" data-browser="closure20190215">No</td>
+<td class="no obsolete" data-browser="closure20190215">No</td>
+<td class="no" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -14128,14 +14128,14 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14222,14 +14222,14 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14315,14 +14315,14 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14407,14 +14407,14 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -14496,14 +14496,14 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -14589,14 +14589,14 @@ return f();
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14681,14 +14681,14 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14778,14 +14778,14 @@ return Array.isArray(arr)
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14881,14 +14881,14 @@ return target === C.prototype
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -14980,14 +14980,14 @@ return (@inverse function(it){
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15069,14 +15069,14 @@ return (@inverse function(it){
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -15163,14 +15163,14 @@ return Reflect.isCallable(function(){})
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15257,14 +15257,14 @@ return Reflect.isConstructor(function(){})
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15346,14 +15346,14 @@ return Reflect.isConstructor(function(){})
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -15438,14 +15438,14 @@ return typeof Zone == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15530,14 +15530,14 @@ return &apos;current&apos; in Zone;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15622,14 +15622,14 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15714,14 +15714,14 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15806,14 +15806,14 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15898,14 +15898,14 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15990,14 +15990,14 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16079,14 +16079,14 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -16177,14 +16177,14 @@ return (function f(n){
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16282,14 +16282,14 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16371,14 +16371,14 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -16465,14 +16465,14 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16560,14 +16560,14 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16658,14 +16658,14 @@ Promise.any([
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no needs-polyfill-or-native obsolete not-applicable" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete not-applicable" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete not-applicable" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -16749,14 +16749,14 @@ Promise.any([
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
@@ -16841,14 +16841,14 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -16933,14 +16933,14 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17025,14 +17025,14 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17117,14 +17117,14 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17209,14 +17209,14 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17301,14 +17301,14 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17393,14 +17393,14 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17485,14 +17485,14 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17577,14 +17577,14 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes unstable not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20180910" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>


### PR DESCRIPTION
- Support: ES2019 `Symbol.prototype.description`
- Support: ES2019 `Array.prototype.{flat, flatMap}`
- Support: ES6 `new Symbol()` throws
- Degrade: ES6 `Reflect.ownKeys` with symbols