### PR TITLE
Firefox now implements String.prototype.replaceAll

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -2164,6 +2164,8 @@ exports.tests = [
       ie11: false,
       firefox10: false,
       firefox52: false,
+      firefox71: false,
+      firefox72: true,
       chrome77: false,
       graalvm: false,
   }

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -2068,7 +2068,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no" data-browser="firefox69">No</td>
 <td class="no" data-browser="firefox70">No</td>
 <td class="no unstable" data-browser="firefox71">No</td>
-<td class="no unstable" data-browser="firefox72">No</td>
+<td class="yes unstable" data-browser="firefox72">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome70">No</td>
 <td class="no obsolete" data-browser="chrome71">No</td>


### PR DESCRIPTION
Firefox 72 implements `String.prototype.replaceAll`:
https://bugzilla.mozilla.org/show_bug.cgi?id=1540021