### PR TITLE
String generics removed from Firefox 68

### DIFF
--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -1666,6 +1666,8 @@ exports.tests = [
   res: {
     ie7: false,
     firefox2: true,
+    firefox67: true,
+    firefox68: false,
     safari3_1: false,
     chrome7: false,
     opera7_5: false,

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -6222,7 +6222,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="yes" data-browser="firefox65">Yes</td>
 <td class="yes" data-browser="firefox66">Yes</td>
 <td class="yes unstable" data-browser="firefox67">Yes</td>
-<td class="yes unstable" data-browser="firefox68">Yes</td>
+<td class="no unstable" data-browser="firefox68">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome65">No</td>
 <td class="no obsolete" data-browser="chrome66">No</td>


### PR DESCRIPTION
This feature was removed from Firefox 68:
https://bugzilla.mozilla.org/show_bug.cgi?id=1222552