### PR TITLE
Move IE engine right before Edge

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -2174,7 +2174,9 @@
     "family": "Chakra",
     "short": "Edge 12",
     "release": "2015-07-15",
-    "obsolete": "very"
+    "obsolete": "very",
+    "#": "IE11 and Edge12 are not equal, but we can use IE11 as a baseline",
+    "equals": "ie11"
   },
   "edge13": {
     "full": "Microsoft Edge 13",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -7162,9 +7162,9 @@ return (function(){
 <td class="tally" data-browser="chrome79" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="chrome80" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="chrome81" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
-<td class="tally obsolete" data-browser="edge17" data-tally="0.375" style="background-color:hsl(45,69%,50%)">6/16</td>
-<td class="tally" data-browser="edge18" data-tally="0.375" style="background-color:hsl(45,69%,50%)">6/16</td>
+<td class="tally obsolete" data-browser="edge15" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally obsolete" data-browser="edge17" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
+<td class="tally" data-browser="edge18" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally" data-browser="edge79" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="safari11" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">16/16</td>
@@ -7273,9 +7273,9 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -7608,9 +7608,9 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -7945,9 +7945,9 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -8058,9 +8058,9 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -8283,9 +8283,9 @@ return true;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -8506,9 +8506,9 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -8619,9 +8619,9 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -8844,9 +8844,9 @@ return true;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -260,9 +260,9 @@
 <td class="tally" data-browser="chrome79" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="chrome80" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="chrome81" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/5</td>
-<td class="tally obsolete" data-browser="edge17" data-tally="0">0/5</td>
-<td class="tally" data-browser="edge18" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="edge15" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="edge17" data-tally="1">5/5</td>
+<td class="tally" data-browser="edge18" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge79" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="safari11" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">5/5</td>
@@ -363,9 +363,9 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -468,9 +468,9 @@ return value === 1;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -571,9 +571,9 @@ return { a: true, }.a === true;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -674,9 +674,9 @@ return [1,].length === 1;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -777,9 +777,9 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -879,9 +879,9 @@ return ({ if: 1 }).if === 1;
 <td class="tally" data-browser="chrome79" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="chrome80" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="chrome81" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/13</td>
-<td class="tally obsolete" data-browser="edge17" data-tally="0">0/13</td>
-<td class="tally" data-browser="edge18" data-tally="0">0/13</td>
+<td class="tally obsolete" data-browser="edge15" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="edge17" data-tally="1">13/13</td>
+<td class="tally" data-browser="edge18" data-tally="1">13/13</td>
 <td class="tally" data-browser="edge79" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="safari11" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">13/13</td>
@@ -984,9 +984,9 @@ return typeof Object.create == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -1089,9 +1089,9 @@ return typeof Object.defineProperty == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -1194,9 +1194,9 @@ return typeof Object.defineProperties == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -1299,9 +1299,9 @@ return typeof Object.getPrototypeOf == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -1404,9 +1404,9 @@ return typeof Object.keys == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -1509,9 +1509,9 @@ return typeof Object.seal == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -1614,9 +1614,9 @@ return typeof Object.freeze == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -1719,9 +1719,9 @@ return typeof Object.preventExtensions == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -1824,9 +1824,9 @@ return typeof Object.isSealed == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -1929,9 +1929,9 @@ return typeof Object.isFrozen == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -2034,9 +2034,9 @@ return typeof Object.isExtensible == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -2139,9 +2139,9 @@ return typeof Object.getOwnPropertyDescriptor == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -2244,9 +2244,9 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -2344,9 +2344,9 @@ return typeof Object.getOwnPropertyNames == 'function';
 <td class="tally" data-browser="chrome79" data-tally="1">12/12</td>
 <td class="tally unstable" data-browser="chrome80" data-tally="1">12/12</td>
 <td class="tally unstable" data-browser="chrome81" data-tally="1">12/12</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="edge17" data-tally="0">0/12</td>
-<td class="tally" data-browser="edge18" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="edge15" data-tally="1">12/12</td>
+<td class="tally obsolete" data-browser="edge17" data-tally="1">12/12</td>
+<td class="tally" data-browser="edge18" data-tally="1">12/12</td>
 <td class="tally" data-browser="edge79" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="safari11" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
@@ -2449,9 +2449,9 @@ return typeof Array.isArray == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -2554,9 +2554,9 @@ return typeof Array.prototype.indexOf == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -2659,9 +2659,9 @@ return typeof Array.prototype.lastIndexOf == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -2764,9 +2764,9 @@ return typeof Array.prototype.every == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -2869,9 +2869,9 @@ return typeof Array.prototype.some == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -2974,9 +2974,9 @@ return typeof Array.prototype.forEach == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -3079,9 +3079,9 @@ return typeof Array.prototype.map == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -3184,9 +3184,9 @@ return typeof Array.prototype.filter == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -3289,9 +3289,9 @@ return typeof Array.prototype.reduce == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -3394,9 +3394,9 @@ return typeof Array.prototype.reduceRight == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -3539,9 +3539,9 @@ return true;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="no obsolete" data-browser="safari11">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
@@ -3654,9 +3654,9 @@ try {
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -3754,9 +3754,9 @@ try {
 <td class="tally" data-browser="chrome79" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome80" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome81" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge17" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge18" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge17" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge18" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge79" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari11" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">2/2</td>
@@ -3859,9 +3859,9 @@ return "foobar"[3] === "b";
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -3964,9 +3964,9 @@ return typeof String.prototype.trim == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -4064,9 +4064,9 @@ return typeof String.prototype.trim == 'function';
 <td class="tally" data-browser="chrome79" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome80" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome81" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="edge17" data-tally="0">0/3</td>
-<td class="tally" data-browser="edge18" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="edge15" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge17" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge18" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge79" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari11" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">3/3</td>
@@ -4169,9 +4169,9 @@ return typeof Date.prototype.toISOString == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -4274,9 +4274,9 @@ return typeof Date.now == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -4387,9 +4387,9 @@ try {
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -4492,9 +4492,9 @@ return typeof Function.prototype.bind == 'function';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -4597,9 +4597,9 @@ return typeof JSON == 'object';
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -4699,9 +4699,9 @@ return typeof JSON == 'object';
 <td class="tally" data-browser="chrome79" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome80" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome81" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="edge17" data-tally="0">0/3</td>
-<td class="tally" data-browser="edge18" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="edge15" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge17" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge18" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge79" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari11" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">3/3</td>
@@ -4805,9 +4805,9 @@ return result;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -4911,9 +4911,9 @@ return result;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -5017,9 +5017,9 @@ return result;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -5117,9 +5117,9 @@ return result;
 <td class="tally" data-browser="chrome79" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="chrome80" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="chrome81" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
-<td class="tally obsolete" data-browser="edge17" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
-<td class="tally" data-browser="edge18" data-tally="0.125" style="background-color:hsl(15,80%,50%)">1/8</td>
+<td class="tally obsolete" data-browser="edge15" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="edge17" data-tally="1">8/8</td>
+<td class="tally" data-browser="edge18" data-tally="1">8/8</td>
 <td class="tally" data-browser="edge79" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="safari11" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
@@ -5230,9 +5230,9 @@ try {
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -5335,9 +5335,9 @@ return parseInt('010') === 10;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -5438,9 +5438,9 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -5541,9 +5541,9 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -5645,9 +5645,9 @@ return _\u200c\u200d;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -5750,9 +5750,9 @@ return true;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -5970,9 +5970,9 @@ catch(e) {
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -6070,9 +6070,9 @@ catch(e) {
 <td class="tally" data-browser="chrome79" data-tally="1">19/19</td>
 <td class="tally unstable" data-browser="chrome80" data-tally="1">19/19</td>
 <td class="tally unstable" data-browser="chrome81" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/19</td>
-<td class="tally obsolete" data-browser="edge17" data-tally="0">0/19</td>
-<td class="tally" data-browser="edge18" data-tally="0">0/19</td>
+<td class="tally obsolete" data-browser="edge15" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="edge17" data-tally="1">19/19</td>
+<td class="tally" data-browser="edge18" data-tally="1">19/19</td>
 <td class="tally" data-browser="edge79" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="safari11" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">19/19</td>
@@ -6178,9 +6178,9 @@ return true;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -6282,9 +6282,9 @@ return this === undefined &amp;&amp; (function(){ return this === undefined; }).
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
+<td class="yes obsolete" data-browser="edge17">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
+<td class="yes" data-browser="edge18">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -6388,9 +6388,9 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -6508,9 +6508,9 @@ return test(String, &apos;&apos;)
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -6614,9 +6614,9 @@ return true;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -6718,9 +6718,9 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -6826,9 +6826,9 @@ return true;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -6934,9 +6934,9 @@ return true;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -7044,9 +7044,9 @@ return true;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -7151,9 +7151,9 @@ return true;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -7256,9 +7256,9 @@ return true;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -7362,9 +7362,9 @@ return true;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -7472,9 +7472,9 @@ return (function(x){
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -7576,9 +7576,9 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -7680,9 +7680,9 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -7784,9 +7784,9 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -7888,9 +7888,9 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -7992,9 +7992,9 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -8096,9 +8096,9 @@ return typeof foo === &apos;function&apos;;
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="no obsolete" data-browser="safari11">No</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -6258,9 +6258,9 @@ return 'caller' in function(){};
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -6454,9 +6454,9 @@ return f(1, 'boo');
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -9375,9 +9375,9 @@ try {
 <td class="yes" data-browser="chrome79">Yes</td>
 <td class="yes unstable" data-browser="chrome80">Yes</td>
 <td class="yes unstable" data-browser="chrome81">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes obsolete" data-browser="safari11">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -9747,9 +9747,9 @@ return 'description' in new Error();
 <td class="no" data-browser="chrome79">No</td>
 <td class="no unstable" data-browser="chrome80">No</td>
 <td class="no unstable" data-browser="chrome81">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="no" data-browser="edge79">No</td>
 <td class="no obsolete" data-browser="safari11">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>


### PR DESCRIPTION
Compatibility data are only inherited if the previous version of an engine is right before the current version.
Edge 12 should default to what IE 11 supports, so they must be next to each other in the environments list.

Fixes #1575

This is the relevant code in the build script: https://github.com/kangax/compat-table/blob/d6680df01bc90bdca73e7c56a7588acd7fe103bf/build.js#L434-L444