### PR TITLE
Fix "for-in loop binding shadowing parameter" of Closure Compiler

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -1352,6 +1352,7 @@ exports.tests = [
         }
       */},
       res: {
+        closure: true,
         ie11: true,
         edge14: true,
         firefox2: false,
@@ -1627,6 +1628,7 @@ exports.tests = [
         }
       */},
       res: {
+        closure: true,
         ie11: true,
         edge14: true,
         firefox2: false,


### PR DESCRIPTION
Closure Compiler has been passed the added test from the oldest version.