### PR TITLE
update closure-compiler to v20190325

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -3176,6 +3176,7 @@ exports.tests = [
     res: {
       babel6corejs2: false,
       babel7corejs3: babel.corejs,
+      closure20190325: true,
       typescript1corejs2: typescript.fallthrough,
       typescript3_2corejs3: typescript.corejs,
       firefox52: false,
@@ -3300,6 +3301,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure20190325: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
           firefox2: false,
@@ -3321,6 +3323,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure20190325: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
           firefox2: false,

--- a/environments.json
+++ b/environments.json
@@ -157,7 +157,7 @@
     "short": "Closure 2018.10",
     "family": "Closure",
     "platformtype": "compiler",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -238,6 +238,18 @@
   },
   "closure20190301": {
     "full": "Closure Compiler v20190301",
+    "short": "Closure 2019.03",
+    "family": "Closure",
+    "platformtype": "compiler",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "closure20190325": {
+    "full": "Closure Compiler v20190325",
     "short": "Closure 2019.03",
     "family": "Closure",
     "platformtype": "compiler",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -129,14 +129,14 @@
 <th class="platform babel7corejs2 compiler" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform closure compiler obsolete" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure 2018.02</abbr></a></th>
-<th class="platform closure20181008 compiler obsolete" data-browser="closure20181008"><a href="#closure20181008" class="browser-name"><abbr title="Closure Compiler v20181008">Closure 2018.10</abbr></a></th>
 <th class="platform closure20181028 compiler obsolete" data-browser="closure20181028"><a href="#closure20181028" class="browser-name"><abbr title="Closure Compiler v20181028">Closure 2018.10</abbr></a></th>
 <th class="platform closure20181125 compiler obsolete" data-browser="closure20181125"><a href="#closure20181125" class="browser-name"><abbr title="Closure Compiler v20181125">Closure 2018.11</abbr></a></th>
 <th class="platform closure20181210 compiler obsolete" data-browser="closure20181210"><a href="#closure20181210" class="browser-name"><abbr title="Closure Compiler v20181210">Closure 2018.12</abbr></a></th>
 <th class="platform closure20190106 compiler obsolete" data-browser="closure20190106"><a href="#closure20190106" class="browser-name"><abbr title="Closure Compiler v20190106">Closure 2019.01</abbr></a></th>
 <th class="platform closure20190121 compiler obsolete" data-browser="closure20190121"><a href="#closure20190121" class="browser-name"><abbr title="Closure Compiler v20190121">Closure 2019.01</abbr></a></th>
 <th class="platform closure20190215 compiler obsolete" data-browser="closure20190215"><a href="#closure20190215" class="browser-name"><abbr title="Closure Compiler v20190215">Closure 2019.02</abbr></a></th>
-<th class="platform closure20190301 compiler" data-browser="closure20190301"><a href="#closure20190301" class="browser-name"><abbr title="Closure Compiler v20190301">Closure 2019.03</abbr></a></th>
+<th class="platform closure20190301 compiler obsolete" data-browser="closure20190301"><a href="#closure20190301" class="browser-name"><abbr title="Closure Compiler v20190301">Closure 2019.03</abbr></a></th>
+<th class="platform closure20190325 compiler" data-browser="closure20190325"><a href="#closure20190325" class="browser-name"><abbr title="Closure Compiler v20190325">Closure 2019.03</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_7corejs2 compiler obsolete" data-browser="typescript2_7corejs2"><a href="#typescript2_7corejs2" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_8corejs2 compiler obsolete" data-browser="typescript2_8corejs2"><a href="#typescript2_8corejs2" class="browser-name"><abbr title="TypeScript 2.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -225,14 +225,14 @@
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20190301" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20190325" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -318,14 +318,14 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -411,14 +411,14 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -509,14 +509,14 @@ return true;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -599,14 +599,14 @@ return true;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20190301" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20190325" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">3/3</td>
@@ -696,14 +696,14 @@ return [1, 2, 3].includes(1)
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -811,14 +811,14 @@ return 24;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -909,14 +909,14 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1011,14 +1011,14 @@ return true;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1117,14 +1117,14 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -1215,14 +1215,14 @@ return true;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1309,14 +1309,14 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -1404,14 +1404,14 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -1504,14 +1504,14 @@ return passed;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1606,14 +1606,14 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1698,14 +1698,14 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="closure20190301" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="closure20190325" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">4/4</td>
@@ -1794,14 +1794,14 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1894,14 +1894,14 @@ return Array.isArray(e)
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1995,14 +1995,14 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2091,14 +2091,14 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2181,14 +2181,14 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20190301" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20190325" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -2279,14 +2279,14 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2377,14 +2377,14 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2467,14 +2467,14 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20190301" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20190325" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -2560,14 +2560,14 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -2653,14 +2653,14 @@ return Math.min(1,2,3,) === 1;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -2743,14 +2743,14 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
-<td class="tally" data-browser="closure20190301" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally" data-browser="closure20190325" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
@@ -2847,14 +2847,14 @@ p.then(function(result) {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -2951,14 +2951,14 @@ p.catch(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3045,14 +3045,14 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -3139,14 +3139,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3239,14 +3239,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3341,14 +3341,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3435,14 +3435,14 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -3534,14 +3534,14 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3628,14 +3628,14 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -3732,14 +3732,14 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3836,14 +3836,14 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3940,14 +3940,14 @@ var p = new C().a();
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4042,14 +4042,14 @@ p.then(function(result) {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4137,14 +4137,14 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4230,14 +4230,14 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4332,14 +4332,14 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4422,14 +4422,14 @@ p.then(function(result) {
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/17</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/17</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/17</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/17</td>
@@ -4515,14 +4515,14 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4608,14 +4608,14 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4701,14 +4701,14 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4794,14 +4794,14 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4887,14 +4887,14 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4980,14 +4980,14 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5073,14 +5073,14 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5166,14 +5166,14 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5259,14 +5259,14 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5352,14 +5352,14 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5445,14 +5445,14 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5538,14 +5538,14 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5631,14 +5631,14 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5724,14 +5724,14 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5817,14 +5817,14 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5910,14 +5910,14 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6003,14 +6003,14 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6103,14 +6103,14 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6199,14 +6199,14 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6295,14 +6295,14 @@ return (function(){
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -6387,14 +6387,14 @@ return (function(){
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -6485,14 +6485,14 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6584,14 +6584,14 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6683,14 +6683,14 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6781,14 +6781,14 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6880,14 +6880,14 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6979,14 +6979,14 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7079,14 +7079,14 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7179,14 +7179,14 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7280,14 +7280,14 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7378,14 +7378,14 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7475,14 +7475,14 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7575,14 +7575,14 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7675,14 +7675,14 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7776,14 +7776,14 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7874,14 +7874,14 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7971,14 +7971,14 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8061,14 +8061,14 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -8158,14 +8158,14 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8255,14 +8255,14 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8357,14 +8357,14 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8459,14 +8459,14 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8553,14 +8553,14 @@ return i === 0;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8645,14 +8645,14 @@ return i === 0;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -8739,14 +8739,14 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="no obsolete" data-browser="closure20181028">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20181125">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20181210">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190106">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190215">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="closure20190301">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190301">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="closure20190325">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -8834,14 +8834,14 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190215">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="closure20190301">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190301">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="closure20190325">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -8924,14 +8924,14 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20190301" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20190325" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">3/3</td>
@@ -9043,14 +9043,14 @@ function check() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9154,14 +9154,14 @@ function check() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9267,14 +9267,14 @@ function check() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9361,14 +9361,14 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_7corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_8corejs2">?</td>
@@ -9461,14 +9461,14 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9555,14 +9555,14 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9649,14 +9649,14 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9739,14 +9739,14 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20190301" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20190325" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">2/2</td>
@@ -9839,14 +9839,14 @@ iterator.next().then(function(step){
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -9949,14 +9949,14 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -10051,14 +10051,14 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20181008">Yes</td>
 <td class="yes obsolete" data-browser="closure20181028">Yes</td>
 <td class="yes obsolete" data-browser="closure20181125">Yes</td>
 <td class="yes obsolete" data-browser="closure20181210">Yes</td>
 <td class="yes obsolete" data-browser="closure20190106">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10147,14 +10147,14 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -10237,14 +10237,14 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20190325" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">4/4</td>
@@ -10330,14 +10330,14 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10423,14 +10423,14 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10516,14 +10516,14 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10609,14 +10609,14 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10699,14 +10699,14 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20190301" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20190325" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -10792,14 +10792,14 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -10887,14 +10887,14 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10981,14 +10981,14 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -11073,14 +11073,14 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20190301" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20190325" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">3/3</td>
@@ -11172,14 +11172,14 @@ return false;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -11272,14 +11272,14 @@ return false;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -11377,14 +11377,14 @@ return it.next().value;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -11467,14 +11467,14 @@ return it.next().value;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20190301" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20190325" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/3</td>
@@ -11560,14 +11560,14 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -11653,14 +11653,14 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -11747,14 +11747,14 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -11837,14 +11837,14 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/7</td>
@@ -11932,14 +11932,14 @@ return fn + &apos;&apos; === str;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12026,14 +12026,14 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12120,14 +12120,14 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12214,14 +12214,14 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12308,14 +12308,14 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12402,14 +12402,14 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12496,14 +12496,14 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12586,14 +12586,14 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20190301" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20190325" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -12679,14 +12679,14 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12772,14 +12772,14 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
-<td class="yes" data-browser="closure20190301">Yes</td>
+<td class="yes obsolete" data-browser="closure20190301">Yes</td>
+<td class="yes" data-browser="closure20190325">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12866,14 +12866,14 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -12971,14 +12971,14 @@ return a === &apos;1a2b&apos;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -135,14 +135,14 @@
 <th class="platform babel7corejs2 compiler" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform closure compiler obsolete" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure 2018.02</abbr></a></th>
-<th class="platform closure20181008 compiler obsolete" data-browser="closure20181008"><a href="#closure20181008" class="browser-name"><abbr title="Closure Compiler v20181008">Closure 2018.10</abbr></a></th>
 <th class="platform closure20181028 compiler obsolete" data-browser="closure20181028"><a href="#closure20181028" class="browser-name"><abbr title="Closure Compiler v20181028">Closure 2018.10</abbr></a></th>
 <th class="platform closure20181125 compiler obsolete" data-browser="closure20181125"><a href="#closure20181125" class="browser-name"><abbr title="Closure Compiler v20181125">Closure 2018.11</abbr></a></th>
 <th class="platform closure20181210 compiler obsolete" data-browser="closure20181210"><a href="#closure20181210" class="browser-name"><abbr title="Closure Compiler v20181210">Closure 2018.12</abbr></a></th>
 <th class="platform closure20190106 compiler obsolete" data-browser="closure20190106"><a href="#closure20190106" class="browser-name"><abbr title="Closure Compiler v20190106">Closure 2019.01</abbr></a></th>
 <th class="platform closure20190121 compiler obsolete" data-browser="closure20190121"><a href="#closure20190121" class="browser-name"><abbr title="Closure Compiler v20190121">Closure 2019.01</abbr></a></th>
 <th class="platform closure20190215 compiler obsolete" data-browser="closure20190215"><a href="#closure20190215" class="browser-name"><abbr title="Closure Compiler v20190215">Closure 2019.02</abbr></a></th>
-<th class="platform closure20190301 compiler" data-browser="closure20190301"><a href="#closure20190301" class="browser-name"><abbr title="Closure Compiler v20190301">Closure 2019.03</abbr></a></th>
+<th class="platform closure20190301 compiler obsolete" data-browser="closure20190301"><a href="#closure20190301" class="browser-name"><abbr title="Closure Compiler v20190301">Closure 2019.03</abbr></a></th>
+<th class="platform closure20190325 compiler" data-browser="closure20190325"><a href="#closure20190325" class="browser-name"><abbr title="Closure Compiler v20190325">Closure 2019.03</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_7corejs2 compiler obsolete" data-browser="typescript2_7corejs2"><a href="#typescript2_7corejs2" class="browser-name"><abbr title="TypeScript 2.7 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_8corejs2 compiler obsolete" data-browser="typescript2_8corejs2"><a href="#typescript2_8corejs2" class="browser-name"><abbr title="TypeScript 2.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -229,14 +229,14 @@
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -322,14 +322,14 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -419,14 +419,14 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -507,14 +507,14 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
@@ -601,14 +601,14 @@ return new C().x === &apos;x&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -701,14 +701,14 @@ return new C(42).x() === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -798,14 +798,14 @@ return new C().x() === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -892,14 +892,14 @@ return new C().x === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -980,14 +980,14 @@ return new C().x === 42;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -1074,14 +1074,14 @@ return C.x === &apos;x&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -1171,14 +1171,14 @@ return new C().x() === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1265,14 +1265,14 @@ return C.x === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1357,14 +1357,14 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -1445,14 +1445,14 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/8</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/8</td>
@@ -1536,14 +1536,14 @@ return (1n + 2n) === 3n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1627,14 +1627,14 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1718,14 +1718,14 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1809,14 +1809,14 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1903,14 +1903,14 @@ return view[0] === -0x8000000000000000n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -1997,14 +1997,14 @@ return view[0] === 0n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2091,14 +2091,14 @@ return view.getBigInt64(0) === 1n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2185,14 +2185,14 @@ return view.getBigUint64(0) === 1n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2287,14 +2287,14 @@ Promise.allSettled([
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -2375,14 +2375,14 @@ Promise.allSettled([
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -2472,14 +2472,14 @@ return RegExp.lastMatch === 'x';
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2571,14 +2571,14 @@ return true;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2670,14 +2670,14 @@ return result === &apos;tromple&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -2758,14 +2758,14 @@ return result === &apos;tromple&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/1</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/1</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/1</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">1/1</td>
@@ -2857,14 +2857,14 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no" data-browser="babel7corejs2">No<a href="#babel-decorators-legacy-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="babel7corejs3">No<a href="#babel-decorators-legacy-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes</td>
@@ -2951,14 +2951,14 @@ return typeof Realm === &quot;function&quot;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3046,14 +3046,14 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3134,14 +3134,14 @@ return works &amp;&amp; weakref.get() === undefined;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/4</td>
@@ -3231,14 +3231,14 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3332,14 +3332,14 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3428,14 +3428,14 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3524,14 +3524,14 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -3615,14 +3615,14 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -3703,14 +3703,14 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/7</td>
@@ -3797,14 +3797,14 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -3892,14 +3892,14 @@ return set.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -3986,14 +3986,14 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4080,14 +4080,14 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4171,14 +4171,14 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4262,14 +4262,14 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4353,14 +4353,14 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -4441,14 +4441,14 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -4535,14 +4535,14 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4629,14 +4629,14 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4725,14 +4725,14 @@ return do {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -4813,14 +4813,14 @@ return do {
 <td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">7/7</td>
@@ -4904,14 +4904,14 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -4995,14 +4995,14 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5086,14 +5086,14 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5187,14 +5187,14 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5279,14 +5279,14 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5370,14 +5370,14 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5461,14 +5461,14 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5553,14 +5553,14 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -5647,14 +5647,14 @@ return Math.signbit(-0) === false
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5735,14 +5735,14 @@ return Math.signbit(-0) === false
 <td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">7/7</td>
@@ -5828,14 +5828,14 @@ return Math.clamp(2, 4, 6) === 4
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -5919,14 +5919,14 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6011,14 +6011,14 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6102,14 +6102,14 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6193,14 +6193,14 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6285,14 +6285,14 @@ return Math.radians(90) === Math.PI / 2
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6376,14 +6376,14 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6464,14 +6464,14 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">7/7</td>
@@ -6555,14 +6555,14 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6646,14 +6646,14 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6739,14 +6739,14 @@ return score === 1;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6837,14 +6837,14 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -6935,14 +6935,14 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7033,14 +7033,14 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7131,14 +7131,14 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7219,14 +7219,14 @@ Promise.try(function() {
 <td class="tally" data-browser="babel7corejs2" data-tally="1">8/8</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="1">8/8</td>
@@ -7313,14 +7313,14 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7409,14 +7409,14 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7503,14 +7503,14 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7597,14 +7597,14 @@ return C.has(3) + C.has(4);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7691,14 +7691,14 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7787,14 +7787,14 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7881,14 +7881,14 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7975,14 +7975,14 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_7corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_8corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8078,14 +8078,14 @@ return result === &apos;Hello, hello!&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8173,14 +8173,14 @@ return 123i === &apos;string123number123&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8261,14 +8261,14 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/3</td>
@@ -8354,14 +8354,14 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8447,14 +8447,14 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8540,14 +8540,14 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8635,14 +8635,14 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8723,14 +8723,14 @@ return null ?? 42 === 42 &amp;&amp;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/12</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/12</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/12</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/12</td>
@@ -8818,14 +8818,14 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -8913,14 +8913,14 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9008,14 +9008,14 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9103,14 +9103,14 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9198,14 +9198,14 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9293,14 +9293,14 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9388,14 +9388,14 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9486,14 +9486,14 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9582,14 +9582,14 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9677,14 +9677,14 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9772,14 +9772,14 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9867,14 +9867,14 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -9955,14 +9955,14 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/8</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/8</td>
@@ -10046,14 +10046,14 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10137,14 +10137,14 @@ return Object.isFrozen([# 42 #]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10228,14 +10228,14 @@ return Object.isSealed({| foo: 42 |});
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10319,14 +10319,14 @@ return Object.isSealed([| 42 |]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10418,14 +10418,14 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10518,14 +10518,14 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10617,14 +10617,14 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10717,14 +10717,14 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -10813,14 +10813,14 @@ return results.length === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -10901,14 +10901,14 @@ return results.length === 3
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -10992,14 +10992,14 @@ return [1, 2, 3].lastItem === 3;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11083,14 +11083,14 @@ return [1, 2, 3].lastIndex === 2;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11171,14 +11171,14 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/26</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">26/26</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/26</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/26</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/26</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/26</td>
@@ -11267,14 +11267,14 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11361,14 +11361,14 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11456,14 +11456,14 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11547,14 +11547,14 @@ return new Map([[1, 4], [2, 5], [3, 6]]).every(it =&gt; typeof it == &apos;numbe
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11641,14 +11641,14 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11732,14 +11732,14 @@ return new Map([[1, 2], [2, 3], [3, 4]]).find(it =&gt; it % 2) === 3;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11823,14 +11823,14 @@ return new Map([[1, 2], [2, 3], [3, 4]]).findKey(it =&gt; it % 2) === 2;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -11915,14 +11915,14 @@ return new Map([[1, 2], [2, NaN]]).includes(2)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12007,14 +12007,14 @@ return new Map([[1, 2], [2, NaN]]).keyOf(2) === 1
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12102,14 +12102,14 @@ return map.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12197,14 +12197,14 @@ return map.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12292,14 +12292,14 @@ return map.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12383,14 +12383,14 @@ return new Map([[&apos;a&apos;, 1], [&apos;b&apos;, 2], [&apos;c&apos;, 3], ]).r
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12474,14 +12474,14 @@ return new Map([[1, 4], [2, 5], [3, 6]]).some(it =&gt; it % 2);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12569,14 +12569,14 @@ return set.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12664,14 +12664,14 @@ return set.deleteAll(2, 3) === true
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12755,14 +12755,14 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12849,14 +12849,14 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -12940,14 +12940,14 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13031,14 +13031,14 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13126,14 +13126,14 @@ return set.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13217,14 +13217,14 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13308,14 +13308,14 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13408,14 +13408,14 @@ return !map.has(a)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13508,14 +13508,14 @@ return set.has(a)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13608,14 +13608,14 @@ return !set.has(a)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13707,14 +13707,14 @@ return second === gen2.next().value;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13795,14 +13795,14 @@ return second === gen2.next().value;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20181008" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181028" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181125" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20181210" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190106" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20190301" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_7corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_8corejs2" data-tally="0">0/2</td>
@@ -13886,14 +13886,14 @@ return Number.fromString(&apos;42&apos;) === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -13977,14 +13977,14 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_7corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_8corejs2">No</td>
@@ -14074,14 +14074,14 @@ Promise.any([
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20181008">No</td>
 <td class="no obsolete" data-browser="closure20181028">No</td>
 <td class="no obsolete" data-browser="closure20181125">No</td>
 <td class="no obsolete" data-browser="closure20181210">No</td>
 <td class="no obsolete" data-browser="closure20190106">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
-<td class="no" data-browser="closure20190301">No</td>
+<td class="no obsolete" data-browser="closure20190301">No</td>
+<td class="no" data-browser="closure20190325">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_7corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_8corejs2">No<a href="#typescript-es6-note"><sup>[5]</sup></a></td>
@@ -14164,14 +14164,14 @@ Promise.any([
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -14257,14 +14257,14 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14349,14 +14349,14 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14440,14 +14440,14 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -14528,14 +14528,14 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -14620,14 +14620,14 @@ return f();
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14711,14 +14711,14 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14807,14 +14807,14 @@ return Array.isArray(arr)
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -14909,14 +14909,14 @@ return target === C.prototype
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -15007,14 +15007,14 @@ return (@inverse function(it){
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15095,14 +15095,14 @@ return (@inverse function(it){
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -15188,14 +15188,14 @@ return Reflect.isCallable(function(){})
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15281,14 +15281,14 @@ return Reflect.isConstructor(function(){})
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15369,14 +15369,14 @@ return Reflect.isConstructor(function(){})
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -15460,14 +15460,14 @@ return typeof Zone == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15551,14 +15551,14 @@ return &apos;current&apos; in Zone;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15642,14 +15642,14 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15733,14 +15733,14 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15824,14 +15824,14 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -15915,14 +15915,14 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16006,14 +16006,14 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16094,14 +16094,14 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -16191,14 +16191,14 @@ return (function f(n){
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16295,14 +16295,14 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16383,14 +16383,14 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -16476,14 +16476,14 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16570,14 +16570,14 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -16660,14 +16660,14 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
@@ -16751,14 +16751,14 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -16842,14 +16842,14 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -16933,14 +16933,14 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17024,14 +17024,14 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17115,14 +17115,14 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17206,14 +17206,14 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17297,14 +17297,14 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17388,14 +17388,14 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -17479,14 +17479,14 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20181008" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181028" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181125" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20181210" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190106" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_8corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>


### PR DESCRIPTION
- support `Object.fromEntries`
- support `String.prototype.trimStart` / `String.prototype.trimEnd`

https://github.com/google/closure-compiler/wiki/Releases#march-25-2019-v20190325