### PR TITLE
String.prototype.matchAll is enabled by default in Firefox 67

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -400,6 +400,7 @@ exports.tests = [
     firefox2: false,
     firefox65: false,
     firefox66: firefox.nightly,
+    firefox67: true,
     chrome67: false,
     chrome68: chrome.harmony,
     chrome74: true,

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -555,7 +555,7 @@ return a === &apos;1a2b&apos;
 <td class="no" data-browser="firefox64">No</td>
 <td class="no" data-browser="firefox65">No</td>
 <td class="no unstable" data-browser="firefox66">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
-<td class="no unstable" data-browser="firefox67">No<a href="#firefox-nightly-note"><sup>[8]</sup></a></td>
+<td class="yes unstable" data-browser="firefox67">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome64">No</td>
 <td class="no obsolete" data-browser="chrome65">No</td>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1531830