### PR TITLE
Non-standard Array generics removed from Firefox 71

### DIFF
--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -1646,6 +1646,7 @@ exports.tests = [
     ie7: false,
     firefox2: true,
     firefox70: {val: true, note_id: "firefox-not-nightly", note_html: "The feature is disabled only in Firefox Nightly builds."},
+    firefox71: false,
     safari3_1: false,
     chrome7: false,
     opera7_5: false,

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -6286,7 +6286,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="yes" data-browser="firefox68">Yes</td>
 <td class="yes" data-browser="firefox69">Yes</td>
 <td class="yes unstable" data-browser="firefox70">Yes<a href="#firefox-not-nightly-note"><sup>[9]</sup></a></td>
-<td class="yes unstable" data-browser="firefox71">Yes<a href="#firefox-not-nightly-note"><sup>[9]</sup></a></td>
+<td class="no unstable" data-browser="firefox71">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome69">No</td>
 <td class="no obsolete" data-browser="chrome70">No</td>


### PR DESCRIPTION
Non-standard Array generics have been removed from Firefox 71:
https://www.fxsitecompat.dev/en-CA/docs/2019/non-standard-array-generics-have-been-removed/