### PR TITLE
Fixing the result values for Firefox features marked as "nightly" and "developer"

### DIFF
--- a/data-common.json
+++ b/data-common.json
@@ -57,12 +57,12 @@
       "note_html": "The feature is available on desktop versions only, it is not available on mobile versions yet."
     },
     "developer": {
-      "val": "flagged",
+      "val": false,
       "note_id": "firefox-developer",
       "note_html": "The feature is available only in Firefox Developer Edition and Firefox Nightly builds."
     },
     "nightly": {
-      "val": "flagged",
+      "val": false,
       "note_id": "firefox-nightly",
       "note_html": "The feature is available only in Firefox Nightly builds."
     },

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -10261,7 +10261,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally" data-browser="edge18" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally unstable" data-browser="edge19" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox59" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally" data-browser="firefox60" data-tally="0.5" style="background-color:hsl(60,64%,50%)" data-flagged-tally="1">2/4</td>
+<td class="tally" data-browser="firefox60" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="firefox61" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox62" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="firefox63" data-tally="1">4/4</td>
@@ -10540,7 +10540,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
 <td class="no obsolete" data-browser="firefox59">No</td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
 <td class="yes obsolete" data-browser="firefox62">Yes</td>
 <td class="yes obsolete" data-browser="firefox63">Yes</td>
@@ -10633,7 +10633,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
 <td class="no obsolete" data-browser="firefox59">No</td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox61">Yes</td>
 <td class="yes obsolete" data-browser="firefox62">Yes</td>
 <td class="yes obsolete" data-browser="firefox63">Yes</td>
@@ -10722,9 +10722,9 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="edge17" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/3</td>
 <td class="tally unstable" data-browser="edge19" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="firefox59" data-tally="0" data-flagged-tally="0.3333333333333333">0/3</td>
-<td class="tally" data-browser="firefox60" data-tally="0" data-flagged-tally="0.3333333333333333">0/3</td>
-<td class="tally obsolete" data-browser="firefox61" data-tally="0" data-flagged-tally="0.3333333333333333">0/3</td>
+<td class="tally obsolete" data-browser="firefox59" data-tally="0">0/3</td>
+<td class="tally" data-browser="firefox60" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="firefox61" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox62" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="firefox63" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="firefox64" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -10910,9 +10910,9 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox62">Yes</td>
 <td class="yes obsolete" data-browser="firefox63">Yes</td>
 <td class="yes obsolete" data-browser="firefox64">Yes</td>
@@ -13001,7 +13001,7 @@ return a === &apos;1a2b&apos;
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
-<td class="no flagged" data-browser="firefox66">Flag<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
+<td class="no" data-browser="firefox66">No<a href="#firefox-nightly-note"><sup>[27]</sup></a></td>
 <td class="yes" data-browser="firefox67">Yes</td>
 <td class="yes unstable" data-browser="firefox68">Yes</td>
 <td class="yes unstable" data-browser="firefox69">Yes</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -206,10 +206,10 @@
 <td class="tally" data-browser="edge17" data-tally="0">0/57</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/57</td>
 <td class="tally unstable" data-browser="edge19" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="firefox59" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally" data-browser="firefox60" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally obsolete" data-browser="firefox61" data-tally="0" data-flagged-tally="1">0/57</td>
-<td class="tally obsolete" data-browser="firefox62" data-tally="0" data-flagged-tally="1">0/57</td>
+<td class="tally obsolete" data-browser="firefox59" data-tally="0">0/57</td>
+<td class="tally" data-browser="firefox60" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="firefox61" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="firefox62" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox63" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox64" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="firefox65" data-tally="0">0/57</td>
@@ -292,10 +292,10 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -370,10 +370,10 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -448,10 +448,10 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -526,10 +526,10 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -604,10 +604,10 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -682,10 +682,10 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -760,10 +760,10 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -838,10 +838,10 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -916,10 +916,10 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -994,10 +994,10 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -1072,10 +1072,10 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -1152,10 +1152,10 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -1232,10 +1232,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -1312,10 +1312,10 @@ return simdSmallIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -1392,10 +1392,10 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -1472,10 +1472,10 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -1552,10 +1552,10 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -1632,10 +1632,10 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -1712,10 +1712,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -1792,10 +1792,10 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -1872,10 +1872,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -1952,10 +1952,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -2032,10 +2032,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -2112,10 +2112,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -2192,10 +2192,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -2272,10 +2272,10 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -2352,10 +2352,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -2432,10 +2432,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -2512,10 +2512,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -2592,10 +2592,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -2672,10 +2672,10 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -2752,10 +2752,10 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -2832,10 +2832,10 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -2912,10 +2912,10 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -2992,10 +2992,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -3072,10 +3072,10 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -3152,10 +3152,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -3232,10 +3232,10 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -3312,10 +3312,10 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -3392,10 +3392,10 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -3472,10 +3472,10 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -3552,10 +3552,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -3632,10 +3632,10 @@ return simdIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -3712,10 +3712,10 @@ return simdIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -3792,10 +3792,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -3872,10 +3872,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -3952,10 +3952,10 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -4032,10 +4032,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -4112,10 +4112,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -4192,10 +4192,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -4272,10 +4272,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -4352,10 +4352,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -4432,10 +4432,10 @@ return simdSmallIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -4512,10 +4512,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -4592,10 +4592,10 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -4672,10 +4672,10 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>
@@ -4750,10 +4750,10 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no unstable" data-browser="edge19">No</td>
-<td class="no flagged obsolete" data-browser="firefox59">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox61">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox62">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox59">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no" data-browser="firefox60">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox61">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="firefox62">No<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="firefox63">No</td>
 <td class="no obsolete" data-browser="firefox64">No</td>
 <td class="no obsolete" data-browser="firefox65">No</td>


### PR DESCRIPTION
"flagged" means that the feature is not available by default, but it can be turned on by the user (either by changing the browser configuration or adding a command line parameter).
This is not what "nightly" means: it is available by default on nightly builds (via compilation flags), and not available at all on other builds. Changing this to "flagged" marked lots of features as optionally available on older versions, which is not true.

This PR reverts a change made in #1438, which was trying to mark BigInt as a "flagged" on nightly builds for Firefox 68, but the feature is not #ifdef as nightly anymore (see #1448 and #1449).