### PR TITLE
Mark Nashorn 10 as obsolete

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -3054,7 +3054,7 @@
     "short": "JJS 10",
     "platformtype": "engine",
     "release": "2018-03-20",
-    "obsolete": false,
+    "obsolete": true,
     "test_suites": [
       "es5",
       "es6"

--- a/es5/index.html
+++ b/es5/index.html
@@ -200,7 +200,7 @@
 <th class="platform duktape2_3 engine" data-browser="duktape2_3"><a href="#duktape2_3" class="browser-name"><abbr title="Duktape 2.3">DUK 2.3</abbr></a></th>
 <th class="platform nashorn1_8 engine" data-browser="nashorn1_8"><a href="#nashorn1_8" class="browser-name"><abbr title="Oracle Nashorn 1.8">JJS 1.8</abbr></a></th>
 <th class="platform nashorn9 engine obsolete" data-browser="nashorn9"><a href="#nashorn9" class="browser-name"><abbr title="Oracle Nashorn 9">JJS 9</abbr></a></th>
-<th class="platform nashorn10 engine" data-browser="nashorn10"><a href="#nashorn10" class="browser-name"><abbr title="Oracle Nashorn 10">JJS 10</abbr></a></th>
+<th class="platform nashorn10 engine obsolete" data-browser="nashorn10"><a href="#nashorn10" class="browser-name"><abbr title="Oracle Nashorn 10">JJS 10</abbr></a></th>
 <th class="platform graalvm engine" data-browser="graalvm"><a href="#graalvm" class="browser-name"><abbr title="GraalVM JavaScript 19.0.0">GraalVM 19.0.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[4]</sup></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
@@ -295,7 +295,7 @@
 <td class="tally" data-browser="duktape2_3" data-tally="1">5/5</td>
 <td class="tally" data-browser="nashorn1_8" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="1">5/5</td>
-<td class="tally" data-browser="nashorn10" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="nashorn10" data-tally="1">5/5</td>
 <td class="tally" data-browser="graalvm" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">5/5</td>
@@ -389,7 +389,7 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -485,7 +485,7 @@ return value === 1;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -579,7 +579,7 @@ return { a: true, }.a === true;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -673,7 +673,7 @@ return [1,].length === 1;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -767,7 +767,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -860,7 +860,7 @@ return ({ if: 1 }).if === 1;
 <td class="tally" data-browser="duktape2_3" data-tally="1">13/13</td>
 <td class="tally" data-browser="nashorn1_8" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="1">13/13</td>
-<td class="tally" data-browser="nashorn10" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="nashorn10" data-tally="1">13/13</td>
 <td class="tally" data-browser="graalvm" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">13/13</td>
@@ -956,7 +956,7 @@ return typeof Object.create == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -1052,7 +1052,7 @@ return typeof Object.defineProperty == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -1148,7 +1148,7 @@ return typeof Object.defineProperties == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -1244,7 +1244,7 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -1340,7 +1340,7 @@ return typeof Object.keys == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -1436,7 +1436,7 @@ return typeof Object.seal == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -1532,7 +1532,7 @@ return typeof Object.freeze == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -1628,7 +1628,7 @@ return typeof Object.preventExtensions == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -1724,7 +1724,7 @@ return typeof Object.isSealed == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -1820,7 +1820,7 @@ return typeof Object.isFrozen == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -1916,7 +1916,7 @@ return typeof Object.isExtensible == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -2012,7 +2012,7 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -2108,7 +2108,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -2199,7 +2199,7 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally" data-browser="duktape2_3" data-tally="1">12/12</td>
 <td class="tally" data-browser="nashorn1_8" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="1">12/12</td>
-<td class="tally" data-browser="nashorn10" data-tally="1">12/12</td>
+<td class="tally obsolete" data-browser="nashorn10" data-tally="1">12/12</td>
 <td class="tally" data-browser="graalvm" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
@@ -2295,7 +2295,7 @@ return typeof Array.isArray == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -2391,7 +2391,7 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -2487,7 +2487,7 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -2583,7 +2583,7 @@ return typeof Array.prototype.every == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -2679,7 +2679,7 @@ return typeof Array.prototype.some == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -2775,7 +2775,7 @@ return typeof Array.prototype.forEach == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -2871,7 +2871,7 @@ return typeof Array.prototype.map == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -2967,7 +2967,7 @@ return typeof Array.prototype.filter == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -3063,7 +3063,7 @@ return typeof Array.prototype.reduce == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -3159,7 +3159,7 @@ return typeof Array.prototype.reduceRight == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -3295,7 +3295,7 @@ return true;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
@@ -3401,7 +3401,7 @@ try {
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -3492,7 +3492,7 @@ try {
 <td class="tally" data-browser="duktape2_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="nashorn1_8" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="1">2/2</td>
-<td class="tally" data-browser="nashorn10" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="nashorn10" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">2/2</td>
@@ -3588,7 +3588,7 @@ return "foobar"[3] === "b";
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -3684,7 +3684,7 @@ return typeof String.prototype.trim == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -3775,7 +3775,7 @@ return typeof String.prototype.trim == 'function';
 <td class="tally" data-browser="duktape2_3" data-tally="1">3/3</td>
 <td class="tally" data-browser="nashorn1_8" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="1">3/3</td>
-<td class="tally" data-browser="nashorn10" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="nashorn10" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">3/3</td>
@@ -3871,7 +3871,7 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -3967,7 +3967,7 @@ return typeof Date.now == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -4071,7 +4071,7 @@ try {
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -4167,7 +4167,7 @@ return typeof Function.prototype.bind == 'function';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -4263,7 +4263,7 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -4356,7 +4356,7 @@ return typeof JSON == 'object';
 <td class="tally" data-browser="duktape2_3" data-tally="1">3/3</td>
 <td class="tally" data-browser="nashorn1_8" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="1">3/3</td>
-<td class="tally" data-browser="nashorn10" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="nashorn10" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">3/3</td>
@@ -4453,7 +4453,7 @@ return result;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -4550,7 +4550,7 @@ return result;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -4647,7 +4647,7 @@ return result;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -4738,7 +4738,7 @@ return result;
 <td class="tally" data-browser="duktape2_3" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="nashorn1_8" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="1">8/8</td>
-<td class="tally" data-browser="nashorn10" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="nashorn10" data-tally="1">8/8</td>
 <td class="tally" data-browser="graalvm" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
@@ -4842,7 +4842,7 @@ try {
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -4938,7 +4938,7 @@ return parseInt('010') === 10;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -5032,7 +5032,7 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -5126,7 +5126,7 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -5221,7 +5221,7 @@ return _\u200c\u200d;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -5317,7 +5317,7 @@ return true;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -5419,7 +5419,7 @@ return result;
 <td class="no" data-browser="duktape2_3">No</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
@@ -5519,7 +5519,7 @@ catch(e) {
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -5610,7 +5610,7 @@ catch(e) {
 <td class="tally" data-browser="duktape2_3" data-tally="1">19/19</td>
 <td class="tally" data-browser="nashorn1_8" data-tally="0.8947368421052632" style="background-color:hsl(107,46%,50%)">17/19</td>
 <td class="tally obsolete" data-browser="nashorn9" data-tally="0.8947368421052632" style="background-color:hsl(107,46%,50%)">17/19</td>
-<td class="tally" data-browser="nashorn10" data-tally="0.8947368421052632" style="background-color:hsl(107,46%,50%)">17/19</td>
+<td class="tally obsolete" data-browser="nashorn10" data-tally="0.8947368421052632" style="background-color:hsl(107,46%,50%)">17/19</td>
 <td class="tally" data-browser="graalvm" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">19/19</td>
@@ -5709,7 +5709,7 @@ return true;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -5804,7 +5804,7 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -5901,7 +5901,7 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -6012,7 +6012,7 @@ return test(String, &apos;&apos;)
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="no" data-browser="nashorn1_8">No</td>
 <td class="no obsolete" data-browser="nashorn9">No</td>
-<td class="no" data-browser="nashorn10">No</td>
+<td class="no obsolete" data-browser="nashorn10">No</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -6109,7 +6109,7 @@ return true;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -6204,7 +6204,7 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -6303,7 +6303,7 @@ return true;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -6402,7 +6402,7 @@ return true;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="no" data-browser="nashorn1_8">No</td>
 <td class="no obsolete" data-browser="nashorn9">No</td>
-<td class="no" data-browser="nashorn10">No</td>
+<td class="no obsolete" data-browser="nashorn10">No</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -6503,7 +6503,7 @@ return true;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -6601,7 +6601,7 @@ return true;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -6697,7 +6697,7 @@ return true;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -6794,7 +6794,7 @@ return true;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -6895,7 +6895,7 @@ return (function(x){
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -6990,7 +6990,7 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -7085,7 +7085,7 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -7180,7 +7180,7 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -7275,7 +7275,7 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -7370,7 +7370,7 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
@@ -7465,7 +7465,7 @@ return typeof foo === &apos;function&apos;;
 <td class="yes" data-browser="duktape2_3">Yes</td>
 <td class="yes" data-browser="nashorn1_8">Yes</td>
 <td class="yes obsolete" data-browser="nashorn9">Yes</td>
-<td class="yes" data-browser="nashorn10">Yes</td>
+<td class="yes obsolete" data-browser="nashorn10">Yes</td>
 <td class="yes" data-browser="graalvm">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>


### PR DESCRIPTION
I'm not an expert in Java world, but:
- If I understood correctly, Nashorn [is deprecated from JDK 11](http://openjdk.java.net/jeps/335)
- JDK 10 is not an LTS release, the end of support - September 2018
- JDK 8 is LTS and will be supported... I don't know... [up to March 2025](https://en.wikipedia.org/wiki/Java_version_history)... or?