### PR TITLE
toSource and uneval removed with Firefox 74

### DIFF
--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -1263,6 +1263,7 @@ exports.tests = [
       res: {
         ie11: false,
         firefox2: true,
+        firefox74: false,
         opera10_50: false,
         chrome77: false,
         rhino1_7: true,
@@ -1288,6 +1289,7 @@ exports.tests = [
       res: {
         ie11: false,
         firefox2: true,
+        firefox74: false,
         opera10_50: false,
         chrome77: false,
         besen: true,
@@ -1304,6 +1306,7 @@ exports.tests = [
       res: {
         ie11: false,
         firefox2: true,
+        firefox74: false,
         opera10_50: false,
         chrome77: false,
         rhino1_7: null,
@@ -1406,6 +1409,7 @@ exports.tests = [
       res: {
         ie11: false,
         firefox2: true,
+        firefox74: false,
         opera10_50: false,
         chrome77: false,
         besen: null,

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -5599,7 +5599,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally" data-browser="firefox71" data-tally="1">4/4</td>
 <td class="tally" data-browser="firefox72" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="firefox73" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="firefox74" data-tally="1">4/4</td>
+<td class="tally unstable" data-browser="firefox74" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome71" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="chrome72" data-tally="0">0/4</td>
@@ -5690,7 +5690,7 @@ return typeof uneval == &apos;function&apos;;
 <td class="yes" data-browser="firefox71">Yes</td>
 <td class="yes" data-browser="firefox72">Yes</td>
 <td class="yes unstable" data-browser="firefox73">Yes</td>
-<td class="yes unstable" data-browser="firefox74">Yes</td>
+<td class="no unstable" data-browser="firefox74">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome71">No</td>
 <td class="no obsolete" data-browser="chrome72">No</td>
@@ -5789,7 +5789,7 @@ return &apos;toSource&apos; in Object.prototype
 <td class="yes" data-browser="firefox71">Yes</td>
 <td class="yes" data-browser="firefox72">Yes</td>
 <td class="yes unstable" data-browser="firefox73">Yes</td>
-<td class="yes unstable" data-browser="firefox74">Yes</td>
+<td class="no unstable" data-browser="firefox74">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome71">No</td>
 <td class="no obsolete" data-browser="chrome72">No</td>
@@ -5880,7 +5880,7 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="yes" data-browser="firefox71">Yes</td>
 <td class="yes" data-browser="firefox72">Yes</td>
 <td class="yes unstable" data-browser="firefox73">Yes</td>
-<td class="yes unstable" data-browser="firefox74">Yes</td>
+<td class="no unstable" data-browser="firefox74">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome71">No</td>
 <td class="no obsolete" data-browser="chrome72">No</td>
@@ -6058,7 +6058,7 @@ return true;
 <td class="yes" data-browser="firefox71">Yes</td>
 <td class="yes" data-browser="firefox72">Yes</td>
 <td class="yes unstable" data-browser="firefox73">Yes</td>
-<td class="yes unstable" data-browser="firefox74">Yes</td>
+<td class="no unstable" data-browser="firefox74">No</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome71">No</td>
 <td class="no obsolete" data-browser="chrome72">No</td>


### PR DESCRIPTION
Since https://bugzilla.mozilla.org/show_bug.cgi?id=1565170 toSource and uneval are unavailable to web content.