### PR TITLE
Fix String.prototype.replaceAll support in Firefox 72

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -2165,7 +2165,7 @@ exports.tests = [
       firefox10: false,
       firefox52: false,
       firefox71: false,
-      firefox72: true,
+      firefox72: firefox.nightly,
       chrome77: false,
       chrome80: chrome.stringPrototypeReplaceAll,
       graalvm: false,

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -2068,7 +2068,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no" data-browser="firefox69">No</td>
 <td class="no" data-browser="firefox70">No</td>
 <td class="no unstable" data-browser="firefox71">No</td>
-<td class="yes unstable" data-browser="firefox72">Yes</td>
+<td class="no flagged unstable" data-browser="firefox72">Flag<a href="#firefox-nightly-note"><sup>[11]</sup></a></td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome70">No</td>
 <td class="no obsolete" data-browser="chrome71">No</td>


### PR DESCRIPTION
This feature is enabled for Nightly builds only because of lack of test262 tests for it