### PR TITLE
Update Safari Template Strings Permanent Caching results

### DIFF
--- a/data-common.json
+++ b/data-common.json
@@ -114,6 +114,13 @@
       "note_html": "The feature is considered unstable, but can be enabled via <code>--js-flags=\"--harmony-simd\"</code> flag"
     }
   },
+  "safari": {
+    "templateStringsPermanentCaching": {
+      "val": false,
+      "note_id": "safari-templ-cahing",
+      "note_html": "Safari 12 caches TemplateStrings using a GC-able \"CodeBlock\". But TemplateStrings are supposed to always be identical! When the CodeBlock is reclaimed, the TemplateStrings' identity is broken. Thankfully, <code>[[Call]]</code> vs <code>[[Construct]]</code> generate different CodeBlocks, which exposes the <a href='https://bugs.webkit.org/show_bug.cgi?id=190756'>broken behavior.</a>"
+    }
+  },
   "sparseNote": {
     "val": true,
     "note_id": "sparse_arrays",

--- a/data-es6.js
+++ b/data-es6.js
@@ -4,6 +4,7 @@ var babel = common.babel;
 var typescript = common.typescript;
 var chrome = common.chrome;
 var edge = common.edge;
+var safari = common.safari;
 
 exports.name = 'ES6';
 exports.target_file = 'es6/index.html';
@@ -5505,12 +5506,6 @@ exports.tests = [
     {
       name: 'TemplateStrings permanent caching',
       exec: function () {/*
-        // Safari 12 caches TemplateStrings using a GC-able "CodeBlock".
-        // But TemplateStrings are supposed to always be identical! When the
-        // CodeBlock is reclaimed, the TemplateStrings' identity is broken.
-        // Thankfully, [[Call]] vs [[Construct]] generate different CodeBlocks,
-        // which exposes the broken behavior.
-        // https://bugs.webkit.org/show_bug.cgi?id=190756
         function strings(array) {
           return array;
         }
@@ -5535,7 +5530,8 @@ exports.tests = [
         opera10_50: false,
         chrome41: true,
         safari9: true,
-        safari12: false,
+        safari12: safari.templateStringsPermanentCaching,
+        safari13: true,
         node4: true,
         xs6: true,
         jxa: true,


### PR DESCRIPTION
[Bug](https://github.com/kangax/compat-table/pull/1456) was fixed in Safari 13 Beta

closes #1472