### PR TITLE
Do not rely on envs ordering when determining browsers inheritance

### DIFF
--- a/build.js
+++ b/build.js
@@ -424,7 +424,7 @@ function dataToHtml(skeleton, rawBrowsers, tests, compiler) {
   var browersTree = buildEnvironmentsTree(environments);
 
   function interpolateResults(res) {
-    var result, bid, prevBid;
+    var bid, prevBid;
     for (bid in rawBrowsers) {
       if (res[bid] !== undefined) continue;
 

--- a/environments.json
+++ b/environments.json
@@ -1468,6 +1468,8 @@
     "family": "Carakan",
     "short": "OP 10.5",
     "obsolete": "very",
+    "#": "Opera 10.20 uses the 'Futhark' engine, while Opera 10.50 uses 'Carakan'. TODO: Check it can inherit.",
+    "equals": false,
     "test_suites": [
       "es5",
       "es6",
@@ -2461,6 +2463,8 @@
     "family": "JavaScriptCore",
     "short": "WK",
     "release": "2017-10-04",
+    "#": "Webkit and Safari TP are not equal, but we can use Safari TP as a baseline",
+    "equals": "safaritp",
     "unstable": true
   },
   "opera15": {

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -10450,7 +10450,7 @@ return i === 0;
 <td class="no obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no" data-browser="ie11">No</td>
+<td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox66">Yes</td>
 <td class="yes obsolete" data-browser="firefox67">Yes</td>
@@ -10464,7 +10464,7 @@ return i === 0;
 <td class="yes" data-browser="firefox75">Yes</td>
 <td class="yes unstable" data-browser="firefox76">Yes</td>
 <td class="yes unstable" data-browser="firefox77">Yes</td>
-<td class="no obsolete" data-browser="opera12_10">No</td>
+<td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome74">Yes</td>
 <td class="yes obsolete" data-browser="chrome75">Yes</td>
 <td class="yes obsolete" data-browser="chrome76">Yes</td>
@@ -14656,7 +14656,7 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="tally" data-browser="firefox75" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="firefox76" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="firefox77" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="opera12_10" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="chrome74" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome75" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="chrome76" data-tally="1">7/7</td>
@@ -15008,7 +15008,7 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes" data-browser="firefox75">Yes</td>
 <td class="yes unstable" data-browser="firefox76">Yes</td>
 <td class="yes unstable" data-browser="firefox77">Yes</td>
-<td class="no obsolete" data-browser="opera12_10">No</td>
+<td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome74">Yes</td>
 <td class="yes obsolete" data-browser="chrome75">Yes</td>
 <td class="yes obsolete" data-browser="chrome76">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -2025,7 +2025,7 @@ Promise.any([
 <td class="tally" data-browser="firefox75" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox76" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="firefox77" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="opera12_10" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome74" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome75" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="chrome76" data-tally="1">2/2</td>
@@ -2036,9 +2036,9 @@ Promise.any([
 <td class="tally" data-browser="chrome81" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome83" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge17" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge18" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="edge15" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge17" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge18" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge79" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge80" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">2/2</td>
@@ -2145,7 +2145,7 @@ return RegExp.lastMatch === 'x';
 <td class="yes" data-browser="firefox75">Yes</td>
 <td class="yes unstable" data-browser="firefox76">Yes</td>
 <td class="yes unstable" data-browser="firefox77">Yes</td>
-<td class="no obsolete" data-browser="opera12_10">No</td>
+<td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome74">Yes</td>
 <td class="yes obsolete" data-browser="chrome75">Yes</td>
 <td class="yes obsolete" data-browser="chrome76">Yes</td>
@@ -2156,9 +2156,9 @@ return RegExp.lastMatch === 'x';
 <td class="yes" data-browser="chrome81">Yes</td>
 <td class="yes unstable" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes" data-browser="edge80">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
@@ -2267,7 +2267,7 @@ return true;
 <td class="yes" data-browser="firefox75">Yes</td>
 <td class="yes unstable" data-browser="firefox76">Yes</td>
 <td class="yes unstable" data-browser="firefox77">Yes</td>
-<td class="no obsolete" data-browser="opera12_10">No</td>
+<td class="yes obsolete" data-browser="opera12_10">Yes</td>
 <td class="yes obsolete" data-browser="chrome74">Yes</td>
 <td class="yes obsolete" data-browser="chrome75">Yes</td>
 <td class="yes obsolete" data-browser="chrome76">Yes</td>
@@ -2278,9 +2278,9 @@ return true;
 <td class="yes" data-browser="chrome81">Yes</td>
 <td class="yes unstable" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
-<td class="no obsolete" data-browser="edge17">No</td>
-<td class="no" data-browser="edge18">No</td>
+<td class="yes obsolete" data-browser="edge15">Yes</td>
+<td class="yes obsolete" data-browser="edge17">Yes</td>
+<td class="yes" data-browser="edge18">Yes</td>
 <td class="yes" data-browser="edge79">Yes</td>
 <td class="yes" data-browser="edge80">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -9803,8 +9803,8 @@ var brokenOnIE10 = !isNaN(Date.parse('2012-12-31T24:01:00.000Z'));
 var brokenOnChrome = !isNaN(Date.parse('2011-02-29T12:00:00.000Z'));
 return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
   }())</script></td>
-<td class="no obsolete" data-browser="konq4_13">No</td>
-<td class="no" data-browser="konq4_14">No</td>
+<td class="yes obsolete" data-browser="konq4_13">Yes</td>
+<td class="yes" data-browser="konq4_14">Yes</td>
 <td class="no obsolete" data-browser="ie8">No</td>
 <td class="no obsolete" data-browser="ie9">No</td>
 <td class="no obsolete" data-browser="ie10">No</td>

--- a/scripts/build-environments-tree.js
+++ b/scripts/build-environments-tree.js
@@ -1,0 +1,86 @@
+var RE = {
+  engine: /^(\w+?)(tp|[\d_]+)?(?:corejs[23])?$/,
+  version: /^(\d{4})(\d{2})(\d{2})$|^(\d+)(?:_(\d+))?(?:_(\d+))?$/
+};
+
+module.exports = buildEnvsTree;
+
+// This function returns an object mapping "browser id" -> "parent browser id"
+function buildEnvsTree(data) {
+  var result = {};
+  // Pre-initialize the "result" object to make it have the same order as "data"
+  Object.keys(data).forEach(function (id) { result[id] = null; });
+
+  var envs = Object.create(null);
+
+  Object.keys(data).forEach(function (id) {
+    var parsed = parseEnvId(id);
+    if (!envs[parsed.name]) envs[parsed.name] = [];
+    envs[parsed.name].push(parsed);
+  });
+
+  Object.keys(envs).forEach(function (name) {
+    envs[name].sort(compareVersions);
+
+    var id = envs[name][0].id;
+    result[id] = data[id].equals || null;
+
+    for (var i = 1; i < envs[name].length; i++) {
+      id = envs[name][i].id;
+      if (data[id].equals === false) result[id] = null;
+      else result[id] = data[id].equals || envs[name][i - 1].id;
+    }
+  });
+
+  return result;
+}
+
+function parseEnvId(id) {
+  var result = { id: id };
+
+  var match = id.match(RE.engine);
+  if (!match) throw new Error("Unable to parse environment id: " + id);
+
+  result.name = match[1];
+  result.version = parseVersion(match[2]);
+
+  return result;
+}
+
+function parseVersion(version) {
+  if (!version) return null;
+
+  if (version === "tp") return ["tp"];
+
+  var match = version.match(RE.version);
+  if (!match) throw new Error("Unable to parse environment version: " + version);
+
+  if (match[1]) return match.slice(1, 4).map(Number);
+
+  var result = [];
+  for (var i = 4; i <= 6 && match[i]; i++) result.push(Number(match[i]));
+
+  return result;
+}
+
+function compareVersions(a, b) {
+  var vA = a.version;
+  var vB = b.version;
+
+  if (!vA && !vB) return 0;
+  if (!vB) return 1;
+  if (!vA) return -1;
+
+  for (var i = 0; i < vA.length && i < vB.length; i++) {
+    if (vA[i] === "tp" && vB[i] === "tp") continue;
+    if (vA[i] === "tp") return 1;
+    if (vB[i] === "tp") return -1;
+    if (vA[i] > vB[i]) return 1;
+    if (vA[i] < vB[i]) return -1;
+  }
+
+  if (vA.length > vB.length) return 1;
+  if (vA.length < vB.length) return -1;
+
+  return 0;
+}

--- a/scripts/build-environments-tree.js
+++ b/scripts/build-environments-tree.js
@@ -8,9 +8,6 @@ module.exports = buildEnvsTree;
 // This function returns an object mapping "browser id" -> "parent browser id"
 function buildEnvsTree(data) {
   var result = {};
-  // Pre-initialize the "result" object to make it have the same order as "data"
-  Object.keys(data).forEach(function (id) { result[id] = null; });
-
   var envs = Object.create(null);
 
   Object.keys(data).forEach(function (id) {


### PR DESCRIPTION
Ref: https://github.com/kangax/compat-table/pull/1576#issuecomment-577084923

This will prevent regressions in case the order of the table columns changes.

There are some changes in the generated HTML: I don't understand why, but they all seem correct to me according to the data we have.