### PR TITLE
Fixing the result values for Firefox features marked as "nomob"

### DIFF
--- a/data-common.json
+++ b/data-common.json
@@ -52,9 +52,9 @@
       "note_html": "The feature have to be enabled via \"javascript.options.shared_memory\" setting under <code>about:config</code>.  It is enabled by default in Firefox Developer Edition and Firefox Nightly builds."
     },
     "nomob": {
-      "val": "flagged",
+      "val": true,
       "note_id": "firefox-nomob",
-      "note_html": "The feature is available on desktop versions only, it is not available on mobile versions yet."
+      "note_html": "The feature is available on desktop builds only, it is not available on mobile builds."
     },
     "developer": {
       "val": "flagged",

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -217,7 +217,7 @@
 <td class="tally" data-browser="edge17" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge18" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="edge19" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="firefox52" data-tally="0" data-flagged-tally="1">0/2</td>
+<td class="tally obsolete" data-browser="firefox52" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox59" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox60" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox61" data-tally="1">2/2</td>
@@ -291,7 +291,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -365,7 +365,7 @@ return Intl.constructor === Object;
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -436,7 +436,7 @@ return Intl.constructor === Object;
 <td class="tally" data-browser="edge17" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge18" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="edge19" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox52" data-tally="0" data-flagged-tally="1">0/4</td>
+<td class="tally obsolete" data-browser="firefox52" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox59" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox60" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox61" data-tally="1">4/4</td>
@@ -510,7 +510,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -584,7 +584,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -658,7 +658,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -760,7 +760,7 @@ try {
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -831,7 +831,7 @@ try {
 <td class="tally" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge19" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox52" data-tally="0" data-flagged-tally="1">0/1</td>
+<td class="tally obsolete" data-browser="firefox52" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox59" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox60" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox61" data-tally="1">1/1</td>
@@ -905,7 +905,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -976,7 +976,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="edge19" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="firefox52" data-tally="0" data-flagged-tally="1">0/1</td>
+<td class="tally obsolete" data-browser="firefox52" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox59" data-tally="1">1/1</td>
 <td class="tally" data-browser="firefox60" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox61" data-tally="1">1/1</td>
@@ -1050,7 +1050,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -1121,7 +1121,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally" data-browser="edge17" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge18" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="edge19" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="firefox52" data-tally="0" data-flagged-tally="1">0/5</td>
+<td class="tally obsolete" data-browser="firefox52" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox59" data-tally="1">5/5</td>
 <td class="tally" data-browser="firefox60" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="firefox61" data-tally="1">5/5</td>
@@ -1195,7 +1195,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -1269,7 +1269,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -1343,7 +1343,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -1417,7 +1417,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -1519,7 +1519,7 @@ try {
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -1590,7 +1590,7 @@ try {
 <td class="tally" data-browser="edge17" data-tally="1">6/6</td>
 <td class="tally" data-browser="edge18" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="edge19" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="firefox52" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)" data-flagged-tally="1">2/6</td>
+<td class="tally obsolete" data-browser="firefox52" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox59" data-tally="1">6/6</td>
 <td class="tally" data-browser="firefox60" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="firefox61" data-tally="1">6/6</td>
@@ -1664,7 +1664,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -1738,7 +1738,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -1812,7 +1812,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -1914,7 +1914,7 @@ try {
 <td class="yes" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes unstable" data-browser="edge19">Yes</td>
-<td class="no flagged obsolete" data-browser="firefox52">Flag<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox52">Yes<a href="#firefox-nomob-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox59">Yes</td>
 <td class="yes" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
@@ -3151,7 +3151,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="firefox-nomob-note">  <sup>[4]</sup> The feature is available on desktop versions only, it is not available on mobile versions yet.</p></div>
+    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="firefox-nomob-note">  <sup>[4]</sup> The feature is available on desktop builds only, it is not available on mobile builds.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
   <script src="../jquery.floatThead.min.js"></script>


### PR DESCRIPTION
"flagged" means that the feature is not available by default, but it can be turned on by the user (either by changing the browser configuration or adding a command line parameter).  This is not what the "nomob" nightly means: the feature is available on desktop builds only, and there's no way to enable it on mobile builds.

This PR reverts a change made in #1438, but had no relation with the issue being fixed.