### PR TITLE
Disable WeakRefs by default in Safari

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -500,7 +500,7 @@ exports.tests = [
         opera10_50: false,
         chrome65: false,
         chrome74: {val: 'flagged', note_id: "chrome-weakrefs", note_html: "Available behind the <a href='https://bugs.chromium.org/p/v8/issues/detail?id=8179'><code>--js-flags=--harmony-weak-refs --expose-gc</code></a> flag in V8."},
-        safari13: true,
+        safari13: false,
         duktape2_0: false,
         graalvm: false,
       }

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -563,9 +563,9 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="safari12" data-tally="0">0/2</td>
 <td class="tally" data-browser="safari12_1" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="safari13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="safaritp" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally unstable" data-browser="webkit" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally unstable" data-browser="safari13" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="0">0/2</td>
+<td class="tally unstable" data-browser="webkit" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
@@ -658,9 +658,9 @@ return weakref.deref() === O;
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no" data-browser="safari12">No</td>
 <td class="no" data-browser="safari12_1">No</td>
-<td class="yes unstable" data-browser="safari13">Yes</td>
-<td class="yes unstable" data-browser="safaritp">Yes</td>
-<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="no unstable" data-browser="safari13">No</td>
+<td class="no unstable" data-browser="safaritp">No</td>
+<td class="no unstable" data-browser="webkit">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>


### PR DESCRIPTION
WeakRefs were disabled by default in Safari 13 and Safari TP. There is a flag to turn them on probably, but I have no information about any yet.