### PR TITLE
Safari 13 got numeric separators and Promise.allSettled support

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -1902,6 +1902,7 @@ exports.tests = [
     chrome67: chrome.harmony,
     chrome75: true,
     opera10_50: false,
+    safari13: true,
     safaritp: true,
     graalvm: false,
   }
@@ -2876,6 +2877,7 @@ exports.tests = [
     typescript3_2corejs3: typescript.corejs,
     firefox68: true,
     chrome76: true,
+    safari13: true,
   }
 },
 {

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -1419,7 +1419,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no" data-browser="safari12">No</td>
 <td class="no" data-browser="safari12_1">No</td>
-<td class="no unstable" data-browser="safari13">No</td>
+<td class="yes unstable" data-browser="safari13">Yes</td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
@@ -2359,9 +2359,9 @@ Promise.allSettled([
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no" data-browser="safari12">No</td>
 <td class="no" data-browser="safari12_1">No</td>
-<td class="no unstable" data-browser="safari13">No</td>
-<td class="no unstable" data-browser="safaritp">No</td>
-<td class="no unstable" data-browser="webkit">No</td>
+<td class="yes unstable" data-browser="safari13">Yes</td>
+<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>


### PR DESCRIPTION
...with latest beta update of macOS Catalina