### PR TITLE
Numeric Separators enabled by default on Firefox 70

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -1924,6 +1924,7 @@ exports.tests = [
     firefox2: false,
     firefox67: false,
     firefox68: firefox.nightly,
+    firefox70: true,
     chrome67: chrome.harmony,
     chrome75: true,
     opera10_50: false,

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -2164,7 +2164,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="no" data-browser="firefox67">No</td>
 <td class="no flagged" data-browser="firefox68">Flag<a href="#firefox-nightly-note"><sup>[12]</sup></a></td>
 <td class="no flagged unstable" data-browser="firefox69">Flag<a href="#firefox-nightly-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox70">Flag<a href="#firefox-nightly-note"><sup>[12]</sup></a></td>
+<td class="yes unstable" data-browser="firefox70">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no flagged obsolete" data-browser="chrome67">Flag<a href="#chrome-harmony-note"><sup>[10]</sup></a></td>
 <td class="no flagged obsolete" data-browser="chrome68">Flag<a href="#chrome-harmony-note"><sup>[10]</sup></a></td>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1435818