### PR TITLE
Fix opera 30 & 33 info

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -2572,8 +2572,8 @@
     "short": "OP 29",
     "obsolete": "very"
   },
-  "opera29": {
-    "full": "Opera 29",
+  "opera30": {
+    "full": "Opera 30",
     "family": "V8",
     "equals": "chrome43",
     "short": "OP 30",
@@ -2596,7 +2596,7 @@
   "opera33": {
     "full": "Opera 33",
     "family": "V8",
-    "equals": "chrome36",
+    "equals": "chrome46",
     "short": "OP 33",
     "obsolete": "very"
   },


### PR DESCRIPTION
I found these errors while trying to unify Babel's tests results analysis logic with `compat-data`'s.

It didn't cause any change in the generated HTML.