### PR TITLE
Update Closure Compiler to v20200112

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -2871,6 +2871,7 @@ exports.tests = [
       res: {
         tr: true,
         babel6corejs2: true,
+        closure20200112: true,
         typescript1corejs2: true,
         es6tr: true,
         ejs: true,

--- a/environments.json
+++ b/environments.json
@@ -181,7 +181,7 @@
     "short": "Closure 2019.01",
     "family": "Closure",
     "platformtype": "compiler",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -250,6 +250,18 @@
   },
   "closure20200101": {
     "full": "Closure Compiler v20200101",
+    "short": "Closure 2020.01",
+    "family": "Closure",
+    "platformtype": "compiler",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "closure20200112": {
+    "full": "Closure Compiler v20200112",
     "short": "Closure 2020.01",
     "family": "Closure",
     "platformtype": "compiler",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -129,13 +129,13 @@
 <th class="platform babel7corejs2 compiler" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform closure compiler obsolete" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure 2018.02</abbr></a></th>
-<th class="platform closure20190121 compiler obsolete" data-browser="closure20190121"><a href="#closure20190121" class="browser-name"><abbr title="Closure Compiler v20190121">Closure 2019.01</abbr></a></th>
 <th class="platform closure20190215 compiler obsolete" data-browser="closure20190215"><a href="#closure20190215" class="browser-name"><abbr title="Closure Compiler v20190215">Closure 2019.02</abbr></a></th>
 <th class="platform closure20190301 compiler obsolete" data-browser="closure20190301"><a href="#closure20190301" class="browser-name"><abbr title="Closure Compiler v20190301">Closure 2019.03</abbr></a></th>
 <th class="platform closure20190325 compiler obsolete" data-browser="closure20190325"><a href="#closure20190325" class="browser-name"><abbr title="Closure Compiler &gt;=v20190325 &lt;v20190709">Closure 2019.03</abbr></a></th>
 <th class="platform closure20190709 compiler obsolete" data-browser="closure20190709"><a href="#closure20190709" class="browser-name"><abbr title="Closure Compiler &gt;=v20190709 &lt;v20191027">Closure 2019.07</abbr></a></th>
 <th class="platform closure20191027 compiler obsolete" data-browser="closure20191027"><a href="#closure20191027" class="browser-name"><abbr title="Closure Compiler &gt;=v20191027 &lt;v20200101">Closure 2019.10</abbr></a></th>
-<th class="platform closure20200101 compiler" data-browser="closure20200101"><a href="#closure20200101" class="browser-name"><abbr title="Closure Compiler v20200101">Closure 2020.01</abbr></a></th>
+<th class="platform closure20200101 compiler obsolete" data-browser="closure20200101"><a href="#closure20200101" class="browser-name"><abbr title="Closure Compiler v20200101">Closure 2020.01</abbr></a></th>
+<th class="platform closure20200112 compiler" data-browser="closure20200112"><a href="#closure20200112" class="browser-name"><abbr title="Closure Compiler v20200112">Closure 2020.01</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_9corejs2 compiler obsolete" data-browser="typescript2_9corejs2"><a href="#typescript2_9corejs2" class="browser-name"><abbr title="TypeScript 2.9 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript3_2corejs2 compiler obsolete" data-browser="typescript3_2corejs2"><a href="#typescript3_2corejs2" class="browser-name"><abbr title="TypeScript 3.2 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -238,13 +238,13 @@
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20200101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20200112" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -344,13 +344,13 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -450,13 +450,13 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -561,13 +561,13 @@ return true;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -664,13 +664,13 @@ return true;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20200101" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20200112" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
@@ -774,13 +774,13 @@ return [1, 2, 3].includes(1)
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -902,13 +902,13 @@ return 24;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1013,13 +1013,13 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1128,13 +1128,13 @@ return true;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -1247,13 +1247,13 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -1358,13 +1358,13 @@ return true;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -1465,13 +1465,13 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -1573,13 +1573,13 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -1686,13 +1686,13 @@ return passed;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -1801,13 +1801,13 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -1906,13 +1906,13 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="closure20200101" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="closure20200112" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">4/4</td>
@@ -2015,13 +2015,13 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2128,13 +2128,13 @@ return Array.isArray(e)
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2242,13 +2242,13 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2351,13 +2351,13 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2454,13 +2454,13 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20200112" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -2565,13 +2565,13 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2676,13 +2676,13 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2779,13 +2779,13 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20200112" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -2885,13 +2885,13 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -2991,13 +2991,13 @@ return Math.min(1,2,3,) === 1;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -3094,13 +3094,13 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
-<td class="tally" data-browser="closure20200101" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally" data-browser="closure20200112" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
@@ -3211,13 +3211,13 @@ p.then(function(result) {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3328,13 +3328,13 @@ p.catch(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3435,13 +3435,13 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3542,13 +3542,13 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -3655,13 +3655,13 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3770,13 +3770,13 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3877,13 +3877,13 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3989,13 +3989,13 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4096,13 +4096,13 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4213,13 +4213,13 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4330,13 +4330,13 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4447,13 +4447,13 @@ var p = new C().a();
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4562,13 +4562,13 @@ p.then(function(result) {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4670,13 +4670,13 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -4776,13 +4776,13 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] == &quot;A
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -4891,13 +4891,13 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -4994,13 +4994,13 @@ p.then(function(result) {
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/17</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/17</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/17</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/17</td>
@@ -5100,13 +5100,13 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -5206,13 +5206,13 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -5312,13 +5312,13 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -5418,13 +5418,13 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -5524,13 +5524,13 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -5630,13 +5630,13 @@ return typeof Atomics.add == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -5736,13 +5736,13 @@ return typeof Atomics.and == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -5842,13 +5842,13 @@ return typeof Atomics.compareExchange == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -5948,13 +5948,13 @@ return typeof Atomics.exchange == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -6054,13 +6054,13 @@ return typeof Atomics.wait == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -6160,13 +6160,13 @@ return typeof Atomics.wake == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -6266,13 +6266,13 @@ return typeof Atomics.isLockFree == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -6372,13 +6372,13 @@ return typeof Atomics.load == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -6478,13 +6478,13 @@ return typeof Atomics.or == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -6584,13 +6584,13 @@ return typeof Atomics.store == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -6690,13 +6690,13 @@ return typeof Atomics.sub == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -6796,13 +6796,13 @@ return typeof Atomics.xor == &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -6907,13 +6907,13 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -7016,13 +7016,13 @@ return (function(){
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -7121,13 +7121,13 @@ return (function(){
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -7232,13 +7232,13 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7344,13 +7344,13 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7456,13 +7456,13 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7567,13 +7567,13 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7679,13 +7679,13 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7791,13 +7791,13 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -7904,13 +7904,13 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8017,13 +8017,13 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8131,13 +8131,13 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8242,13 +8242,13 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8352,13 +8352,13 @@ return b.__lookupGetter__(&quot;foo&quot;) === undefined
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8465,13 +8465,13 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8578,13 +8578,13 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8692,13 +8692,13 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8803,13 +8803,13 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8913,13 +8913,13 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9016,13 +9016,13 @@ return b.__lookupSetter__(&quot;foo&quot;) === undefined
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -9126,13 +9126,13 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9236,13 +9236,13 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9351,13 +9351,13 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9466,13 +9466,13 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9573,13 +9573,13 @@ return i === 0;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9678,13 +9678,13 @@ return i === 0;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -9785,13 +9785,13 @@ return a === 1 &amp;&amp; rest.a === undefined &amp;&amp; rest.b === 2 &amp;&amp
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190215">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190301">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190325">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190709">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20191027">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
-<td class="no" data-browser="closure20200101">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="closure20200101">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no" data-browser="closure20200112">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -9893,13 +9893,13 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190215">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190301">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190325">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190709">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20191027">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
-<td class="no" data-browser="closure20200101">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="closure20200101">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no" data-browser="closure20200112">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -9996,13 +9996,13 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20200101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20200112" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
@@ -10128,13 +10128,13 @@ function check() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10252,13 +10252,13 @@ function check() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10378,13 +10378,13 @@ function check() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10485,13 +10485,13 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -10598,13 +10598,13 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -10705,13 +10705,13 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -10812,13 +10812,13 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -10915,13 +10915,13 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20200112" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -11028,13 +11028,13 @@ iterator.next().then(function(step){
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -11151,13 +11151,13 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -11269,13 +11269,13 @@ return false;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -11382,13 +11382,13 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -11491,13 +11491,13 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -11594,13 +11594,13 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">4/4</td>
-<td class="tally" data-browser="closure20200101" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="1">4/4</td>
+<td class="tally" data-browser="closure20200112" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">4/4</td>
@@ -11700,13 +11700,13 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11806,13 +11806,13 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11912,13 +11912,13 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No<a href="#closure-string-trimstart-note"><sup>[26]</sup></a></td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12018,13 +12018,13 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No<a href="#closure-string-trimend-note"><sup>[27]</sup></a></td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12121,13 +12121,13 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20200101" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20200112" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -12227,13 +12227,13 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -12335,13 +12335,13 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12442,13 +12442,13 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -12547,13 +12547,13 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20200101" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20200112" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
@@ -12659,13 +12659,13 @@ return false;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -12772,13 +12772,13 @@ return false;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -12890,13 +12890,13 @@ return it.next().value;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -12993,13 +12993,13 @@ return it.next().value;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20200101" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20200112" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/3</td>
@@ -13099,13 +13099,13 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -13205,13 +13205,13 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -13312,13 +13312,13 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -13415,13 +13415,13 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/7</td>
@@ -13523,13 +13523,13 @@ return fn + &apos;&apos; === str;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -13630,13 +13630,13 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -13737,13 +13737,13 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -13844,13 +13844,13 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -13951,13 +13951,13 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -14058,13 +14058,13 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -14165,13 +14165,13 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -14268,13 +14268,13 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20200112" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -14374,13 +14374,13 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -14480,13 +14480,13 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
 <td class="yes obsolete" data-browser="closure20190301">Yes</td>
 <td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -14587,13 +14587,13 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -14692,13 +14692,13 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally" data-browser="babel7corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20200112" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -14808,13 +14808,13 @@ return a === &apos;1a2b&apos;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -14919,13 +14919,13 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -15022,13 +15022,13 @@ try {
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/8</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/8</td>
@@ -15128,13 +15128,13 @@ return (1n + 2n) === 3n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -15234,13 +15234,13 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -15340,13 +15340,13 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -15446,13 +15446,13 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -15555,13 +15555,13 @@ return view[0] === -0x8000000000000000n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -15664,13 +15664,13 @@ return view[0] === 0n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -15773,13 +15773,13 @@ return view.getBigInt64(0) === 1n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -15882,13 +15882,13 @@ return view.getBigUint64(0) === 1n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -15999,13 +15999,13 @@ Promise.allSettled([
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -16102,13 +16102,13 @@ Promise.allSettled([
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200101" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20200112" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -16210,13 +16210,13 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -16322,13 +16322,13 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="yes" data-browser="closure20200101">Yes</td>
+<td class="yes obsolete" data-browser="closure20200101">Yes</td>
+<td class="yes" data-browser="closure20200112">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -16425,13 +16425,13 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/3</td>
@@ -16533,13 +16533,13 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === undefined;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -16641,13 +16641,13 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === undef
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -16749,13 +16749,13 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === undefined;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -16860,13 +16860,13 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -135,13 +135,13 @@
 <th class="platform babel7corejs2 compiler" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform closure compiler obsolete" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure 2018.02</abbr></a></th>
-<th class="platform closure20190121 compiler obsolete" data-browser="closure20190121"><a href="#closure20190121" class="browser-name"><abbr title="Closure Compiler v20190121">Closure 2019.01</abbr></a></th>
 <th class="platform closure20190215 compiler obsolete" data-browser="closure20190215"><a href="#closure20190215" class="browser-name"><abbr title="Closure Compiler v20190215">Closure 2019.02</abbr></a></th>
 <th class="platform closure20190301 compiler obsolete" data-browser="closure20190301"><a href="#closure20190301" class="browser-name"><abbr title="Closure Compiler v20190301">Closure 2019.03</abbr></a></th>
 <th class="platform closure20190325 compiler obsolete" data-browser="closure20190325"><a href="#closure20190325" class="browser-name"><abbr title="Closure Compiler &gt;=v20190325 &lt;v20190709">Closure 2019.03</abbr></a></th>
 <th class="platform closure20190709 compiler obsolete" data-browser="closure20190709"><a href="#closure20190709" class="browser-name"><abbr title="Closure Compiler &gt;=v20190709 &lt;v20191027">Closure 2019.07</abbr></a></th>
 <th class="platform closure20191027 compiler obsolete" data-browser="closure20191027"><a href="#closure20191027" class="browser-name"><abbr title="Closure Compiler &gt;=v20191027 &lt;v20200101">Closure 2019.10</abbr></a></th>
-<th class="platform closure20200101 compiler" data-browser="closure20200101"><a href="#closure20200101" class="browser-name"><abbr title="Closure Compiler v20200101">Closure 2020.01</abbr></a></th>
+<th class="platform closure20200101 compiler obsolete" data-browser="closure20200101"><a href="#closure20200101" class="browser-name"><abbr title="Closure Compiler v20200101">Closure 2020.01</abbr></a></th>
+<th class="platform closure20200112 compiler" data-browser="closure20200112"><a href="#closure20200112" class="browser-name"><abbr title="Closure Compiler v20200112">Closure 2020.01</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_9corejs2 compiler obsolete" data-browser="typescript2_9corejs2"><a href="#typescript2_9corejs2" class="browser-name"><abbr title="TypeScript 2.9 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript3_2corejs2 compiler obsolete" data-browser="typescript3_2corejs2"><a href="#typescript3_2corejs2" class="browser-name"><abbr title="TypeScript 3.2 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -242,13 +242,13 @@
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -348,13 +348,13 @@ return weakref.deref() === O;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -453,13 +453,13 @@ return Object.getPrototypeOf(fg) === FinalizationGroup.prototype;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -554,13 +554,13 @@ return Object.getPrototypeOf(fg) === FinalizationGroup.prototype;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
@@ -661,13 +661,13 @@ return new C().x === &apos;x&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -774,13 +774,13 @@ return new C(42).x() === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -884,13 +884,13 @@ return new C().x() === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -991,13 +991,13 @@ return new C().x === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -1092,13 +1092,13 @@ return new C().x === 42;
 <td class="tally" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -1199,13 +1199,13 @@ return C.x === &apos;x&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -1309,13 +1309,13 @@ return new C().x() === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -1416,13 +1416,13 @@ return C.x === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -1521,13 +1521,13 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -1625,13 +1625,13 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -1735,13 +1735,13 @@ Promise.any([
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -1836,13 +1836,13 @@ Promise.any([
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -1946,13 +1946,13 @@ return RegExp.lastMatch === 'x';
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -2058,13 +2058,13 @@ return true;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -2170,13 +2170,13 @@ return result === &apos;tromple&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -2271,13 +2271,13 @@ return result === &apos;tromple&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/1</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/1</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/1</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">1/1</td>
@@ -2383,13 +2383,13 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no" data-browser="babel7corejs2">No<a href="#babel-decorators-legacy-note"><sup>[13]</sup></a></td>
 <td class="no" data-browser="babel7corejs3">No<a href="#babel-decorators-legacy-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -2490,13 +2490,13 @@ return typeof Realm === &quot;function&quot;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -2591,13 +2591,13 @@ return typeof Realm === &quot;function&quot;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/4</td>
@@ -2701,13 +2701,13 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -2815,13 +2815,13 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -2924,13 +2924,13 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -3033,13 +3033,13 @@ try {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -3134,13 +3134,13 @@ try {
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/7</td>
@@ -3241,13 +3241,13 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -3349,13 +3349,13 @@ return set.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -3456,13 +3456,13 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -3563,13 +3563,13 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -3667,13 +3667,13 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -3771,13 +3771,13 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -3875,13 +3875,13 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -3976,13 +3976,13 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -4083,13 +4083,13 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -4190,13 +4190,13 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -4291,13 +4291,13 @@ return buffer1.byteLength === 0
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -4398,13 +4398,13 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -4506,13 +4506,13 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -4611,13 +4611,13 @@ return !Array.isTemplateObject([])
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -4712,13 +4712,13 @@ return !Array.isTemplateObject([])
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/35</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">35/35</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/35</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/35</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/35</td>
@@ -4816,13 +4816,13 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -4922,13 +4922,13 @@ return instance[Symbol.iterator]() === instance;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -5029,13 +5029,13 @@ return &apos;next&apos; in iterator
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -5141,13 +5141,13 @@ return &apos;next&apos; in iterator
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -5245,13 +5245,13 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -5349,13 +5349,13 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -5453,13 +5453,13 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -5557,13 +5557,13 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -5661,13 +5661,13 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -5765,13 +5765,13 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -5871,13 +5871,13 @@ return result === &apos;123&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -5975,13 +5975,13 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -6079,13 +6079,13 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -6183,13 +6183,13 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -6287,13 +6287,13 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -6392,13 +6392,13 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -6496,13 +6496,13 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -6600,13 +6600,13 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -6706,13 +6706,13 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -6822,13 +6822,13 @@ toArray(iterator).then(it =&gt; {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -6938,13 +6938,13 @@ toArray(iterator).then(it =&gt; {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -7054,13 +7054,13 @@ toArray(iterator).then(it =&gt; {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -7166,13 +7166,13 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -7278,13 +7278,13 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -7384,13 +7384,13 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -7496,13 +7496,13 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -7602,13 +7602,13 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -7714,13 +7714,13 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -7821,13 +7821,13 @@ let result = &apos;&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -7933,13 +7933,13 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -8039,13 +8039,13 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -8145,13 +8145,13 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -8257,13 +8257,13 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -8363,13 +8363,13 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -8467,13 +8467,13 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -8576,13 +8576,13 @@ return do {
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -8677,13 +8677,13 @@ return do {
 <td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">7/7</td>
@@ -8781,13 +8781,13 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -8885,13 +8885,13 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -8989,13 +8989,13 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -9103,13 +9103,13 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -9208,13 +9208,13 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -9312,13 +9312,13 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -9416,13 +9416,13 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -9521,13 +9521,13 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -9629,13 +9629,13 @@ return Math.signbit(NaN) === false
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -9730,13 +9730,13 @@ return Math.signbit(NaN) === false
 <td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">7/7</td>
@@ -9836,13 +9836,13 @@ return Math.clamp(2, 4, 6) === 4
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -9940,13 +9940,13 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -10045,13 +10045,13 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -10149,13 +10149,13 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -10253,13 +10253,13 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -10358,13 +10358,13 @@ return Math.radians(90) === Math.PI / 2
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -10462,13 +10462,13 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -10563,13 +10563,13 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">7/7</td>
@@ -10667,13 +10667,13 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -10771,13 +10771,13 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -10877,13 +10877,13 @@ return score === 1;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -10988,13 +10988,13 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -11099,13 +11099,13 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -11210,13 +11210,13 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -11321,13 +11321,13 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -11422,13 +11422,13 @@ Promise.try(function() {
 <td class="tally" data-browser="babel7corejs2" data-tally="1">8/8</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">8/8</td>
@@ -11529,13 +11529,13 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -11638,13 +11638,13 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -11745,13 +11745,13 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -11852,13 +11852,13 @@ return C.has(3) + C.has(4);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -11959,13 +11959,13 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -12068,13 +12068,13 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -12175,13 +12175,13 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -12282,13 +12282,13 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -12398,13 +12398,13 @@ return result === &apos;Hello, hello!&apos;;
 <td class="yes" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -12506,13 +12506,13 @@ return 123i === &apos;string123number123&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -12607,13 +12607,13 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/12</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/12</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/12</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/12</td>
@@ -12715,13 +12715,13 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -12823,13 +12823,13 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -12931,13 +12931,13 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -13039,13 +13039,13 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -13147,13 +13147,13 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -13255,13 +13255,13 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -13363,13 +13363,13 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -13474,13 +13474,13 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -13583,13 +13583,13 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -13691,13 +13691,13 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -13799,13 +13799,13 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -13907,13 +13907,13 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -14008,13 +14008,13 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/8</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/8</td>
@@ -14112,13 +14112,13 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -14216,13 +14216,13 @@ return Object.isFrozen([# 42 #]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -14320,13 +14320,13 @@ return Object.isSealed({| foo: 42 |});
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -14424,13 +14424,13 @@ return Object.isSealed([| 42 |]);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -14536,13 +14536,13 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -14649,13 +14649,13 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -14761,13 +14761,13 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -14874,13 +14874,13 @@ try {
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -14983,13 +14983,13 @@ return results.length === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -15084,13 +15084,13 @@ return results.length === 3
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -15188,13 +15188,13 @@ return [1, 2, 3].lastItem === 3;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -15292,13 +15292,13 @@ return [1, 2, 3].lastIndex === 2;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -15393,13 +15393,13 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/26</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">26/26</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/26</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/26</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/26</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/26</td>
@@ -15502,13 +15502,13 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -15609,13 +15609,13 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -15717,13 +15717,13 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -15821,13 +15821,13 @@ return new Map([[1, 4], [2, 5], [3, 6]]).every(it =&gt; typeof it == &apos;numbe
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -15928,13 +15928,13 @@ return map.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -16032,13 +16032,13 @@ return new Map([[1, 2], [2, 3], [3, 4]]).find(it =&gt; it % 2) === 3;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -16136,13 +16136,13 @@ return new Map([[1, 2], [2, 3], [3, 4]]).findKey(it =&gt; it % 2) === 2;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -16241,13 +16241,13 @@ return new Map([[1, 2], [2, NaN]]).includes(2)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -16346,13 +16346,13 @@ return new Map([[1, 2], [2, NaN]]).keyOf(2) === 1
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -16454,13 +16454,13 @@ return map.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -16562,13 +16562,13 @@ return map.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -16670,13 +16670,13 @@ return map.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -16774,13 +16774,13 @@ return new Map([[&apos;a&apos;, 1], [&apos;b&apos;, 2], [&apos;c&apos;, 3], ]).r
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -16878,13 +16878,13 @@ return new Map([[1, 4], [2, 5], [3, 6]]).some(it =&gt; it % 2);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -16986,13 +16986,13 @@ return set.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -17094,13 +17094,13 @@ return set.deleteAll(2, 3) === true
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -17198,13 +17198,13 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -17305,13 +17305,13 @@ return set.size === 2
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -17409,13 +17409,13 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -17513,13 +17513,13 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -17621,13 +17621,13 @@ return set.size === 3
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -17725,13 +17725,13 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -17829,13 +17829,13 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -17942,13 +17942,13 @@ return !map.has(a)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -18055,13 +18055,13 @@ return set.has(a)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -18168,13 +18168,13 @@ return !set.has(a)
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -18280,13 +18280,13 @@ return second === gen2.next().value;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -18381,13 +18381,13 @@ return second === gen2.next().value;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -18485,13 +18485,13 @@ return Number.fromString(&apos;42&apos;) === 42;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -18589,13 +18589,13 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -18690,13 +18690,13 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="tally" data-browser="babel7corejs2" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20200101" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/3</td>
@@ -18798,13 +18798,13 @@ return [...iterator].join() === &apos;a,c&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -18906,13 +18906,13 @@ return [...iterator].join() === &apos;1,3&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -19014,13 +19014,13 @@ return [...iterator].join() === &apos;a,1,c,3&apos;;
 <td class="no" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
-<td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
 <td class="no obsolete" data-browser="closure20190301">No</td>
 <td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
-<td class="no" data-browser="closure20200101">No</td>
+<td class="no obsolete" data-browser="closure20200101">No</td>
+<td class="no" data-browser="closure20200112">No</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">No<a href="#typescript-es6-note"><sup>[10]</sup></a></td>
@@ -19117,13 +19117,13 @@ return [...iterator].join() === &apos;a,1,c,3&apos;;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -19223,13 +19223,13 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -19328,13 +19328,13 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -19432,13 +19432,13 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -19533,13 +19533,13 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -19638,13 +19638,13 @@ return f();
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -19742,13 +19742,13 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -19851,13 +19851,13 @@ return Array.isArray(arr)
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -19966,13 +19966,13 @@ return target === C.prototype
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -20077,13 +20077,13 @@ return (@inverse function(it){
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -20178,13 +20178,13 @@ return (@inverse function(it){
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -20284,13 +20284,13 @@ return Reflect.isCallable(function(){})
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -20390,13 +20390,13 @@ return Reflect.isConstructor(function(){})
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -20491,13 +20491,13 @@ return Reflect.isConstructor(function(){})
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -20595,13 +20595,13 @@ return typeof Zone == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -20699,13 +20699,13 @@ return &apos;current&apos; in Zone;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -20803,13 +20803,13 @@ return &apos;name&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -20907,13 +20907,13 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21011,13 +21011,13 @@ return typeof Zone.prototype.fork == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21115,13 +21115,13 @@ return typeof Zone.prototype.run == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21219,13 +21219,13 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21320,13 +21320,13 @@ return typeof Zone.prototype.wrap == &apos;function&apos;;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -21430,13 +21430,13 @@ return (function f(n){
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21547,13 +21547,13 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21648,13 +21648,13 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -21754,13 +21754,13 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21861,13 +21861,13 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21964,13 +21964,13 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
@@ -22068,13 +22068,13 @@ return typeof Reflect.defineMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -22172,13 +22172,13 @@ return typeof Reflect.hasMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -22276,13 +22276,13 @@ return typeof Reflect.hasOwnMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -22380,13 +22380,13 @@ return typeof Reflect.getMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -22484,13 +22484,13 @@ return typeof Reflect.getOwnMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -22588,13 +22588,13 @@ return typeof Reflect.getMetadataKeys == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -22692,13 +22692,13 @@ return typeof Reflect.getOwnMetadataKeys == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -22796,13 +22796,13 @@ return typeof Reflect.deleteMetadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
@@ -22900,13 +22900,13 @@ return typeof Reflect.metadata == &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[9]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190301" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[11]</sup></a></td>


### PR DESCRIPTION
- Support ES6 Classes: computed static accessor properties (https://github.com/google/closure-compiler/commit/bd0832c68248137447fee25f6b8eb37fd7f0b753)