### PR TITLE
chore: obsolete core-js 2 environments

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -24,7 +24,7 @@
     "short": "Babel 6 +<br><nobr>core-js 2</nobr>",
     "family": "Babel",
     "platformtype": "compiler",
-    "obsolete": false,
+    "obsolete": true,
     "test_suites": [
       "es6",
       "es2016plus",
@@ -36,7 +36,7 @@
     "short": "Babel 7 +<br><nobr>core-js 2</nobr>",
     "family": "Babel",
     "platformtype": "compiler",
-    "obsolete": false,
+    "obsolete": true,
     "test_suites": [
       "es6",
       "es2016plus",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -125,8 +125,8 @@
 
           <!-- TABLE HEADERS -->
         <th class="platform tr compiler obsolete" data-browser="tr"><a href="#tr" class="browser-name"><abbr title="Traceur">Traceur</abbr></a></th>
-<th class="platform babel6corejs2 compiler" data-browser="babel6corejs2"><a href="#babel6corejs2" class="browser-name"><abbr title="Babel 6.5 + core-js 2.5">Babel 6 +<br><nobr>core-js 2</nobr></abbr></a></th>
-<th class="platform babel7corejs2 compiler" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
+<th class="platform babel6corejs2 compiler obsolete" data-browser="babel6corejs2"><a href="#babel6corejs2" class="browser-name"><abbr title="Babel 6.5 + core-js 2.5">Babel 6 +<br><nobr>core-js 2</nobr></abbr></a></th>
+<th class="platform babel7corejs2 compiler obsolete" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform closure compiler obsolete" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure 2018.02</abbr></a></th>
 <th class="platform closure20190215 compiler obsolete" data-browser="closure20190215"><a href="#closure20190215" class="browser-name"><abbr title="Closure Compiler v20190215">Closure 2019.02</abbr></a></th>
@@ -244,8 +244,8 @@
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="1">3/3</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">3/3</td>
@@ -360,8 +360,8 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("1");try{return Function("asyncTestPassed","\nreturn 2 ** 3 === 8 && -(5 ** 2) === -25 && (-5) ** 2 === 25;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("1");return Function("asyncTestPassed","'use strict';"+"\nreturn 2 ** 3 === 8 && -(5 ** 2) === -25 && (-5) ** 2 === 25;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -476,8 +476,8 @@ var a = 2; a **= 3; return a === 8;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");try{return Function("asyncTestPassed","\nvar a = 2; a **= 3; return a === 8;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("2");return Function("asyncTestPassed","'use strict';"+"\nvar a = 2; a **= 3; return a === 8;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -597,8 +597,8 @@ return true;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("3");try{return Function("asyncTestPassed","\nif (2 ** 3 !== 8) { return false; }\ntry {\nFunction(\"-5 ** 2\")();\n} catch(e) {\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("3");return Function("asyncTestPassed","'use strict';"+"\nif (2 ** 3 !== 8) { return false; }\ntry {\nFunction(\"-5 ** 2\")();\n} catch(e) {\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -710,8 +710,8 @@ return true;
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Array.prototype.includes"><span><a class="anchor" href="#test-Array.prototype.includes">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-array.prototype.includes">Array.prototype.includes</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="1">3/3</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -830,8 +830,8 @@ return [1, 2, 3].includes(1)
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].includes(1)\n&& ![1, 2, 3].includes(4)\n&& ![1, 2, 3].includes(1, 1)\n&& [NaN].includes(NaN)\n&& Array(1).includes();\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("5");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].includes(1)\n&& ![1, 2, 3].includes(4)\n&& ![1, 2, 3].includes(1, 1)\n&& [NaN].includes(NaN)\n&& Array(1).includes();\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -968,8 +968,8 @@ return 24;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("6");try{return Function("asyncTestPassed","\nvar passed = 0;\nreturn [].includes.call({\nget \"0\"() {\npassed = NaN;\nreturn 'foo';\n},\nget \"11\"() {\npassed += 1;\nreturn 0;\n},\nget \"19\"() {\npassed += 1;\nreturn 'foo';\n},\nget \"21\"() {\npassed = NaN;\nreturn 'foo';\n},\nget length() {\npassed += 1;\nreturn 24;\n}\n}, 'foo', 6) === true && passed === 3;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("6");return Function("asyncTestPassed","'use strict';"+"\nvar passed = 0;\nreturn [].includes.call({\nget \"0\"() {\npassed = NaN;\nreturn 'foo';\n},\nget \"11\"() {\npassed += 1;\nreturn 0;\n},\nget \"19\"() {\npassed += 1;\nreturn 'foo';\n},\nget \"21\"() {\npassed = NaN;\nreturn 'foo';\n},\nget length() {\npassed += 1;\nreturn 24;\n}\n}, 'foo', 6) === true && passed === 3;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -1089,8 +1089,8 @@ return new TypedArray([1, 2, 3]).includes(1)
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\nreturn [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,\nInt32Array, Uint32Array, Float32Array, Float64Array].every(function(TypedArray){\nreturn new TypedArray([1, 2, 3]).includes(1)\n&& !new TypedArray([1, 2, 3]).includes(4)\n&& !new TypedArray([1, 2, 3]).includes(1, 1);\n});\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\nreturn [Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array,\nInt32Array, Uint32Array, Float32Array, Float64Array].every(function(TypedArray){\nreturn new TypedArray([1, 2, 3]).includes(1)\n&& !new TypedArray([1, 2, 3]).includes(4)\n&& !new TypedArray([1, 2, 3]).includes(1, 1);\n});\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -1214,8 +1214,8 @@ return true;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("8");try{return Function("asyncTestPassed","\nfunction * generator() {\nyield 3;\n}\ntry {\nnew generator();\n} catch(e) {\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("8");return Function("asyncTestPassed","'use strict';"+"\nfunction * generator() {\nyield 3;\n}\ntry {\nnew generator();\n} catch(e) {\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -1343,8 +1343,8 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("9");try{return Function("asyncTestPassed","\nfunction * generator() {\nyield * (function * () {\ntry {\nyield 'foo';\n}\ncatch(e) {\nreturn;\n}\n}());\nyield 'bar';\n}\nvar iter = generator();\niter.next();\nreturn iter['throw']().value === 'bar';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("9");return Function("asyncTestPassed","'use strict';"+"\nfunction * generator() {\nyield * (function * () {\ntry {\nyield 'foo';\n}\ncatch(e) {\nreturn;\n}\n}());\nyield 'bar';\n}\nvar iter = generator();\niter.next();\nreturn iter['throw']().value === 'bar';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -1464,8 +1464,8 @@ return true;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("10");try{return Function("asyncTestPassed","\nfunction foo(...a){}\ntry {\nFunction(\"function bar(...a){'use strict';}\")();\n} catch(e) {\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("10");return Function("asyncTestPassed","'use strict';"+"\nfunction foo(...a){}\ntry {\nFunction(\"function bar(...a){'use strict';}\")();\n} catch(e) {\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -1581,8 +1581,8 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("11");try{return Function("asyncTestPassed","\nvar [x, ...[y, ...z]] = [1,2,3,4];\nreturn x === 1 && y === 2 && z + '' === '3,4';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("11");return Function("asyncTestPassed","'use strict';"+"\nvar [x, ...[y, ...z]] = [1,2,3,4];\nreturn x === 1 && y === 2 && z + '' === '3,4';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -1699,8 +1699,8 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("12");try{return Function("asyncTestPassed","\nreturn function([x, ...[y, ...z]]) {\nreturn x === 1 && y === 2 && z + '' === '3,4';\n}([1,2,3,4]);\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("12");return Function("asyncTestPassed","'use strict';"+"\nreturn function([x, ...[y, ...z]]) {\nreturn x === 1 && y === 2 && z + '' === '3,4';\n}([1,2,3,4]);\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -1822,8 +1822,8 @@ return passed;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("13");try{return Function("asyncTestPassed","\nvar passed = true;\nvar proxy = new Proxy({}, {\nenumerate: function() {\npassed = false;\n}\n});\nfor(var key in proxy); // Should not throw, nor execute the 'enumerate' method.\nreturn passed;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("13");return Function("asyncTestPassed","'use strict';"+"\nvar passed = true;\nvar proxy = new Proxy({}, {\nenumerate: function() {\npassed = false;\n}\n});\nfor(var key in proxy); // Should not throw, nor execute the 'enumerate' method.\nreturn passed;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -1947,8 +1947,8 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("14");try{return Function("asyncTestPassed","\n// Array.prototype.includes -> Get -> [[Get]]\nvar get = [];\nvar p = new Proxy({length: 3, 0: '', 1: '', 2: '', 3: ''}, { get: function(o, k) { get.push(k); return o[k]; }});\nArray.prototype.includes.call(p, {});\nif (get + '' !== \"length,0,1,2\") return;\n\nget = [];\np = new Proxy({length: 4, 0: NaN, 1: '', 2: NaN, 3: ''}, { get: function(o, k) { get.push(k); return o[k]; }});\nArray.prototype.includes.call(p, NaN, 1);\nreturn (get + '' === \"length,1,2\");\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("14");return Function("asyncTestPassed","'use strict';"+"\n// Array.prototype.includes -> Get -> [[Get]]\nvar get = [];\nvar p = new Proxy({length: 3, 0: '', 1: '', 2: '', 3: ''}, { get: function(o, k) { get.push(k); return o[k]; }});\nArray.prototype.includes.call(p, {});\nif (get + '' !== \"length,0,1,2\") return;\n\nget = [];\np = new Proxy({length: 4, 0: NaN, 1: '', 2: NaN, 3: ''}, { get: function(o, k) { get.push(k); return o[k]; }});\nArray.prototype.includes.call(p, NaN, 1);\nreturn (get + '' === \"length,1,2\");\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -2062,8 +2062,8 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="1">4/4</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
@@ -2181,8 +2181,8 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nvar obj = Object.create({ a: \"qux\", d: \"qux\" });\nobj.a = \"foo\"; obj.b = \"bar\"; obj.c = \"baz\";\nvar v = Object.values(obj);\nreturn Array.isArray(v) && String(v) === \"foo,bar,baz\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nvar obj = Object.create({ a: \"qux\", d: \"qux\" });\nobj.a = \"foo\"; obj.b = \"bar\"; obj.c = \"baz\";\nvar v = Object.values(obj);\nreturn Array.isArray(v) && String(v) === \"foo,bar,baz\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -2304,8 +2304,8 @@ return Array.isArray(e)
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");try{return Function("asyncTestPassed","\nvar obj = Object.create({ a: \"qux\", d: \"qux\" });\nobj.a = \"foo\"; obj.b = \"bar\"; obj.c = \"baz\";\nvar e = Object.entries(obj);\nreturn Array.isArray(e)\n&& e.length === 3\n&& String(e[0]) === \"a,foo\"\n&& String(e[1]) === \"b,bar\"\n&& String(e[2]) === \"c,baz\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("17");return Function("asyncTestPassed","'use strict';"+"\nvar obj = Object.create({ a: \"qux\", d: \"qux\" });\nobj.a = \"foo\"; obj.b = \"bar\"; obj.c = \"baz\";\nvar e = Object.entries(obj);\nreturn Array.isArray(e)\n&& e.length === 3\n&& String(e[0]) === \"a,foo\"\n&& String(e[1]) === \"b,bar\"\n&& String(e[2]) === \"c,baz\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -2428,8 +2428,8 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");try{return Function("asyncTestPassed","\nvar object = {a: 1};\nvar B = typeof Symbol === 'function' ? Symbol('b') : 'b';\nobject[B] = 2;\nvar O = Object.defineProperty(object, 'c', {value: 3});\nvar D = Object.getOwnPropertyDescriptors(O);\n\nreturn D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true\n&& D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true\n&& D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("18");return Function("asyncTestPassed","'use strict';"+"\nvar object = {a: 1};\nvar B = typeof Symbol === 'function' ? Symbol('b') : 'b';\nobject[B] = 2;\nvar O = Object.defineProperty(object, 'c', {value: 3});\nvar D = Object.getOwnPropertyDescriptors(O);\n\nreturn D.a.value === 1 && D.a.enumerable === true && D.a.configurable === true && D.a.writable === true\n&& D[B].value === 2 && D[B].enumerable === true && D[B].configurable === true && D[B].writable === true\n&& D.c.value === 3 && D.c.enumerable === false && D.c.configurable === false && D.c.writable === false;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -2547,8 +2547,8 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");try{return Function("asyncTestPassed","\nvar P = new Proxy({a:1}, {\n  getOwnPropertyDescriptor: function(t, k) {}\n});\nreturn !Object.getOwnPropertyDescriptors(P).hasOwnProperty('a');\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("19");return Function("asyncTestPassed","'use strict';"+"\nvar P = new Proxy({a:1}, {\n  getOwnPropertyDescriptor: function(t, k) {}\n});\nreturn !Object.getOwnPropertyDescriptors(P).hasOwnProperty('a');\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -2660,8 +2660,8 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-String_padding"><span><a class="anchor" href="#test-String_padding">&#xA7;</a><a href="https://github.com/tc39/proposal-string-pad-start-end">String padding</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="1">2/2</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
@@ -2781,8 +2781,8 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("21");try{return Function("asyncTestPassed","\nreturn 'hello'.padStart(10) === '     hello'\n&& 'hello'.padStart(10, '1234') === '12341hello'\n&& 'hello'.padStart() === 'hello'\n&& 'hello'.padStart(6, '123') === '1hello'\n&& 'hello'.padStart(3) === 'hello'\n&& 'hello'.padStart(3, '123') === 'hello';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("21");return Function("asyncTestPassed","'use strict';"+"\nreturn 'hello'.padStart(10) === '     hello'\n&& 'hello'.padStart(10, '1234') === '12341hello'\n&& 'hello'.padStart() === 'hello'\n&& 'hello'.padStart(6, '123') === '1hello'\n&& 'hello'.padStart(3) === 'hello'\n&& 'hello'.padStart(3, '123') === 'hello';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -2902,8 +2902,8 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("22");try{return Function("asyncTestPassed","\nreturn 'hello'.padEnd(10) === 'hello     '\n&& 'hello'.padEnd(10, '1234') === 'hello12341'\n&& 'hello'.padEnd() === 'hello'\n&& 'hello'.padEnd(6, '123') === 'hello1'\n&& 'hello'.padEnd(3) === 'hello'\n&& 'hello'.padEnd(3, '123') === 'hello';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("22");return Function("asyncTestPassed","'use strict';"+"\nreturn 'hello'.padEnd(10) === 'hello     '\n&& 'hello'.padEnd(10, '1234') === 'hello12341'\n&& 'hello'.padEnd() === 'hello'\n&& 'hello'.padEnd(6, '123') === 'hello1'\n&& 'hello'.padEnd(3) === 'hello'\n&& 'hello'.padEnd(3, '123') === 'hello';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -3015,8 +3015,8 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-trailing_commas_in_function_syntax"><span><a class="anchor" href="#test-trailing_commas_in_function_syntax">&#xA7;</a><a href="https://github.com/tc39/proposal-trailing-function-commas">trailing commas in function syntax</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="1">2/2</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
@@ -3131,8 +3131,8 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("24");try{return Function("asyncTestPassed","\nreturn typeof function f( a, b, ){} === 'function';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("24");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof function f( a, b, ){} === 'function';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -3247,8 +3247,8 @@ return Math.min(1,2,3,) === 1;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("25");try{return Function("asyncTestPassed","\nreturn Math.min(1,2,3,) === 1;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("25");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.min(1,2,3,) === 1;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -3360,8 +3360,8 @@ return Math.min(1,2,3,) === 1;
 </tr>
 <tr class="supertest" significance="1"><td id="test-async_functions"><span><a class="anchor" href="#test-async_functions">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-async-function-definitions">async functions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
@@ -3487,8 +3487,8 @@ p.then(function(result) {
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");try{return Function("asyncTestPassed","\nasync function a(){\n  return \"foo\";\n}\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("27");return Function("asyncTestPassed","'use strict';"+"\nasync function a(){\n  return \"foo\";\n}\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -3614,8 +3614,8 @@ p.catch(function(result) {
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nasync function a(){\n  throw \"foo\";\n}\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.catch(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nasync function a(){\n  throw \"foo\";\n}\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.catch(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
-<td class="unknown" data-browser="babel6corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -3731,8 +3731,8 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("29");try{return Function("asyncTestPassed","\nasync function a(){}\ntry { Function(\"async\\n function a(){}\")(); } catch(e) { return true; }\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("29");return Function("asyncTestPassed","'use strict';"+"\nasync function a(){}\ntry { Function(\"async\\n function a(){}\")(); } catch(e) { return true; }\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
-<td class="unknown" data-browser="babel6corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -3848,8 +3848,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\nasync function a(){};\nreturn !a.hasOwnProperty(\"prototype\");\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\nasync function a(){};\nreturn !a.hasOwnProperty(\"prototype\");\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
-<td class="unknown" data-browser="babel6corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -3971,8 +3971,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\n(async function (){\n  await Promise.resolve();\n  var a1 = await new Promise(function(resolve) { setTimeout(resolve,800,\"foo\"); });\n  var a2 = await new Promise(function(resolve) { setTimeout(resolve,800,\"bar\"); });\n  if (a1 + a2 === \"foobar\") {\n    asyncTestPassed();\n  }\n}());\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\n(async function (){\n  await Promise.resolve();\n  var a1 = await new Promise(function(resolve) { setTimeout(resolve,800,\"foo\"); });\n  var a2 = await new Promise(function(resolve) { setTimeout(resolve,800,\"bar\"); });\n  if (a1 + a2 === \"foobar\") {\n    asyncTestPassed();\n  }\n}());\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -4096,8 +4096,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\n(async function (){\n  await Promise.resolve();\n  try {\n    var a1 = await new Promise(function(_, reject) { setTimeout(reject,800,\"foo\"); });\n  } catch(e) {\n    if (e === \"foo\") {\n      asyncTestPassed();\n    }\n  }\n}());\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\n(async function (){\n  await Promise.resolve();\n  try {\n    var a1 = await new Promise(function(_, reject) { setTimeout(reject,800,\"foo\"); });\n  } catch(e) {\n    if (e === \"foo\") {\n      asyncTestPassed();\n    }\n  }\n}());\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
-<td class="unknown" data-browser="babel6corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -4213,8 +4213,8 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("33");try{return Function("asyncTestPassed","\nasync function a(){ await Promise.resolve(); }\ntry { Function(\"(async function a(){ await; }())\")(); } catch(e) { return true; }\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("33");return Function("asyncTestPassed","'use strict';"+"\nasync function a(){ await Promise.resolve(); }\ntry { Function(\"(async function a(){ await; }())\")(); } catch(e) { return true; }\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
-<td class="unknown" data-browser="babel6corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -4335,8 +4335,8 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("34");try{return Function("asyncTestPassed","\n(async function (){\n  await Promise.resolve();\n  var e = await \"foo\";\n  if (e === \"foo\") {\n    asyncTestPassed();\n  }\n}());\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("34");return Function("asyncTestPassed","'use strict';"+"\n(async function (){\n  await Promise.resolve();\n  var e = await \"foo\";\n  if (e === \"foo\") {\n    asyncTestPassed();\n  }\n}());\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
-<td class="unknown" data-browser="babel6corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -4452,8 +4452,8 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("35");try{return Function("asyncTestPassed","\nasync function a(){ await Promise.resolve(); }\ntry { Function(\"(async function a(b = await Promise.resolve()){}())\")(); } catch(e) { return true; }\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("35");return Function("asyncTestPassed","'use strict';"+"\nasync function a(){ await Promise.resolve(); }\ntry { Function(\"(async function a(b = await Promise.resolve()){}())\")(); } catch(e) { return true; }\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
-<td class="unknown" data-browser="babel6corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -4579,8 +4579,8 @@ p.then(function(result) {
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("36");try{return Function("asyncTestPassed","\nvar o = {\n  async a(){ return await Promise.resolve(\"foo\"); }\n};\nvar p = o.a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("36");return Function("asyncTestPassed","'use strict';"+"\nvar o = {\n  async a(){ return await Promise.resolve(\"foo\"); }\n};\nvar p = o.a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
-<td class="unknown" data-browser="babel6corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -4706,8 +4706,8 @@ p.then(function(result) {
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("37");try{return Function("asyncTestPassed","\nclass C {\n  async a(){ return await Promise.resolve(\"foo\"); }\n};\nvar p = new C().a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("37");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  async a(){ return await Promise.resolve(\"foo\"); }\n};\nvar p = new C().a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
-<td class="unknown" data-browser="babel6corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -4833,8 +4833,8 @@ var p = new C().a();
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nfunction doSomething(callback) {\n  callback();\n}\nclass C {\n  a(){\n    doSomething(async () => {\n      await 1;\n      asyncTestPassed();\n    });\n  }\n};\nvar p = new C().a();\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nfunction doSomething(callback) {\n  callback();\n}\nclass C {\n  a(){\n    doSomething(async () => {\n      await 1;\n      asyncTestPassed();\n    });\n  }\n};\nvar p = new C().a();\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -4958,8 +4958,8 @@ p.then(function(result) {
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("39");try{return Function("asyncTestPassed","\nvar a = async () => await Promise.resolve(\"foo\");\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("39");return Function("asyncTestPassed","'use strict';"+"\nvar a = async () => await Promise.resolve(\"foo\");\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -5076,8 +5076,8 @@ return asyncFunctionProto !== function(){}.prototype
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("40");try{return Function("asyncTestPassed","\nvar asyncFunctionProto = Object.getPrototypeOf(async function (){});\nreturn asyncFunctionProto !== function(){}.prototype\n  && Object.getPrototypeOf(asyncFunctionProto) === Function.prototype;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("40");return Function("asyncTestPassed","'use strict';"+"\nvar asyncFunctionProto = Object.getPrototypeOf(async function (){});\nreturn asyncFunctionProto !== function(){}.prototype\n  && Object.getPrototypeOf(asyncFunctionProto) === Function.prototype;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
-<td class="unknown" data-browser="babel6corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -5192,8 +5192,8 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("41");try{return Function("asyncTestPassed","\nreturn Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === \"AsyncFunction\";\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("41");return Function("asyncTestPassed","'use strict';"+"\nreturn Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === \"AsyncFunction\";\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
-<td class="unknown" data-browser="babel6corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -5317,8 +5317,8 @@ p.then(function(result) {
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("42");try{return Function("asyncTestPassed","\nvar a = async function (){}.constructor(\"return 'foo';\");\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("42");return Function("asyncTestPassed","'use strict';"+"\nvar a = async function (){}.constructor(\"return 'foo';\");\nvar p = a();\nif (!(p instanceof Promise)) {\n  return false;\n}\np.then(function(result) {\n  if (result === \"foo\") {\n    asyncTestPassed();\n  }\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
-<td class="unknown" data-browser="babel6corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -5430,8 +5430,8 @@ p.then(function(result) {
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-shared_memory_and_atomics"><span><a class="anchor" href="#test-shared_memory_and_atomics">&#xA7;</a>shared memory and atomics</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/17</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/17</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/17</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/17</td>
@@ -5546,8 +5546,8 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("44");try{return Function("asyncTestPassed","\nreturn typeof SharedArrayBuffer === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("44");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SharedArrayBuffer === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -5662,8 +5662,8 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("45");try{return Function("asyncTestPassed","\nreturn SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("45");return Function("asyncTestPassed","'use strict';"+"\nreturn SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -5778,8 +5778,8 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("46");try{return Function("asyncTestPassed","\nreturn 'byteLength' in SharedArrayBuffer.prototype;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("46");return Function("asyncTestPassed","'use strict';"+"\nreturn 'byteLength' in SharedArrayBuffer.prototype;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -5894,8 +5894,8 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("47");try{return Function("asyncTestPassed","\nreturn typeof SharedArrayBuffer.prototype.slice === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("47");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof SharedArrayBuffer.prototype.slice === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6010,8 +6010,8 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("48");try{return Function("asyncTestPassed","\nreturn SharedArrayBuffer.prototype[Symbol.toStringTag] === 'SharedArrayBuffer';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("48");return Function("asyncTestPassed","'use strict';"+"\nreturn SharedArrayBuffer.prototype[Symbol.toStringTag] === 'SharedArrayBuffer';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6126,8 +6126,8 @@ return typeof Atomics.add === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("49");try{return Function("asyncTestPassed","\nreturn typeof Atomics.add === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("49");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.add === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6242,8 +6242,8 @@ return typeof Atomics.and === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("50");try{return Function("asyncTestPassed","\nreturn typeof Atomics.and === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("50");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.and === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6358,8 +6358,8 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("51");try{return Function("asyncTestPassed","\nreturn typeof Atomics.compareExchange === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("51");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.compareExchange === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6474,8 +6474,8 @@ return typeof Atomics.exchange === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("52");try{return Function("asyncTestPassed","\nreturn typeof Atomics.exchange === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("52");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.exchange === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6590,8 +6590,8 @@ return typeof Atomics.wait === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("53");try{return Function("asyncTestPassed","\nreturn typeof Atomics.wait === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("53");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.wait === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6706,8 +6706,8 @@ return typeof Atomics.wake === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("54");try{return Function("asyncTestPassed","\nreturn typeof Atomics.wake === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("54");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.wake === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6822,8 +6822,8 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("55");try{return Function("asyncTestPassed","\nreturn typeof Atomics.isLockFree === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("55");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.isLockFree === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6938,8 +6938,8 @@ return typeof Atomics.load === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("56");try{return Function("asyncTestPassed","\nreturn typeof Atomics.load === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("56");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.load === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7054,8 +7054,8 @@ return typeof Atomics.or === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("57");try{return Function("asyncTestPassed","\nreturn typeof Atomics.or === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("57");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.or === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7170,8 +7170,8 @@ return typeof Atomics.store === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("58");try{return Function("asyncTestPassed","\nreturn typeof Atomics.store === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("58");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.store === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7286,8 +7286,8 @@ return typeof Atomics.sub === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("59");try{return Function("asyncTestPassed","\nreturn typeof Atomics.sub === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("59");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.sub === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7402,8 +7402,8 @@ return typeof Atomics.xor === &apos;function&apos;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("60");try{return Function("asyncTestPassed","\nreturn typeof Atomics.xor === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("60");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.xor === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7523,8 +7523,8 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("61");try{return Function("asyncTestPassed","\nreturn \"ſ\".match(/\\w/iu) && !\"ſ\".match(/\\W/iu)\n&& \"\\u212a\".match(/\\w/iu) && !\"\\u212a\".match(/\\W/iu)\n&& \"\\u212a\".match(/.\\b/iu) && \"ſ\".match(/.\\b/iu)\n&& !\"\\u212a\".match(/.\\B/iu) && !\"ſ\".match(/.\\B/iu);\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("61");return Function("asyncTestPassed","'use strict';"+"\nreturn \"ſ\".match(/\\w/iu) && !\"ſ\".match(/\\W/iu)\n&& \"\\u212a\".match(/\\w/iu) && !\"\\u212a\".match(/\\W/iu)\n&& \"\\u212a\".match(/.\\b/iu) && \"ſ\".match(/.\\b/iu)\n&& !\"\\u212a\".match(/.\\B/iu) && !\"ſ\".match(/.\\B/iu);\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7642,8 +7642,8 @@ return (function(){
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("62");try{return Function("asyncTestPassed","\nreturn (function(){\n  'use strict';\n  return !Object.getOwnPropertyDescriptor(arguments,'caller');\n})();\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("62");return Function("asyncTestPassed","'use strict';"+"\nreturn (function(){\n  'use strict';\n  return !Object.getOwnPropertyDescriptor(arguments,'caller');\n})();\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7757,8 +7757,8 @@ return (function(){
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
-<td class="tally not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -7878,8 +7878,8 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("64");try{return Function("asyncTestPassed","\nvar obj = {};\nfunction bar() { return \"bar\"; }\nObject.prototype.__defineGetter__.call(obj, \"foo\", bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, \"foo\");\nreturn prop.get === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("64");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {};\nfunction bar() { return \"bar\"; }\nObject.prototype.__defineGetter__.call(obj, \"foo\", bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, \"foo\");\nreturn prop.get === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8000,8 +8000,8 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("65");try{return Function("asyncTestPassed","\nvar obj = {};\nvar sym = Symbol();\nfunction bar() { return \"bar\"; }\nObject.prototype.__defineGetter__.call(obj, sym, bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, sym);\nreturn prop.get === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("65");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {};\nvar sym = Symbol();\nfunction bar() { return \"bar\"; }\nObject.prototype.__defineGetter__.call(obj, sym, bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, sym);\nreturn prop.get === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8122,8 +8122,8 @@ return true;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("66");try{return Function("asyncTestPassed","\nvar key = '__accessors_test__';\n__defineGetter__.call(1, key, function(){});\ntry {\n__defineGetter__.call(null, key, function(){});\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("66");return Function("asyncTestPassed","'use strict';"+"\nvar key = '__accessors_test__';\n__defineGetter__.call(1, key, function(){});\ntry {\n__defineGetter__.call(null, key, function(){});\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8243,8 +8243,8 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("67");try{return Function("asyncTestPassed","\nvar obj = {};\nfunction bar() {}\nObject.prototype.__defineSetter__.call(obj, \"foo\", bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, \"foo\");\nreturn prop.set === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("67");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {};\nfunction bar() {}\nObject.prototype.__defineSetter__.call(obj, \"foo\", bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, \"foo\");\nreturn prop.set === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8365,8 +8365,8 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("68");try{return Function("asyncTestPassed","\nvar obj = {};\nvar sym = Symbol();\nfunction bar(baz) {}\nObject.prototype.__defineSetter__.call(obj, sym, bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, sym);\nreturn prop.set === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("68");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {};\nvar sym = Symbol();\nfunction bar(baz) {}\nObject.prototype.__defineSetter__.call(obj, sym, bar);\nvar prop = Object.getOwnPropertyDescriptor(obj, sym);\nreturn prop.set === bar && !prop.writable && prop.configurable\n&& prop.enumerable;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8487,8 +8487,8 @@ return true;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("69");try{return Function("asyncTestPassed","\nvar key = '__accessors_test__';\n__defineSetter__.call(1, key, function(){});\ntry {\n__defineSetter__.call(null, key, function(){});\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("69");return Function("asyncTestPassed","'use strict';"+"\nvar key = '__accessors_test__';\n__defineSetter__.call(1, key, function(){});\ntry {\n__defineSetter__.call(null, key, function(){});\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8610,8 +8610,8 @@ return foo() === &quot;bar&quot;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("70");try{return Function("asyncTestPassed","\nvar obj = {\nget foo() { return \"bar\"},\nqux: 1\n};\nvar foo = Object.prototype.__lookupGetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, \"qux\") === void undefined\n&& Object.prototype.__lookupGetter__.call(obj, \"baz\") === void undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("70");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nget foo() { return \"bar\"},\nqux: 1\n};\nvar foo = Object.prototype.__lookupGetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, \"qux\") === void undefined\n&& Object.prototype.__lookupGetter__.call(obj, \"baz\") === void undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8733,8 +8733,8 @@ return foo() === &quot;bar&quot;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("71");try{return Function("asyncTestPassed","\nvar obj = {\nget foo() { return \"bar\"},\nqux: 1\n};\nvar foo = Object.prototype.__lookupGetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, \"qux\") === void undefined\n&& Object.prototype.__lookupGetter__.call(obj, \"baz\") === void undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("71");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nget foo() { return \"bar\"},\nqux: 1\n};\nvar foo = Object.prototype.__lookupGetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, \"qux\") === void undefined\n&& Object.prototype.__lookupGetter__.call(obj, \"baz\") === void undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8857,8 +8857,8 @@ return foo() === &quot;bar&quot;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("72");try{return Function("asyncTestPassed","\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { get: function() { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupGetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, sym2) === void undefined\n&& Object.prototype.__lookupGetter__.call(obj, Symbol()) === void undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("72");return Function("asyncTestPassed","'use strict';"+"\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { get: function() { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupGetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupGetter__.call(obj, sym2) === void undefined\n&& Object.prototype.__lookupGetter__.call(obj, Symbol()) === void undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -8978,8 +8978,8 @@ return true;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("73");try{return Function("asyncTestPassed","\n__lookupGetter__.call(1, 'key');\ntry {\n__lookupGetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("73");return Function("asyncTestPassed","'use strict';"+"\n__lookupGetter__.call(1, 'key');\ntry {\n__lookupGetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9098,8 +9098,8 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("74");try{return Function("asyncTestPassed","\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineGetter__(\"foo\", function () {})\nreturn b.__lookupGetter__(\"foo\") === void undefined\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("74");return Function("asyncTestPassed","'use strict';"+"\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineGetter__(\"foo\", function () {})\nreturn b.__lookupGetter__(\"foo\") === void undefined\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9221,8 +9221,8 @@ return foo() === &quot;bar&quot;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("75");try{return Function("asyncTestPassed","\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === void undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === void undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("75");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(obj, \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === void undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === void undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9344,8 +9344,8 @@ return foo() === &quot;bar&quot;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("76");try{return Function("asyncTestPassed","\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === void undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === void undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("76");return Function("asyncTestPassed","'use strict';"+"\nvar obj = {\nset foo(baz) { return \"bar\"; },\nqux: 1\n};\nvar foo = Object.prototype.__lookupSetter__.call(Object.create(obj), \"foo\");\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, \"qux\") === void undefined\n&& Object.prototype.__lookupSetter__.call(obj, \"baz\") === void undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9468,8 +9468,8 @@ return foo() === &quot;bar&quot;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("77");try{return Function("asyncTestPassed","\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { set: function(baz) { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupSetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, sym2) === void undefined\n&& Object.prototype.__lookupSetter__.call(obj, Symbol()) === void undefined;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("77");return Function("asyncTestPassed","'use strict';"+"\nvar sym = Symbol();\nvar sym2 = Symbol();\nvar obj = {};\nObject.defineProperty(obj, sym, { set: function(baz) { return \"bar\"; }});\nObject.defineProperty(obj, sym2, { value: 1 });\nvar foo = Object.prototype.__lookupSetter__.call(obj, sym);\nreturn foo() === \"bar\"\n&& Object.prototype.__lookupSetter__.call(obj, sym2) === void undefined\n&& Object.prototype.__lookupSetter__.call(obj, Symbol()) === void undefined;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9589,8 +9589,8 @@ return true;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("78");try{return Function("asyncTestPassed","\n__lookupSetter__.call(1, 'key');\ntry {\n__lookupSetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("78");return Function("asyncTestPassed","'use strict';"+"\n__lookupSetter__.call(1, 'key');\ntry {\n__lookupSetter__.call(null, 'key');\n} catch(e){\nreturn true;\n}\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9709,8 +9709,8 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("79");try{return Function("asyncTestPassed","\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineSetter__(\"foo\", function () {})\nreturn b.__lookupSetter__(\"foo\") === void undefined\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("79");return Function("asyncTestPassed","'use strict';"+"\nvar a = { };\nvar b = Object.create(a);\nb.foo = 1;\na.__defineSetter__(\"foo\", function () {})\nreturn b.__lookupSetter__(\"foo\") === void undefined\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -9822,8 +9822,8 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Proxy_internal_calls,_getter/setter_methods"><span><a class="anchor" href="#test-Proxy_internal_calls,_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Proxy internal calls, getter/setter methods</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -9942,8 +9942,8 @@ return def + &apos;&apos; === &quot;foo&quot;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("81");try{return Function("asyncTestPassed","\n// Object.prototype.__defineGetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineGetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("81");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__defineGetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineGetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10062,8 +10062,8 @@ return def + &apos;&apos; === &quot;foo&quot;;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("82");try{return Function("asyncTestPassed","\n// Object.prototype.__defineSetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineSetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("82");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__defineSetter__ -> DefinePropertyOrThrow -> [[DefineOwnProperty]]\nvar def = [];\nvar p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});\nObject.prototype.__defineSetter__.call(p, \"foo\", Object);\nreturn def + '' === \"foo\";\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10187,8 +10187,8 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("83");try{return Function("asyncTestPassed","\n// Object.prototype.__lookupGetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupGetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupGetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("83");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__lookupGetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupGetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupGetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10312,8 +10312,8 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("84");try{return Function("asyncTestPassed","\n// Object.prototype.__lookupSetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupSetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupSetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("84");return Function("asyncTestPassed","'use strict';"+"\n// Object.prototype.__lookupSetter__ -> [[GetOwnProperty]]\n// Object.prototype.__lookupSetter__ -> [[GetPrototypeOf]]\nvar gopd = [];\nvar gpo = false;\nvar p = new Proxy({}, {\ngetPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },\ngetOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }\n});\nObject.prototype.__lookupSetter__.call(p, \"foo\");\nreturn gopd + '' === \"foo\" && gpo;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10429,8 +10429,8 @@ return i === 0;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("85");try{return Function("asyncTestPassed","\nfor (var i = 0 in {}) {}\nreturn i === 0;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("85");return Function("asyncTestPassed","'use strict';"+"\nfor (var i = 0 in {}) {}\nreturn i === 0;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -10544,8 +10544,8 @@ return i === 0;
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="1">2/2</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
@@ -10661,8 +10661,8 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("87");try{return Function("asyncTestPassed","\nvar {a, ...rest} = {a: 1, b: 2, c: 3};\nreturn a === 1 && rest.a === void undefined && rest.b === 2 && rest.c === 3;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("87");return Function("asyncTestPassed","'use strict';"+"\nvar {a, ...rest} = {a: 1, b: 2, c: 3};\nreturn a === 1 && rest.a === void undefined && rest.b === 2 && rest.c === 3;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="closure20190215">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
@@ -10779,8 +10779,8 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("88");try{return Function("asyncTestPassed","\nvar spread = {b: 2, c: 3};\nvar O = {a: 1, ...spread};\nreturn O !== spread && (O.a + O.b + O.c) === 6;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("88");return Function("asyncTestPassed","'use strict';"+"\nvar spread = {b: 2, c: 3};\nvar O = {a: 1, ...spread};\nreturn O !== spread && (O.a + O.b + O.c) === 6;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="closure20190215">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
@@ -10892,8 +10892,8 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Promise.prototype.finally"><span><a class="anchor" href="#test-Promise.prototype.finally">&#xA7;</a><a href="https://github.com/tc39/proposal-promise-finally">Promise.prototype.finally</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="1">3/3</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">3/3</td>
@@ -11034,8 +11034,8 @@ function check() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("90");try{return Function("asyncTestPassed","\nvar p1 = Promise.resolve(\"foo\");\nvar p2 = Promise.reject(\"bar\");\nvar score = 0;\nfunction thenFn(result)  {\n  score += (result === \"foo\");\n  check();\n}\nfunction catchFn(result) {\n  score += (result === \"bar\");\n  check();\n}\nfunction finallyFn() {\n  score += (arguments.length === 0);\n  check();\n}\np1.then(thenFn);\np1.finally(finallyFn);\np1.finally(function() {\n  // should return a new Promise\n  score += p1.finally() !== p1;\n  check();\n});\np2.catch(catchFn);\np2.finally(finallyFn);\nfunction check() {\n  if (score === 5) asyncTestPassed();\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("90");return Function("asyncTestPassed","'use strict';"+"\nvar p1 = Promise.resolve(\"foo\");\nvar p2 = Promise.reject(\"bar\");\nvar score = 0;\nfunction thenFn(result)  {\n  score += (result === \"foo\");\n  check();\n}\nfunction catchFn(result) {\n  score += (result === \"bar\");\n  check();\n}\nfunction finallyFn() {\n  score += (arguments.length === 0);\n  check();\n}\np1.then(thenFn);\np1.finally(finallyFn);\np1.finally(function() {\n  // should return a new Promise\n  score += p1.finally() !== p1;\n  check();\n});\np2.catch(catchFn);\np2.finally(finallyFn);\nfunction check() {\n  if (score === 5) asyncTestPassed();\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -11168,8 +11168,8 @@ function check() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("91");try{return Function("asyncTestPassed","\nvar score = 0;\nfunction thenFn(result)  {\n  score += (result === \"foo\");\n  check();\n}\nfunction catchFn(result) {\n  score += (result === \"bar\");\n  check();\n}\nfunction finallyFn() {\n  score++;\n  check();\n  return Promise.resolve(\"foobar\");\n}\nPromise.resolve(\"foo\").finally(finallyFn).then(thenFn);\nPromise.reject(\"bar\").finally(finallyFn).catch(catchFn);\nfunction check() {\n  if (score === 4) asyncTestPassed();\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("91");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nfunction thenFn(result)  {\n  score += (result === \"foo\");\n  check();\n}\nfunction catchFn(result) {\n  score += (result === \"bar\");\n  check();\n}\nfunction finallyFn() {\n  score++;\n  check();\n  return Promise.resolve(\"foobar\");\n}\nPromise.resolve(\"foo\").finally(finallyFn).then(thenFn);\nPromise.reject(\"bar\").finally(finallyFn).catch(catchFn);\nfunction check() {\n  if (score === 4) asyncTestPassed();\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -11304,8 +11304,8 @@ function check() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("92");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise\n  .reject(\"foobar\")\n  .finally(function() {\n    return Promise.reject(\"foo\");\n  })\n  .catch(function(result) {\n    score += (result === \"foo\");\n    check();\n    return Promise.reject(\"foobar\");\n  })\n  .finally(function() {\n    throw new Error('bar');\n  })\n  .catch(function(result) {\n    score += (result.message === \"bar\");\n    check();\n  });\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("92");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise\n  .reject(\"foobar\")\n  .finally(function() {\n    return Promise.reject(\"foo\");\n  })\n  .catch(function(result) {\n    score += (result === \"foo\");\n    check();\n    return Promise.reject(\"foobar\");\n  })\n  .finally(function() {\n    throw new Error('bar');\n  })\n  .catch(function(result) {\n    score += (result.message === \"bar\");\n    check();\n  });\nfunction check() {\n  if (score === 2) asyncTestPassed();\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -11421,8 +11421,8 @@ return regex.test(&apos;foo\nbar&apos;);
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("93");try{return Function("asyncTestPassed","\nconst regex = /foo.bar/s;\nreturn regex.test('foo\\nbar');\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("93");return Function("asyncTestPassed","'use strict';"+"\nconst regex = /foo.bar/s;\nreturn regex.test('foo\\nbar');\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -11544,8 +11544,8 @@ return result.groups.year === &apos;2016&apos;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("94");try{return Function("asyncTestPassed","\nvar result = /(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})/.exec('2016-03-11');\nreturn result.groups.year === '2016'\n  && result.groups.month === '03'\n  && result.groups.day === '11'\n  && result[0] === '2016-03-11'\n  && result[1] === '2016'\n  && result[2] === '03'\n  && result[3] === '11';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("94");return Function("asyncTestPassed","'use strict';"+"\nvar result = /(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})/.exec('2016-03-11');\nreturn result.groups.year === '2016'\n  && result.groups.month === '03'\n  && result.groups.day === '11'\n  && result[0] === '2016-03-11'\n  && result[1] === '2016'\n  && result[2] === '03'\n  && result[3] === '11';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -11661,8 +11661,8 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("95");try{return Function("asyncTestPassed","\nreturn /(?<=a)b/.test('ab') && /(?<!a)b/.test('cb') &&\n       !/(?<=a)b/.test('b');\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("95");return Function("asyncTestPassed","'use strict';"+"\nreturn /(?<=a)b/.test('ab') && /(?<!a)b/.test('cb') &&\n       !/(?<=a)b/.test('b');\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -11778,8 +11778,8 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("96");try{return Function("asyncTestPassed","\nconst regexGreekSymbol = /\\p{Script=Greek}/u;\nreturn regexGreekSymbol.test('π');\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("96");return Function("asyncTestPassed","'use strict';"+"\nconst regexGreekSymbol = /\\p{Script=Greek}/u;\nreturn regexGreekSymbol.test('π');\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -11891,8 +11891,8 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Asynchronous_Iterators"><span><a class="anchor" href="#test-Asynchronous_Iterators">&#xA7;</a><a href="https://github.com/tc39/proposal-async-iteration">Asynchronous Iterators</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="1">2/2</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
@@ -12014,8 +12014,8 @@ iterator.next().then(function(step){
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("98");try{return Function("asyncTestPassed","\nasync function*generator(){\n  yield 42;\n}\n\nvar iterator = generator();\niterator.next().then(function(step){\n  if(iterator[Symbol.asyncIterator]() === iterator && step.done === false && step.value === 42)asyncTestPassed();\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("98");return Function("asyncTestPassed","'use strict';"+"\nasync function*generator(){\n  yield 42;\n}\n\nvar iterator = generator();\niterator.next().then(function(step){\n  if(iterator[Symbol.asyncIterator]() === iterator && step.done === false && step.value === 42)asyncTestPassed();\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -12147,8 +12147,8 @@ asyncIterable[Symbol.asyncIterator] = function(){
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("99");try{return Function("asyncTestPassed","\nvar asyncIterable = {};\nasyncIterable[Symbol.asyncIterator] = function(){\n  var i = 0;\n  return {\n    next: function(){\n      switch(++i){\n        case 1: return Promise.resolve({done: false, value: 'a'});\n        case 2: return Promise.resolve({done: false, value: 'b'});\n      } return Promise.resolve({done: true});\n    }\n  };\n};\n\n(async function(){\n  var result = '';\n  for await(var value of asyncIterable)result += value;\n  if(result === 'ab')asyncTestPassed();\n})();\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("99");return Function("asyncTestPassed","'use strict';"+"\nvar asyncIterable = {};\nasyncIterable[Symbol.asyncIterator] = function(){\n  var i = 0;\n  return {\n    next: function(){\n      switch(++i){\n        case 1: return Promise.resolve({done: false, value: 'a'});\n        case 2: return Promise.resolve({done: false, value: 'b'});\n      } return Promise.resolve({done: true});\n    }\n  };\n};\n\n(async function(){\n  var result = '';\n  for await(var value of asyncIterable)result += value;\n  if(result === 'ab')asyncTestPassed();\n})();\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -12275,8 +12275,8 @@ return false;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("100");try{return Function("asyncTestPassed","\nvar p = new Proxy({}, {\n  ownKeys() {\n    return [\"a\", \"a\"];\n  }\n});\ntry {\n  Object.keys(p);\n} catch (e) {\n   return e instanceof TypeError\n}\nreturn false;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("100");return Function("asyncTestPassed","'use strict';"+"\nvar p = new Proxy({}, {\n  ownKeys() {\n    return [\"a\", \"a\"];\n  }\n});\ntry {\n  Object.keys(p);\n} catch (e) {\n   return e instanceof TypeError\n}\nreturn false;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -12398,8 +12398,8 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("101");try{return Function("asyncTestPassed","\nfunction tag(strings, a) {\nreturn strings[0] === void 0 &&\nstrings.raw[0] === \"\\\\01\\\\1\\\\xg\\\\xAg\\\\u0\\\\u0g\\\\u00g\\\\u000g\\\\u{g\\\\u{0\\\\u{110000}\" &&\nstrings[1] === \"\\0\" &&\nstrings.raw[1] === \"\\\\0\" &&\na === 0;\n}\nreturn tag`\\01\\1\\xg\\xAg\\u0\\u0g\\u00g\\u000g\\u{g\\u{0\\u{110000}${0}\\0`;\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("101");return Function("asyncTestPassed","'use strict';"+"\nfunction tag(strings, a) {\nreturn strings[0] === void 0 &&\nstrings.raw[0] === \"\\\\01\\\\1\\\\xg\\\\xAg\\\\u0\\\\u0g\\\\u00g\\\\u000g\\\\u{g\\\\u{0\\\\u{110000}\" &&\nstrings[1] === \"\\0\" &&\nstrings.raw[1] === \"\\\\0\" &&\na === 0;\n}\nreturn tag`\\01\\1\\xg\\xAg\\u0\\u0g\\u00g\\u000g\\u{g\\u{0\\u{110000}${0}\\0`;\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -12517,8 +12517,8 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("102");try{return Function("asyncTestPassed","\nvar object = Object.fromEntries(new Map([['foo', 42], ['bar', 23]]));\nreturn object.foo === 42 && object.bar === 23;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("102");return Function("asyncTestPassed","'use strict';"+"\nvar object = Object.fromEntries(new Map([['foo', 42], ['bar', 23]]));\nreturn object.foo === 42 && object.bar === 23;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -12630,8 +12630,8 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-string_trimming"><span><a class="anchor" href="#test-string_trimming">&#xA7;</a><a href="https://github.com/tc39/proposal-string-left-right-trim">string trimming</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="1">4/4</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/4</td>
@@ -12746,8 +12746,8 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("104");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimLeft() === 'abc   \\t\\n';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("104");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimLeft() === 'abc   \\t\\n';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -12862,8 +12862,8 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("105");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimRight() === ' \\t \\n abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("105");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimRight() === ' \\t \\n abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -12978,8 +12978,8 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("106");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimStart() === 'abc   \\t\\n';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("106");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimStart() === 'abc   \\t\\n';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -13094,8 +13094,8 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("107");try{return Function("asyncTestPassed","\nreturn ' \\t \\n abc   \\t\\n'.trimEnd() === ' \\t \\n abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("107");return Function("asyncTestPassed","'use strict';"+"\nreturn ' \\t \\n abc   \\t\\n'.trimEnd() === ' \\t \\n abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -13207,8 +13207,8 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Array.prototype.{flat,_flatMap}"><span><a class="anchor" href="#test-Array.prototype.{flat,_flatMap}">&#xA7;</a><a href="https://tc39.github.io/proposal-flatMap/">Array.prototype.{flat, flatMap}</a><a href="#flatten-compat-issue-note"><sup>[29]</sup></a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
@@ -13323,8 +13323,8 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("109");try{return Function("asyncTestPassed","\nreturn [1, [2, 3], [4, [5, 6]]].flat().join('') === '12345,6';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("109");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, [2, 3], [4, [5, 6]]].flat().join('') === '12345,6';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -13441,8 +13441,8 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("110");try{return Function("asyncTestPassed","\nreturn [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {\n  return [it.a, it.b];\n}).join('') === '1234';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("110");return Function("asyncTestPassed","'use strict';"+"\nreturn [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {\n  return [it.a, it.b];\n}).join('') === '1234';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -13558,8 +13558,8 @@ return Array.prototype[Symbol.unscopables].flat
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("111");try{return Function("asyncTestPassed","\nreturn Array.prototype[Symbol.unscopables].flat\n  && Array.prototype[Symbol.unscopables].flatMap;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("111");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.prototype[Symbol.unscopables].flat\n  && Array.prototype[Symbol.unscopables].flatMap;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -13673,8 +13673,8 @@ return Array.prototype[Symbol.unscopables].flat
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://github.com/tc39/proposal-optional-catch-binding">optional catch binding</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/3</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">3/3</td>
@@ -13795,8 +13795,8 @@ return false;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("113");try{return Function("asyncTestPassed","\ntry {\n  throw new Error();\n}\ncatch {\n  return true;\n}\nreturn false;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("113");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  throw new Error();\n}\ncatch {\n  return true;\n}\nreturn false;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -13918,8 +13918,8 @@ return false;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("114");try{return Function("asyncTestPassed","\n(async function (){\n  try {\n    await Promise.reject();\n  }\n  catch {\n    asyncTestPassed();\n  }\n})();\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("114");return Function("asyncTestPassed","'use strict';"+"\n(async function (){\n  try {\n    await Promise.reject();\n  }\n  catch {\n    asyncTestPassed();\n  }\n})();\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -14046,8 +14046,8 @@ return it.next().value;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("115");try{return Function("asyncTestPassed","\nfunction *foo() {\n  try {\n    yield;\n    throw new Error();\n  }\n  catch {\n    return true;\n  }\n}\n\nvar it = foo();\nit.next();\nreturn it.next().value;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("115");return Function("asyncTestPassed","'use strict';"+"\nfunction *foo() {\n  try {\n    yield;\n    throw new Error();\n  }\n  catch {\n    return true;\n  }\n}\n\nvar it = foo();\nit.next();\nreturn it.next().value;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -14159,8 +14159,8 @@ return it.next().value;
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Symbol.prototype.description"><span><a class="anchor" href="#test-Symbol.prototype.description">&#xA7;</a><a href="https://github.com/tc39/proposal-Symbol-description">Symbol.prototype.description</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/3</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
@@ -14275,8 +14275,8 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("117");try{return Function("asyncTestPassed","\nreturn Symbol('foo').description === 'foo';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("117");return Function("asyncTestPassed","'use strict';"+"\nreturn Symbol('foo').description === 'foo';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -14391,8 +14391,8 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("118");try{return Function("asyncTestPassed","\nreturn Symbol('').description === '';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("118");return Function("asyncTestPassed","'use strict';"+"\nreturn Symbol('').description === '';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -14508,8 +14508,8 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("119");try{return Function("asyncTestPassed","\nreturn Symbol.prototype.hasOwnProperty('description')\n  && Symbol().description === void undefined;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("119");return Function("asyncTestPassed","'use strict';"+"\nreturn Symbol.prototype.hasOwnProperty('description')\n  && Symbol().description === void undefined;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -14621,8 +14621,8 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Function.prototype.toString_revision"><span><a class="anchor" href="#test-Function.prototype.toString_revision">&#xA7;</a><a href="https://github.com/tc39/Function-prototype-toString-revision">Function.prototype.toString revision</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/7</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/7</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
@@ -14739,8 +14739,8 @@ return fn + &apos;&apos; === str;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("121");try{return Function("asyncTestPassed","\nvar fn = Function('a', ' /\\x2A a \\x2A/ b, c /\\x2A b \\x2A/ //', '/\\x2A c \\x2A/ ; /\\x2A d \\x2A/ //');\nvar str = 'function anonymous(a, /\\x2A a \\x2A/ b, c /\\x2A b \\x2A/ //\\n) {\\n/\\x2A c \\x2A/ ; /\\x2A d \\x2A/ //\\n}';\nreturn fn + '' === str;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("121");return Function("asyncTestPassed","'use strict';"+"\nvar fn = Function('a', ' /\\x2A a \\x2A/ b, c /\\x2A b \\x2A/ //', '/\\x2A c \\x2A/ ; /\\x2A d \\x2A/ //');\nvar str = 'function anonymous(a, /\\x2A a \\x2A/ b, c /\\x2A b \\x2A/ //\\n) {\\n/\\x2A c \\x2A/ ; /\\x2A d \\x2A/ //\\n}';\nreturn fn + '' === str;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -14856,8 +14856,8 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("122");try{return Function("asyncTestPassed","\nvar str = 'a => b';\nreturn eval('(' + str + ')') + '' === str;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("122");return Function("asyncTestPassed","'use strict';"+"\nvar str = 'a => b';\nreturn eval('(' + str + ')') + '' === str;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -14973,8 +14973,8 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("123");try{return Function("asyncTestPassed","\nconst NATIVE_EVAL_RE = /\\bfunction\\b[\\s\\S]*\\beval\\b[\\s\\S]*\\([\\s\\S]*\\)[\\s\\S]*\\{[\\s\\S]*\\[[\\s\\S]*\\bnative\\b[\\s\\S]+\\bcode\\b[\\s\\S]*\\][\\s\\S]*\\}/;\nreturn NATIVE_EVAL_RE.test(eval + '');\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("123");return Function("asyncTestPassed","'use strict';"+"\nconst NATIVE_EVAL_RE = /\\bfunction\\b[\\s\\S]*\\beval\\b[\\s\\S]*\\([\\s\\S]*\\)[\\s\\S]*\\{[\\s\\S]*\\[[\\s\\S]*\\bnative\\b[\\s\\S]+\\bcode\\b[\\s\\S]*\\][\\s\\S]*\\}/;\nreturn NATIVE_EVAL_RE.test(eval + '');\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -15090,8 +15090,8 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("124");try{return Function("asyncTestPassed","\nvar str = 'class A {}';\nreturn eval('(' + str + ')') + '' === str;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("124");return Function("asyncTestPassed","'use strict';"+"\nvar str = 'class A {}';\nreturn eval('(' + str + ')') + '' === str;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -15207,8 +15207,8 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("125");try{return Function("asyncTestPassed","\nvar str = 'class /\\x2A a \\x2A/ A /\\x2A b \\x2A/ extends /\\x2A c \\x2A/ function B(){} /\\x2A d \\x2A/ { /\\x2A e \\x2A/ constructor /\\x2A f \\x2A/ ( /\\x2A g \\x2A/ ) /\\x2A h \\x2A/ { /\\x2A i \\x2A/ ; /\\x2A j \\x2A/ } /\\x2A k \\x2A/ m /\\x2A l \\x2A/ ( /\\x2A m \\x2A/ ) /\\x2A n \\x2A/ { /\\x2A o \\x2A/ } /\\x2A p \\x2A/ }';\nreturn eval('(/\\x2A before \\x2A/' + str + '/\\x2A after \\x2A/)') + '' === str;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("125");return Function("asyncTestPassed","'use strict';"+"\nvar str = 'class /\\x2A a \\x2A/ A /\\x2A b \\x2A/ extends /\\x2A c \\x2A/ function B(){} /\\x2A d \\x2A/ { /\\x2A e \\x2A/ constructor /\\x2A f \\x2A/ ( /\\x2A g \\x2A/ ) /\\x2A h \\x2A/ { /\\x2A i \\x2A/ ; /\\x2A j \\x2A/ } /\\x2A k \\x2A/ m /\\x2A l \\x2A/ ( /\\x2A m \\x2A/ ) /\\x2A n \\x2A/ { /\\x2A o \\x2A/ } /\\x2A p \\x2A/ }';\nreturn eval('(/\\x2A before \\x2A/' + str + '/\\x2A after \\x2A/)') + '' === str;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -15324,8 +15324,8 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("126");try{return Function("asyncTestPassed","\nvar str = 'function \\\\u0061(\\\\u{62}, \\\\u0063) { \\\\u0062 = \\\\u{00063}; return b; }';\nreturn eval('(/\\x2A before \\x2A/' + str + '/\\x2A after \\x2A/)') + '' === str;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("126");return Function("asyncTestPassed","'use strict';"+"\nvar str = 'function \\\\u0061(\\\\u{62}, \\\\u0063) { \\\\u0062 = \\\\u{00063}; return b; }';\nreturn eval('(/\\x2A before \\x2A/' + str + '/\\x2A after \\x2A/)') + '' === str;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -15441,8 +15441,8 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("127");try{return Function("asyncTestPassed","\nvar str = '[ /\\x2A a \\x2A/ \"f\" /\\x2A b \\x2A/ ] /\\x2A c \\x2A/ ( /\\x2A d \\x2A/ ) /\\x2A e \\x2A/ { /\\x2A f \\x2A/ }';\nreturn eval('({ /\\x2A before \\x2A/' + str + '/\\x2A after \\x2A/ }.f)') + '' === str;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("127");return Function("asyncTestPassed","'use strict';"+"\nvar str = '[ /\\x2A a \\x2A/ \"f\" /\\x2A b \\x2A/ ] /\\x2A c \\x2A/ ( /\\x2A d \\x2A/ ) /\\x2A e \\x2A/ { /\\x2A f \\x2A/ }';\nreturn eval('({ /\\x2A before \\x2A/' + str + '/\\x2A after \\x2A/ }.f)') + '' === str;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -15554,8 +15554,8 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-JSON_superset"><span><a class="anchor" href="#test-JSON_superset">&#xA7;</a><a href="https://github.com/tc39/proposal-json-superset">JSON superset</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="1">2/2</td>
@@ -15670,8 +15670,8 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("129");try{return Function("asyncTestPassed","\nreturn eval(\"'\\u2028'\") === \"\\u2028\";\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("129");return Function("asyncTestPassed","'use strict';"+"\nreturn eval(\"'\\u2028'\") === \"\\u2028\";\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -15786,8 +15786,8 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("130");try{return Function("asyncTestPassed","\nreturn eval(\"'\\u2029'\") === \"\\u2029\";\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("130");return Function("asyncTestPassed","'use strict';"+"\nreturn eval(\"'\\u2029'\") === \"\\u2029\";\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="yes obsolete" data-browser="closure20190215">Yes</td>
@@ -15903,8 +15903,8 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("131");try{return Function("asyncTestPassed","\nreturn JSON.stringify('\\uDF06\\uD834') === \"\\\"\\\\udf06\\\\ud834\\\"\"\n  && JSON.stringify('\\uDEAD') === \"\\\"\\\\udead\\\"\";\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("131");return Function("asyncTestPassed","'use strict';"+"\nreturn JSON.stringify('\\uDF06\\uD834') === \"\\\"\\\\udf06\\\\ud834\\\"\"\n  && JSON.stringify('\\uDEAD') === \"\\\"\\\\udead\\\"\";\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -16018,8 +16018,8 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-String.prototype.matchAll"><span><a class="anchor" href="#test-String.prototype.matchAll">&#xA7;</a><a href="https://github.com/tc39/String.prototype.matchAll">String.prototype.matchAll</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
@@ -16144,8 +16144,8 @@ return a === &apos;1a2b&apos;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("133");try{return Function("asyncTestPassed","\nvar iterator = '11a2bb'.matchAll(/(\\d)(\\D)/g);\nif(iterator[Symbol.iterator]() !== iterator)return false;\nvar a = '', b = '', c = '', step;\nwhile(!(step = iterator.next()).done){\n  a += step.value[0];\n  b += step.value[1];\n  c += step.value[2];\n}\nreturn a === '1a2b'\n  && b === '12'\n  && c === 'ab';\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("133");return Function("asyncTestPassed","'use strict';"+"\nvar iterator = '11a2bb'.matchAll(/(\\d)(\\D)/g);\nif(iterator[Symbol.iterator]() !== iterator)return false;\nvar a = '', b = '', c = '', step;\nwhile(!(step = iterator.next()).done){\n  a += step.value[0];\n  b += step.value[1];\n  c += step.value[2];\n}\nreturn a === '1a2b'\n  && b === '12'\n  && c === 'ab';\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -16265,8 +16265,8 @@ try {
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("134");try{return Function("asyncTestPassed","\nif (typeof String.prototype.matchAll !== 'function') return false;\ntry {\n  '11a2bb'.matchAll(/(\\d)(\\D)/);\n} catch (e) {\n  return true;\n}\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("134");return Function("asyncTestPassed","'use strict';"+"\nif (typeof String.prototype.matchAll !== 'function') return false;\ntry {\n  '11a2bb'.matchAll(/(\\d)(\\D)/);\n} catch (e) {\n  return true;\n}\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -16378,8 +16378,8 @@ try {
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-BigInt"><span><a class="anchor" href="#test-BigInt">&#xA7;</a><a href="https://github.com/tc39/proposal-bigint">BigInt</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/8</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/8</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/8</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/8</td>
@@ -16494,8 +16494,8 @@ return (1n + 2n) === 3n;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("136");try{return Function("asyncTestPassed","\nreturn (1n + 2n) === 3n;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("136");return Function("asyncTestPassed","'use strict';"+"\nreturn (1n + 2n) === 3n;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -16610,8 +16610,8 @@ return BigInt(&quot;3&quot;) === 3n;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("137");try{return Function("asyncTestPassed","\nreturn BigInt(\"3\") === 3n;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("137");return Function("asyncTestPassed","'use strict';"+"\nreturn BigInt(\"3\") === 3n;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -16726,8 +16726,8 @@ return typeof BigInt.asUintN === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("138");try{return Function("asyncTestPassed","\nreturn typeof BigInt.asUintN === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("138");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof BigInt.asUintN === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -16842,8 +16842,8 @@ return typeof BigInt.asIntN === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("139");try{return Function("asyncTestPassed","\nreturn typeof BigInt.asIntN === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("139");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof BigInt.asIntN === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -16961,8 +16961,8 @@ return view[0] === -0x8000000000000000n;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("140");try{return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new BigInt64Array(buffer);\nview[0] = 0x8000000000000000n;\nreturn view[0] === -0x8000000000000000n;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("140");return Function("asyncTestPassed","'use strict';"+"\nvar buffer = new ArrayBuffer(64);\nvar view = new BigInt64Array(buffer);\nview[0] = 0x8000000000000000n;\nreturn view[0] === -0x8000000000000000n;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17080,8 +17080,8 @@ return view[0] === 0n;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("141");try{return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new BigUint64Array(buffer);\nview[0] = 0x10000000000000000n;\nreturn view[0] === 0n;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("141");return Function("asyncTestPassed","'use strict';"+"\nvar buffer = new ArrayBuffer(64);\nvar view = new BigUint64Array(buffer);\nview[0] = 0x10000000000000000n;\nreturn view[0] === 0n;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17199,8 +17199,8 @@ return view.getBigInt64(0) === 1n;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("142");try{return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setBigInt64(0, 1n);\nreturn view.getBigInt64(0) === 1n;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("142");return Function("asyncTestPassed","'use strict';"+"\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setBigInt64(0, 1n);\nreturn view.getBigInt64(0) === 1n;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17318,8 +17318,8 @@ return view.getBigUint64(0) === 1n;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("143");try{return Function("asyncTestPassed","\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setBigUint64(0, 1n);\nreturn view.getBigUint64(0) === 1n;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("143");return Function("asyncTestPassed","'use strict';"+"\nvar buffer = new ArrayBuffer(64);\nvar view = new DataView(buffer);\nview.setBigUint64(0, 1n);\nreturn view.getBigUint64(0) === 1n;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17445,8 +17445,8 @@ Promise.allSettled([
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("144");try{return Function("asyncTestPassed","\nPromise.allSettled([\n  Promise.resolve(1),\n  Promise.reject(2),\n  Promise.resolve(3)\n]).then(it => {\n  if (\n    it.length === 3 &&\n    it[0].status === 'fulfilled' && it[0].value === 1 &&\n    it[1].status === 'rejected' && it[1].reason === 2 &&\n    it[2].status === 'fulfilled' && it[2].value === 3\n  ) asyncTestPassed();\n});\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("144");return Function("asyncTestPassed","'use strict';"+"\nPromise.allSettled([\n  Promise.resolve(1),\n  Promise.reject(2),\n  Promise.resolve(3)\n]).then(it => {\n  if (\n    it.length === 3 &&\n    it[0].status === 'fulfilled' && it[0].value === 1 &&\n    it[1].status === 'rejected' && it[1].reason === 2 &&\n    it[2].status === 'fulfilled' && it[2].value === 3\n  ) asyncTestPassed();\n});\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17558,8 +17558,8 @@ Promise.allSettled([
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-globalThis"><span><a class="anchor" href="#test-globalThis">&#xA7;</a><a href="https://github.com/tc39/proposal-global">globalThis</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
@@ -17676,8 +17676,8 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("146");try{return Function("asyncTestPassed","\nvar actualGlobal = Function('return this')();\nactualGlobal.__system_global_test__ = 42;\nreturn typeof globalThis === 'object' && globalThis && globalThis === actualGlobal && !globalThis.lacksGlobalThis && globalThis.__system_global_test__ === 42;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("146");return Function("asyncTestPassed","'use strict';"+"\nvar actualGlobal = Function('return this')();\nactualGlobal.__system_global_test__ = 42;\nreturn typeof globalThis === 'object' && globalThis && globalThis === actualGlobal && !globalThis.lacksGlobalThis && globalThis.__system_global_test__ === 42;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17798,8 +17798,8 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("147");try{return Function("asyncTestPassed","\nvar actualGlobal = Function('return this')();\nif (typeof globalThis !== 'object') { return false; }\nif (!('globalThis' in actualGlobal)) { return false; }\nif (Object.prototype.propertyIsEnumerable.call(actualGlobal, 'globalThis')) { return false; }\n\nvar descriptor = Object.getOwnPropertyDescriptor(actualGlobal, 'globalThis');\nreturn descriptor.value === actualGlobal && !descriptor.enumerable && descriptor.configurable && descriptor.writable;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("147");return Function("asyncTestPassed","'use strict';"+"\nvar actualGlobal = Function('return this')();\nif (typeof globalThis !== 'object') { return false; }\nif (!('globalThis' in actualGlobal)) { return false; }\nif (Object.prototype.propertyIsEnumerable.call(actualGlobal, 'globalThis')) { return false; }\n\nvar descriptor = Object.getOwnPropertyDescriptor(actualGlobal, 'globalThis');\nreturn descriptor.value === actualGlobal && !descriptor.enumerable && descriptor.configurable && descriptor.writable;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17911,8 +17911,8 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-optional_chaining_operator_(?.)"><span><a class="anchor" href="#test-optional_chaining_operator_(?.)">&#xA7;</a><a href="https://github.com/tc39/proposal-optional-chaining">optional chaining operator (?.)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/4</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/4</td>
@@ -18029,8 +18029,8 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("149");try{return Function("asyncTestPassed","\nvar foo = { baz: 42 };\nvar bar = null;\nreturn foo?.baz === 42 && bar?.baz === void undefined;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("149");return Function("asyncTestPassed","'use strict';"+"\nvar foo = { baz: 42 };\nvar bar = null;\nreturn foo?.baz === 42 && bar?.baz === void undefined;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -18147,8 +18147,8 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("150");try{return Function("asyncTestPassed","\nvar foo = { baz: 42 };\nvar bar = null;\nreturn foo?.['baz'] === 42 && bar?.['baz'] === void undefined;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("150");return Function("asyncTestPassed","'use strict';"+"\nvar foo = { baz: 42 };\nvar bar = null;\nreturn foo?.['baz'] === 42 && bar?.['baz'] === void undefined;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -18265,8 +18265,8 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("151");try{return Function("asyncTestPassed","\nvar foo = { baz: function () { return this.value; }, value: 42 };\nvar bar = null;\nreturn foo?.baz() === 42 && bar?.baz() === void undefined;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("151");return Function("asyncTestPassed","'use strict';"+"\nvar foo = { baz: function () { return this.value; }, value: 42 };\nvar bar = null;\nreturn foo?.baz() === 42 && bar?.baz() === void undefined;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -18385,8 +18385,8 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
         ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("152");try{return Function("asyncTestPassed","\nvar foo = { baz: function () { return 42; } };\nvar bar = {};\nfunction baz() { return 42; };\nvar n;\nreturn foo.baz?.() === 42 && bar.baz?.() === void undefined && baz?.() === 42 && n?.() === void undefined;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("152");return Function("asyncTestPassed","'use strict';"+"\nvar foo = { baz: function () { return 42; } };\nvar bar = {};\nfunction baz() { return 42; };\nvar n;\nreturn foo.baz?.() === 42 && bar.baz?.() === void undefined && baz?.() === 42 && n?.() === void undefined;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -18506,8 +18506,8 @@ return (null ?? 42) === 42 &amp;&amp;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("153");try{return Function("asyncTestPassed","\nreturn (null ?? 42) === 42 &&\n  (undefined ?? 42) === 42 &&\n  (false ?? 42) === false &&\n  ('' ?? 42) === '' &&\n  (0 ?? 42) === 0 &&\n  isNaN(NaN ?? 42);\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("153");return Function("asyncTestPassed","'use strict';"+"\nreturn (null ?? 42) === 42 &&\n  (undefined ?? 42) === 42 &&\n  (false ?? 42) === false &&\n  ('' ?? 42) === '' &&\n  (0 ?? 42) === 0 &&\n  isNaN(NaN ?? 42);\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -131,8 +131,8 @@
 
           <!-- TABLE HEADERS -->
         <th class="platform tr compiler obsolete" data-browser="tr"><a href="#tr" class="browser-name"><abbr title="Traceur">Traceur</abbr></a></th>
-<th class="platform babel6corejs2 compiler" data-browser="babel6corejs2"><a href="#babel6corejs2" class="browser-name"><abbr title="Babel 6.5 + core-js 2.5">Babel 6 +<br><nobr>core-js 2</nobr></abbr></a></th>
-<th class="platform babel7corejs2 compiler" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
+<th class="platform babel6corejs2 compiler obsolete" data-browser="babel6corejs2"><a href="#babel6corejs2" class="browser-name"><abbr title="Babel 6.5 + core-js 2.5">Babel 6 +<br><nobr>core-js 2</nobr></abbr></a></th>
+<th class="platform babel7corejs2 compiler obsolete" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform closure compiler obsolete" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure 2018.02</abbr></a></th>
 <th class="platform closure20190215 compiler obsolete" data-browser="closure20190215"><a href="#closure20190215" class="browser-name"><abbr title="Closure Compiler v20190215">Closure 2019.02</abbr></a></th>
@@ -248,8 +248,8 @@
 </tr>
 <tr class="supertest" significance="1"><td id="test-WeakReferences"><span><a class="anchor" href="#test-WeakReferences">&#xA7;</a><a href="https://github.com/tc39/proposal-weakrefs">WeakReferences</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
@@ -364,8 +364,8 @@ return weakref.deref() === O;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("1");try{return Function("asyncTestPassed","\nvar O = {};\nvar weakref = new WeakRef(O);\nreturn weakref.deref() === O;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("1");return Function("asyncTestPassed","'use strict';"+"\nvar O = {};\nvar weakref = new WeakRef(O);\nreturn weakref.deref() === O;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -479,8 +479,8 @@ return Object.getPrototypeOf(fg) === FinalizationGroup.prototype;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("2");try{return Function("asyncTestPassed","\nvar fg = new FinalizationGroup(function() {});\nreturn Object.getPrototypeOf(fg) === FinalizationGroup.prototype;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("2");return Function("asyncTestPassed","'use strict';"+"\nvar fg = new FinalizationGroup(function() {});\nreturn Object.getPrototypeOf(fg) === FinalizationGroup.prototype;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -590,8 +590,8 @@ return Object.getPrototypeOf(fg) === FinalizationGroup.prototype;
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-instance_class_fields"><span><a class="anchor" href="#test-instance_class_fields">&#xA7;</a><a href="https://github.com/tc39/proposal-class-fields">instance class fields</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/4</td>
@@ -707,8 +707,8 @@ return new C().x === &apos;x&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("4");try{return Function("asyncTestPassed","\nclass C {\n  x = 'x';\n}\nreturn new C().x === 'x';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("4");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  x = 'x';\n}\nreturn new C().x === 'x';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -830,8 +830,8 @@ return new C(42).x() === 42;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("5");try{return Function("asyncTestPassed","\nclass C {\n  #x;\n  constructor(x){\n    this.#x = x;\n  }\n  x(){\n    return this.#x;\n  }\n}\nreturn new C(42).x() === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("5");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  #x;\n  constructor(x){\n    this.#x = x;\n  }\n  x(){\n    return this.#x;\n  }\n}\nreturn new C(42).x() === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -950,8 +950,8 @@ return new C().x() === 42;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("6");try{return Function("asyncTestPassed","\nclass C {\n  #x = 42;\n  x(){\n    return this.#x;\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("6");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  #x = 42;\n  x(){\n    return this.#x;\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -1067,8 +1067,8 @@ return new C().x === 42;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\nclass C {\n  ['x'] = 42;\n}\nreturn new C().x === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  ['x'] = 42;\n}\nreturn new C().x === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -1178,8 +1178,8 @@ return new C().x === 42;
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-static_class_fields"><span><a class="anchor" href="#test-static_class_fields">&#xA7;</a><a href="https://github.com/tc39/proposal-static-class-features/">static class fields</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
@@ -1295,8 +1295,8 @@ return C.x === &apos;x&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("9");try{return Function("asyncTestPassed","\nclass C {\n  static x = 'x';\n}\nreturn C.x === 'x';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("9");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  static x = 'x';\n}\nreturn C.x === 'x';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="tr">Yes</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -1415,8 +1415,8 @@ return new C().x() === 42;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("10");try{return Function("asyncTestPassed","\nclass C {\n  static #x = 42;\n  x(){\n    return C.#x;\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("10");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  static #x = 42;\n  x(){\n    return C.#x;\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -1532,8 +1532,8 @@ return C.x === 42;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("11");try{return Function("asyncTestPassed","\nclass C {\n  static ['x'] = 42;\n}\nreturn C.x === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("11");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  static ['x'] = 42;\n}\nreturn C.x === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -1647,8 +1647,8 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("12");try{return Function("asyncTestPassed","\nreturn 1_000_000.000_001 === 1000000.000001 &&\n  0b1010_0001_1000_0101 === 0b1010000110000101;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("12");return Function("asyncTestPassed","'use strict';"+"\nreturn 1_000_000.000_001 === 1000000.000001 &&\n  0b1010_0001_1000_0101 === 0b1010000110000101;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -1761,8 +1761,8 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("13");try{return Function("asyncTestPassed","\nreturn 'q=query+string+parameters'.replaceAll('+', ' ') === 'q=query string parameters';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("13");return Function("asyncTestPassed","'use strict';"+"\nreturn 'q=query+string+parameters'.replaceAll('+', ' ') === 'q=query string parameters';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -1881,8 +1881,8 @@ Promise.any([
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("14");try{return Function("asyncTestPassed","\nPromise.any([\n  Promise.resolve(1),\n  Promise.reject(2),\n  Promise.resolve(3)\n]).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("14");return Function("asyncTestPassed","'use strict';"+"\nPromise.any([\n  Promise.resolve(1),\n  Promise.reject(2),\n  Promise.resolve(3)\n]).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -1992,8 +1992,8 @@ Promise.any([
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Legacy_RegExp_features_in_JavaScript"><span><a class="anchor" href="#test-Legacy_RegExp_features_in_JavaScript">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-legacy-features">Legacy RegExp features in JavaScript</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
@@ -2112,8 +2112,8 @@ re.exec('x');
 return RegExp.lastMatch === 'x';
       }())</script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -2234,8 +2234,8 @@ for (var i = 1; i < 10; i++) {
 return true;
       }())</script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -2356,8 +2356,8 @@ return result === &apos;tromple&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");try{return Function("asyncTestPassed","\nvar result;\nfunction* generator() {\n  result = function.sent;\n}\nvar iter = generator();\niter.next('tromple');\nreturn result === 'tromple';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("18");return Function("asyncTestPassed","'use strict';"+"\nvar result;\nfunction* generator() {\n  result = function.sent;\n}\nvar iter = generator();\niter.next('tromple');\nreturn result === 'tromple';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -2467,8 +2467,8 @@ return result === &apos;tromple&apos;;
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Class_and_Property_Decorators"><span><a class="anchor" href="#test-Class_and_Property_Decorators">&#xA7;</a><a href="https://github.com/tc39/proposal-decorators">Class and Property Decorators</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/1</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/1</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/1</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/1</td>
@@ -2589,8 +2589,8 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("20");try{return Function("asyncTestPassed","\nclass A {\n  @nonconf\n  get B() {}\n}\nfunction nonconf(target, name, descriptor) {\n  descriptor.configurable = false;\n  return descriptor;\n}\nreturn Object.getOwnPropertyDescriptor(A.prototype, \"B\").configurable === false;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("20");return Function("asyncTestPassed","'use strict';"+"\nclass A {\n  @nonconf\n  get B() {}\n}\nfunction nonconf(target, name, descriptor) {\n  descriptor.configurable = false;\n  return descriptor;\n}\nreturn Object.getOwnPropertyDescriptor(A.prototype, \"B\").configurable === false;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No<a href="#babel-decorators-legacy-note"><sup>[17]</sup></a></td>
-<td class="no" data-browser="babel7corejs2">No<a href="#babel-decorators-legacy-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="babel6corejs2">No<a href="#babel-decorators-legacy-note"><sup>[17]</sup></a></td>
+<td class="no obsolete" data-browser="babel7corejs2">No<a href="#babel-decorators-legacy-note"><sup>[17]</sup></a></td>
 <td class="no" data-browser="babel7corejs3">No<a href="#babel-decorators-legacy-note"><sup>[17]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -2706,8 +2706,8 @@ return typeof Realm === &quot;function&quot;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("21");try{return Function("asyncTestPassed","\nreturn typeof Realm === \"function\"\n  && [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\", \"indirectEval\", \"initGlobal\", \"nonEval\"].every(function(key){\n    return key in Realm.prototype;\n  });\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("21");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Realm === \"function\"\n  && [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\", \"indirectEval\", \"initGlobal\", \"nonEval\"].every(function(key){\n    return key in Realm.prototype;\n  });\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -2817,8 +2817,8 @@ return typeof Realm === &quot;function&quot;
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-throw_expressions"><span><a class="anchor" href="#test-throw_expressions">&#xA7;</a><a href="https://github.com/tc39/proposal-throw-expressions">throw expressions</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/4</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/4</td>
@@ -2937,8 +2937,8 @@ try {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("23");try{return Function("asyncTestPassed","\nvar a, b;\ntry {\n  a = 19 || throw 77;\n  b = 88 && throw 23;\n} catch (e) {\n  return a + e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("23");return Function("asyncTestPassed","'use strict';"+"\nvar a, b;\ntry {\n  a = 19 || throw 77;\n  b = 88 && throw 23;\n} catch (e) {\n  return a + e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -3061,8 +3061,8 @@ try {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("24");try{return Function("asyncTestPassed","\nfunction fn (arg = throw 42) {\n  return arg;\n}\n\nif (fn(21) !== 21) return false;\n\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("24");return Function("asyncTestPassed","'use strict';"+"\nfunction fn (arg = throw 42) {\n  return arg;\n}\n\nif (fn(21) !== 21) return false;\n\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -3180,8 +3180,8 @@ try {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("25");try{return Function("asyncTestPassed","\nvar fn = () => throw 42;\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("25");return Function("asyncTestPassed","'use strict';"+"\nvar fn = () => throw 42;\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -3299,8 +3299,8 @@ try {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\ntrue ? 42 : throw 21;\ntry {\n  false ? 42 : throw 21;\n} catch (e) {\n  return e === 21;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\ntrue ? 42 : throw 21;\ntry {\n  false ? 42 : throw 21;\n} catch (e) {\n  return e === 21;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -3410,8 +3410,8 @@ try {
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Set_methods"><span><a class="anchor" href="#test-Set_methods">&#xA7;</a><a href="https://github.com/tc39/proposal-set-methods">Set methods</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/7</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/7</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
@@ -3527,8 +3527,8 @@ return set.size === 2
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));\nreturn set.size === 2\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));\nreturn set.size === 2\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -3645,8 +3645,8 @@ return set.size === 3
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("29");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).union(new Set([2, 3]));\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("29");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).union(new Set([2, 3]));\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -3762,8 +3762,8 @@ return set.size === 2
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).difference(new Set([3, 4]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(2);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).difference(new Set([3, 4]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(2);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -3879,8 +3879,8 @@ return set.size === 2
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -3993,8 +3993,8 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -4107,8 +4107,8 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("33");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("33");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -4221,8 +4221,8 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("34");try{return Function("asyncTestPassed","\nreturn new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("34");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -4332,8 +4332,8 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-ArrayBuffer.prototype.transfer"><span><a class="anchor" href="#test-ArrayBuffer.prototype.transfer">&#xA7;</a><a href="https://github.com/domenic/proposal-arraybuffer-transfer/">ArrayBuffer.prototype.transfer</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
@@ -4449,8 +4449,8 @@ return buffer1.byteLength === 0
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("36");try{return Function("asyncTestPassed","\nconst buffer1 = new Uint8Array([1, 2]).buffer;\nconst buffer2 = buffer1.transfer();\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("36");return Function("asyncTestPassed","'use strict';"+"\nconst buffer1 = new Uint8Array([1, 2]).buffer;\nconst buffer2 = buffer1.transfer();\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -4566,8 +4566,8 @@ return buffer1.byteLength === 0
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("37");try{return Function("asyncTestPassed","\nconst buffer1 = new ArrayBuffer(1024);\nconst buffer2 = buffer1.realloc(256);\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 256;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("37");return Function("asyncTestPassed","'use strict';"+"\nconst buffer1 = new ArrayBuffer(1024);\nconst buffer2 = buffer1.realloc(256);\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 256;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -4677,8 +4677,8 @@ return buffer1.byteLength === 0
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Map.prototype.upsert"><span><a class="anchor" href="#test-Map.prototype.upsert">&#xA7;</a><a href="https://github.com/tc39/proposal-upsert">Map.prototype.upsert</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
@@ -4794,8 +4794,8 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("39");try{return Function("asyncTestPassed","\nconst map = new Map([['a', 1]]);\nif (map.upsert('a', it => 2, () => 3) !== 2) return false;\nif (map.upsert('b', it => 2, () => 3) !== 3) return false;\nreturn Array.from(map).join() === 'a,2,b,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("39");return Function("asyncTestPassed","'use strict';"+"\nconst map = new Map([['a', 1]]);\nif (map.upsert('a', it => 2, () => 3) !== 2) return false;\nif (map.upsert('b', it => 2, () => 3) !== 3) return false;\nreturn Array.from(map).join() === 'a,2,b,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -4912,8 +4912,8 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("40");try{return Function("asyncTestPassed","\nconst a = {}, b = {};\nconst map = new WeakMap([[a, 1]]);\nif (map.upsert(a, it => 2, () => 3) !== 2) return false;\nif (map.upsert(b, it => 2, () => 3) !== 3) return false;\nreturn map.get(a) === 2 && map.get(b) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("40");return Function("asyncTestPassed","'use strict';"+"\nconst a = {}, b = {};\nconst map = new WeakMap([[a, 1]]);\nif (map.upsert(a, it => 2, () => 3) !== 2) return false;\nif (map.upsert(b, it => 2, () => 3) !== 3) return false;\nreturn map.get(a) === 2 && map.get(b) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -5027,8 +5027,8 @@ return !Array.isTemplateObject([])
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("41");try{return Function("asyncTestPassed","\nreturn !Array.isTemplateObject([])\n  && Array.isTemplateObject((it => it)`a{1}c`);\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("41");return Function("asyncTestPassed","'use strict';"+"\nreturn !Array.isTemplateObject([])\n  && Array.isTemplateObject((it => it)`a{1}c`);\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -5138,8 +5138,8 @@ return !Array.isTemplateObject([])
 </tr>
 <tr class="supertest" significance="1"><td id="test-Iterator_Helpers"><span><a class="anchor" href="#test-Iterator_Helpers">&#xA7;</a><a href="https://github.com/tc39/proposal-iterator-helpers">Iterator Helpers</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/35</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/35</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/35</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">35/35</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/35</td>
@@ -5252,8 +5252,8 @@ return [1, 2, 3].values() instanceof Iterator;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("43");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values() instanceof Iterator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("43");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values() instanceof Iterator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -5368,8 +5368,8 @@ return instance[Symbol.iterator]() === instance;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("44");try{return Function("asyncTestPassed","\nclass Class extends Iterator { }\nconst instance = new Class();\nreturn instance[Symbol.iterator]() === instance;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("44");return Function("asyncTestPassed","'use strict';"+"\nclass Class extends Iterator { }\nconst instance = new Class();\nreturn instance[Symbol.iterator]() === instance;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -5485,8 +5485,8 @@ return &apos;next&apos; in iterator
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("45");try{return Function("asyncTestPassed","\nconst iterator = Iterator.from([1, 2, 3]);\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("45");return Function("asyncTestPassed","'use strict';"+"\nconst iterator = Iterator.from([1, 2, 3]);\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -5607,8 +5607,8 @@ return &apos;next&apos; in iterator
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("46");try{return Function("asyncTestPassed","\nconst iterator = Iterator.from({\n  i: 0,\n  next() {\n    return { value: ++this.i, done: this.i > 3 };\n  }\n});\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("46");return Function("asyncTestPassed","'use strict';"+"\nconst iterator = Iterator.from({\n  i: 0,\n  next() {\n    return { value: ++this.i, done: this.i > 3 };\n  }\n});\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -5721,8 +5721,8 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("47");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().asIndexedPairs()).join() === '0,1,1,2,2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("47");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().asIndexedPairs()).join() === '0,1,1,2,2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -5835,8 +5835,8 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("48");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().drop(1)).join() === '2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("48");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().drop(1)).join() === '2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -5949,8 +5949,8 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("49");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().every(it => typeof it === 'number');\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("49");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().every(it => typeof it === 'number');\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6063,8 +6063,8 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("50");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().filter(it => it % 2)).join() === '1,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("50");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().filter(it => it % 2)).join() === '1,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6177,8 +6177,8 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("51");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().find(it => it % 2) === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("51");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().find(it => it % 2) === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6291,8 +6291,8 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("52");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().flatMap(it => [it, 0])).join() === '1,0,2,0,3,0';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("52");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().flatMap(it => [it, 0])).join() === '1,0,2,0,3,0';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6407,8 +6407,8 @@ return result === &apos;123&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("53");try{return Function("asyncTestPassed","\nlet result = '';\n[1, 2, 3].values().forEach(it => result += it);\nreturn result === '123';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("53");return Function("asyncTestPassed","'use strict';"+"\nlet result = '';\n[1, 2, 3].values().forEach(it => result += it);\nreturn result === '123';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6521,8 +6521,8 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("54");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().map(it => it * it)).join() === '1,4,9';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("54");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().map(it => it * it)).join() === '1,4,9';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6635,8 +6635,8 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("55");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().reduce((a, b) => a + b) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("55");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().reduce((a, b) => a + b) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6749,8 +6749,8 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("56");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().some(it => typeof it === 'number');\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("56");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().some(it => typeof it === 'number');\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6863,8 +6863,8 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("57");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().take(2)).join() === '1,2';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("57");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().take(2)).join() === '1,2';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -6978,8 +6978,8 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("58");try{return Function("asyncTestPassed","\nconst array = [1, 2, 3].values().toArray();\nreturn Array.isArray(array) && array.join() === '1,2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("58");return Function("asyncTestPassed","'use strict';"+"\nconst array = [1, 2, 3].values().toArray();\nreturn Array.isArray(array) && array.join() === '1,2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7092,8 +7092,8 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("59");try{return Function("asyncTestPassed","\nreturn Iterator.prototype[Symbol.toStringTag] === 'Iterator';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("59");return Function("asyncTestPassed","'use strict';"+"\nreturn Iterator.prototype[Symbol.toStringTag] === 'Iterator';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7206,8 +7206,8 @@ return (async function*() {})() instanceof AsyncIterator;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("60");try{return Function("asyncTestPassed","\nreturn (async function*() {})() instanceof AsyncIterator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("60");return Function("asyncTestPassed","'use strict';"+"\nreturn (async function*() {})() instanceof AsyncIterator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7322,8 +7322,8 @@ return instance[Symbol.asyncIterator]() === instance;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("61");try{return Function("asyncTestPassed","\nclass Class extends AsyncIterator { }\nconst instance = new Class();\nreturn instance[Symbol.asyncIterator]() === instance;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("61");return Function("asyncTestPassed","'use strict';"+"\nclass Class extends AsyncIterator { }\nconst instance = new Class();\nreturn instance[Symbol.asyncIterator]() === instance;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7448,8 +7448,8 @@ toArray(iterator).then(it =&gt; {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("62");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from(async function*() { yield * [1, 2, 3] }());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("62");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from(async function*() { yield * [1, 2, 3] }());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7574,8 +7574,8 @@ toArray(iterator).then(it =&gt; {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("63");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3]);\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("63");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3]);\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7700,8 +7700,8 @@ toArray(iterator).then(it =&gt; {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("64");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3].values());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("64");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3].values());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7822,8 +7822,8 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("65");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it => {\n  if (it.join() === '0,1,1,2,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("65");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it => {\n  if (it.join() === '0,1,1,2,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -7944,8 +7944,8 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("66");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it => {\n  if (it.join() === '2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("66");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it => {\n  if (it.join() === '2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -8060,8 +8060,8 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("67");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().every(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("67");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().every(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -8182,8 +8182,8 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("68");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().filter(it => it % 2)).then(it => {\n  if (it.join() === '1,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("68");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().filter(it => it % 2)).then(it => {\n  if (it.join() === '1,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -8298,8 +8298,8 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("69");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().find(it => it % 2).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("69");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().find(it => it % 2).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -8420,8 +8420,8 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("70");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().flatMap(it => [it, 0])).then(it => {\n  if (it.join() === '1,0,2,0,3,0') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("70");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().flatMap(it => [it, 0])).then(it => {\n  if (it.join() === '1,0,2,0,3,0') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -8537,8 +8537,8 @@ let result = &apos;&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("71");try{return Function("asyncTestPassed","\nlet result = '';\n(async function*() { yield * [1, 2, 3] })().forEach(it => result += it).then(() => {\n  if (result === '123') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("71");return Function("asyncTestPassed","'use strict';"+"\nlet result = '';\n(async function*() { yield * [1, 2, 3] })().forEach(it => result += it).then(() => {\n  if (result === '123') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -8659,8 +8659,8 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("72");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().map(it => it * it)).then(it => {\n  if (it.join() === '1,4,9') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("72");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().map(it => it * it)).then(it => {\n  if (it.join() === '1,4,9') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -8775,8 +8775,8 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("73");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().reduce((a, b) => a + b).then(it => {\n  if (it === 6) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("73");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().reduce((a, b) => a + b).then(it => {\n  if (it === 6) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -8891,8 +8891,8 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("74");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().some(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("74");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().some(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -9013,8 +9013,8 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("75");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it => {\n  if (it.join() === '1,2') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("75");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it => {\n  if (it.join() === '1,2') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -9129,8 +9129,8 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("76");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().toArray().then(it => {\n  if (Array.isArray(it) && it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("76");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().toArray().then(it => {\n  if (Array.isArray(it) && it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -9243,8 +9243,8 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("77");try{return Function("asyncTestPassed","\nreturn AsyncIterator.prototype[Symbol.toStringTag] === 'AsyncIterator';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("77");return Function("asyncTestPassed","'use strict';"+"\nreturn AsyncIterator.prototype[Symbol.toStringTag] === 'AsyncIterator';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -9362,8 +9362,8 @@ return do {
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("78");try{return Function("asyncTestPassed","\nreturn do {\n  let x = 23;\n  x + 19;\n} === 42;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("78");return Function("asyncTestPassed","'use strict';"+"\nreturn do {\n  let x = 23;\n  x + 19;\n} === 42;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -9473,8 +9473,8 @@ return do {
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Observable"><span><a class="anchor" href="#test-Observable">&#xA7;</a><a href="https://github.com/tc39/proposal-observable">Observable</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/7</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="1">7/7</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
@@ -9587,8 +9587,8 @@ return typeof Observable !== &apos;undefined&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("80");try{return Function("asyncTestPassed","\nreturn typeof Observable !== 'undefined';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("80");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Observable !== 'undefined';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -9701,8 +9701,8 @@ return typeof Symbol.observable === &apos;symbol&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("81");try{return Function("asyncTestPassed","\nreturn typeof Symbol.observable === 'symbol';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("81");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Symbol.observable === 'symbol';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -9815,8 +9815,8 @@ return &apos;subscribe&apos; in Observable.prototype;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("82");try{return Function("asyncTestPassed","\nreturn 'subscribe' in Observable.prototype;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("82");return Function("asyncTestPassed","'use strict';"+"\nreturn 'subscribe' in Observable.prototype;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -9939,8 +9939,8 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("83");try{return Function("asyncTestPassed","\nif(!(new Observable(function(){}) instanceof Observable))return false;\n\nvar nonCallableCheckPassed,\n    primitiveCheckPassed,\n    newCheckPassed;\n\ntry { new Observable({ }) } catch(e) { nonCallableCheckPassed = true }\ntry { new Observable(false) } catch(e) { primitiveCheckPassed = true }\ntry { Observable(function() { }) } catch(e) { newCheckPassed = true }\n\nreturn nonCallableCheckPassed && primitiveCheckPassed && newCheckPassed;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("83");return Function("asyncTestPassed","'use strict';"+"\nif(!(new Observable(function(){}) instanceof Observable))return false;\n\nvar nonCallableCheckPassed,\n    primitiveCheckPassed,\n    newCheckPassed;\n\ntry { new Observable({ }) } catch(e) { nonCallableCheckPassed = true }\ntry { new Observable(false) } catch(e) { primitiveCheckPassed = true }\ntry { Observable(function() { }) } catch(e) { newCheckPassed = true }\n\nreturn nonCallableCheckPassed && primitiveCheckPassed && newCheckPassed;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -10054,8 +10054,8 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("84");try{return Function("asyncTestPassed","\nvar o = new Observable(function() { });\nreturn Symbol.observable in Observable.prototype && o[Symbol.observable]() === o;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("84");return Function("asyncTestPassed","'use strict';"+"\nvar o = new Observable(function() { });\nreturn Symbol.observable in Observable.prototype && o[Symbol.observable]() === o;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -10168,8 +10168,8 @@ return Observable.of(1, 2, 3) instanceof Observable;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("85");try{return Function("asyncTestPassed","\nreturn Observable.of(1, 2, 3) instanceof Observable;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("85");return Function("asyncTestPassed","'use strict';"+"\nreturn Observable.of(1, 2, 3) instanceof Observable;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -10282,8 +10282,8 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("86");try{return Function("asyncTestPassed","\nreturn (Observable.from([1,2,3,4]) instanceof Observable) && (Observable.from(new Set([1, 2, 3])) instanceof Observable);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("86");return Function("asyncTestPassed","'use strict';"+"\nreturn (Observable.from([1,2,3,4]) instanceof Observable) && (Observable.from(new Set([1, 2, 3])) instanceof Observable);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -10397,8 +10397,8 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("87");try{return Function("asyncTestPassed","\nreturn typeof Reflect.Realm.immutableRoot === 'function'\n  && typeof Reflect.Realm.prototype.spawn === 'function';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("87");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.Realm.immutableRoot === 'function'\n  && typeof Reflect.Realm.prototype.spawn === 'function';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -10515,8 +10515,8 @@ return Math.signbit(NaN) === false
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("88");try{return Function("asyncTestPassed","\nreturn Math.signbit(NaN) === false\n  && Math.signbit(-0) === true\n  && Math.signbit(0) === false\n  && Math.signbit(-42) === true\n  && Math.signbit(42) === false;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("88");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.signbit(NaN) === false\n  && Math.signbit(-0) === true\n  && Math.signbit(0) === false\n  && Math.signbit(-42) === true\n  && Math.signbit(42) === false;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -10626,8 +10626,8 @@ return Math.signbit(NaN) === false
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Math_extensions_proposal"><span><a class="anchor" href="#test-Math_extensions_proposal">&#xA7;</a><a href="https://github.com/rwaldron/proposal-math-extensions">Math extensions proposal</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/7</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="1">7/7</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
@@ -10742,8 +10742,8 @@ return Math.clamp(2, 4, 6) === 4
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("90");try{return Function("asyncTestPassed","\nreturn Math.clamp(2, 4, 6) === 4\n  && Math.clamp(4, 2, 6) === 4\n  && Math.clamp(6, 2, 4) === 4;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("90");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.clamp(2, 4, 6) === 4\n  && Math.clamp(4, 2, 6) === 4\n  && Math.clamp(6, 2, 4) === 4;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -10856,8 +10856,8 @@ return Math.DEG_PER_RAD === Math.PI / 180;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("91");try{return Function("asyncTestPassed","\nreturn Math.DEG_PER_RAD === Math.PI / 180;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("91");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.DEG_PER_RAD === Math.PI / 180;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -10971,8 +10971,8 @@ return Math.degrees(Math.PI / 2) === 90
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("92");try{return Function("asyncTestPassed","\nreturn Math.degrees(Math.PI / 2) === 90\n  && Math.degrees(Math.PI) === 180;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("92");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.degrees(Math.PI / 2) === 90\n  && Math.degrees(Math.PI) === 180;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -11085,8 +11085,8 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("93");try{return Function("asyncTestPassed","\nreturn Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) / (2 - 1) + 1);\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("93");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) / (2 - 1) + 1);\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -11199,8 +11199,8 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("94");try{return Function("asyncTestPassed","\nreturn Math.RAD_PER_DEG === 180 / Math.PI;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("94");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.RAD_PER_DEG === 180 / Math.PI;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -11314,8 +11314,8 @@ return Math.radians(90) === Math.PI / 2
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("95");try{return Function("asyncTestPassed","\nreturn Math.radians(90) === Math.PI / 2\n  && Math.radians(180) === Math.PI;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("95");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.radians(90) === Math.PI / 2\n  && Math.radians(180) === Math.PI;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -11428,8 +11428,8 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
     ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("96");try{return Function("asyncTestPassed","\nreturn Math.scale(0, 3, 5, 8, 10) === 5;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("96");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.scale(0, 3, 5, 8, 10) === 5;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -11539,8 +11539,8 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Promise.try"><span><a class="anchor" href="#test-Promise.try">&#xA7;</a><a href="https://github.com/tc39/proposal-promise-try">Promise.try</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/7</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="1">7/7</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">7/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/7</td>
@@ -11653,8 +11653,8 @@ return typeof Promise.try === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("98");try{return Function("asyncTestPassed","\nreturn typeof Promise.try === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("98");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Promise.try === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -11767,8 +11767,8 @@ return Promise.try(function () {}) instanceof Promise;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("99");try{return Function("asyncTestPassed","\nreturn Promise.try(function () {}) instanceof Promise;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("99");return Function("asyncTestPassed","'use strict';"+"\nreturn Promise.try(function () {}) instanceof Promise;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -11883,8 +11883,8 @@ return score === 1;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("100");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function () { score++ });\nreturn score === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("100");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function () { score++ });\nreturn score === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -12004,8 +12004,8 @@ Promise.try(function() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("101");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return 'foo';\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("101");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return 'foo';\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -12125,8 +12125,8 @@ Promise.try(function() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("102");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  throw 'bar';\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("102");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  throw 'bar';\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -12246,8 +12246,8 @@ Promise.try(function() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("103");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.resolve('foo');\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("103");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.resolve('foo');\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -12367,8 +12367,8 @@ Promise.try(function() {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("104");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.reject('bar');\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("104");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.reject('bar');\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -12478,8 +12478,8 @@ Promise.try(function() {
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-`.of`_and_`.from`_on_collection_constructors"><span><a class="anchor" href="#test-`.of`_and_`.from`_on_collection_constructors">&#xA7;</a><a href="https://github.com/tc39/proposal-setmap-offrom">`.of` and `.from` on collection constructors</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/8</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="1">8/8</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">8/8</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/8</td>
@@ -12595,8 +12595,8 @@ return C.get(A) + C.get(B) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("106");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Map.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("106");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Map.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -12714,8 +12714,8 @@ return C.get(A) + C.get(B) === 5;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("107");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Map.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("107");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Map.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -12831,8 +12831,8 @@ return C.has(A) + C.has(B);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("108");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Set.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("108");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Set.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -12948,8 +12948,8 @@ return C.has(3) + C.has(4);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("109");try{return Function("asyncTestPassed","\nvar C = Set.from([1, 2], function (it) {\n  return it + 2;\n});\nreturn C.has(3) + C.has(4);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("109");return Function("asyncTestPassed","'use strict';"+"\nvar C = Set.from([1, 2], function (it) {\n  return it + 2;\n});\nreturn C.has(3) + C.has(4);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -13065,8 +13065,8 @@ return C.get(A) + C.get(B) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("110");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakMap.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("110");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakMap.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -13184,8 +13184,8 @@ return C.get(A) + C.get(B) === 5;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("111");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakMap.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("111");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakMap.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -13301,8 +13301,8 @@ return C.has(A) + C.has(B);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("112");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakSet.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("112");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakSet.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -13418,8 +13418,8 @@ return C.has(A) + C.has(B);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("113");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakSet.from([A, B]);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("113");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakSet.from([A, B]);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="yes" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -13544,8 +13544,8 @@ return result === &apos;Hello, hello!&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("114");try{return Function("asyncTestPassed","\nfunction doubleSay (str) {\n  return str + ', ' + str;\n}\nfunction capitalize (str) {\n  return str[0].toUpperCase() + str.slice(1);\n}\n\nvar result = 'hello'\n  |> doubleSay\n  |> capitalize\n  |> _ => _ + '!';\n\nreturn result === 'Hello, hello!';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("114");return Function("asyncTestPassed","'use strict';"+"\nfunction doubleSay (str) {\n  return str + ', ' + str;\n}\nfunction capitalize (str) {\n  return str[0].toUpperCase() + str.slice(1);\n}\n\nvar result = 'hello'\n  |> doubleSay\n  |> capitalize\n  |> _ => _ + '!';\n\nreturn result === 'Hello, hello!';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="yes" data-browser="babel7corejs2">Yes</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -13662,8 +13662,8 @@ return 123i === &apos;string123number123&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("115");try{return Function("asyncTestPassed","\nfunction i (str, num) {\n  return typeof str + str + typeof num + num;\n}\n\nreturn 123i === 'string123number123';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("115");return Function("asyncTestPassed","'use strict';"+"\nfunction i (str, num) {\n  return typeof str + str + typeof num + num;\n}\n\nreturn 123i === 'string123number123';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -13773,8 +13773,8 @@ return 123i === &apos;string123number123&apos;;
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-partial_application_syntax"><span><a class="anchor" href="#test-partial_application_syntax">&#xA7;</a><a href="https://github.com/tc39/proposal-partial-application">partial application syntax</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/12</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/12</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/12</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/12</td>
@@ -13891,8 +13891,8 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("117");try{return Function("asyncTestPassed","\nfunction f(a, b) {\n  return a + b;\n};\nvar p = f('a', ?);\nreturn p('b') === 'ab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("117");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b) {\n  return a + b;\n};\nvar p = f('a', ?);\nreturn p('b') === 'ab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -14009,8 +14009,8 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("118");try{return Function("asyncTestPassed","\nfunction f(a, b) {\n  return a + b;\n};\nvar p = f(?, 'b');\nreturn p('a') === 'ab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("118");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b) {\n  return a + b;\n};\nvar p = f(?, 'b');\nreturn p('a') === 'ab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -14127,8 +14127,8 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("119");try{return Function("asyncTestPassed","\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f(?, 'b', ?);\nreturn p('a', 'c') === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("119");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f(?, 'b', ?);\nreturn p('a', 'c') === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -14245,8 +14245,8 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("120");try{return Function("asyncTestPassed","\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f('a', ...);\nreturn p('b', 'c') === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("120");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f('a', ...);\nreturn p('b', 'c') === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -14363,8 +14363,8 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("121");try{return Function("asyncTestPassed","\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f(..., 'c');\nreturn p('a', 'b') === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("121");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f(..., 'c');\nreturn p('a', 'b') === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -14481,8 +14481,8 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("122");try{return Function("asyncTestPassed","\nfunction f(a, b, c, d, e) {\n  return a + b + c + d + e;\n};\nvar p = f(..., 'c', ...);\nreturn p('a', 'b') === 'abcab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("122");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c, d, e) {\n  return a + b + c + d + e;\n};\nvar p = f(..., 'c', ...);\nreturn p('a', 'b') === 'abcab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -14599,8 +14599,8 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("123");try{return Function("asyncTestPassed","\nfunction f(a, b, c, d) {\n  return a + b + c;\n};\nvar p = f(?, 'b', ...);\nreturn p('a', 'c', 'd') === 'abcd';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("123");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c, d) {\n  return a + b + c;\n};\nvar p = f(?, 'b', ...);\nreturn p('a', 'c', 'd') === 'abcd';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -14720,8 +14720,8 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("124");try{return Function("asyncTestPassed","\nvar f = function() {\n  throw new Error();\n};\nvar p = f(?, 'b');\nf = function(a, b) {\n  return a + b;\n};\nreturn p('a') === 'ab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("124");return Function("asyncTestPassed","'use strict';"+"\nvar f = function() {\n  throw new Error();\n};\nvar p = f(?, 'b');\nf = function(a, b) {\n  return a + b;\n};\nreturn p('a') === 'ab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -14839,8 +14839,8 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("125");try{return Function("asyncTestPassed","\nvar o = {};\nvar p = o.f(?, 'b');\no = { x: 'c', f: function(a, b) {\n  return a + b + this.x;\n} };\nreturn p('a') === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("125");return Function("asyncTestPassed","'use strict';"+"\nvar o = {};\nvar p = o.f(?, 'b');\no = { x: 'c', f: function(a, b) {\n  return a + b + this.x;\n} };\nreturn p('a') === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -14957,8 +14957,8 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("126");try{return Function("asyncTestPassed","\nfunction f(a, b) {\n  return a + b + (this === o);\n}\nvar o = { f: f(?, 'b') };\nreturn o.f('a') === 'abfalse';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("126");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b) {\n  return a + b + (this === o);\n}\nvar o = { f: f(?, 'b') };\nreturn o.f('a') === 'abfalse';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -15075,8 +15075,8 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("127");try{return Function("asyncTestPassed","\nfunction F(a, b) {\n  this.x = a + b;\n}\nvar p = new F(?, 'b');\nreturn p('a').x === 'ab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("127");return Function("asyncTestPassed","'use strict';"+"\nfunction F(a, b) {\n  this.x = a + b;\n}\nvar p = new F(?, 'b');\nreturn p('a').x === 'ab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -15193,8 +15193,8 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("128");try{return Function("asyncTestPassed","\nfunction F(a, b, c) {\n  this.x = a + b + c;\n}\nvar p = new F('a', ...);\nreturn p('b', 'c').x === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("128");return Function("asyncTestPassed","'use strict';"+"\nfunction F(a, b, c) {\n  this.x = a + b + c;\n}\nvar p = new F('a', ...);\nreturn p('b', 'c').x === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -15304,8 +15304,8 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object.freeze_and_Object.seal_syntax"><span><a class="anchor" href="#test-Object.freeze_and_Object.seal_syntax">&#xA7;</a><a href="https://github.com/keithamus/object-freeze-seal-syntax">Object.freeze and Object.seal syntax</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/8</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/8</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/8</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/8</td>
@@ -15418,8 +15418,8 @@ return Object.isFrozen({# foo: 42 #});
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("130");try{return Function("asyncTestPassed","\nreturn Object.isFrozen({# foo: 42 #});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("130");return Function("asyncTestPassed","'use strict';"+"\nreturn Object.isFrozen({# foo: 42 #});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -15532,8 +15532,8 @@ return Object.isFrozen([# 42 #]);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("131");try{return Function("asyncTestPassed","\nreturn Object.isFrozen([# 42 #]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("131");return Function("asyncTestPassed","'use strict';"+"\nreturn Object.isFrozen([# 42 #]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -15646,8 +15646,8 @@ return Object.isSealed({| foo: 42 |});
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("132");try{return Function("asyncTestPassed","\nreturn Object.isSealed({| foo: 42 |});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("132");return Function("asyncTestPassed","'use strict';"+"\nreturn Object.isSealed({| foo: 42 |});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -15760,8 +15760,8 @@ return Object.isSealed([| 42 |]);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("133");try{return Function("asyncTestPassed","\nreturn Object.isSealed([| 42 |]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("133");return Function("asyncTestPassed","'use strict';"+"\nreturn Object.isSealed([| 42 |]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -15882,8 +15882,8 @@ try {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("134");try{return Function("asyncTestPassed","\nfunction foo({| bar, baz |}) {\n  return bar + baz;\n}\nif (foo({ bar: 1, baz: 2 }) !== 3) return;\ntry {\n  foo({ bar: 1, fuz: 2 });\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("134");return Function("asyncTestPassed","'use strict';"+"\nfunction foo({| bar, baz |}) {\n  return bar + baz;\n}\nif (foo({ bar: 1, baz: 2 }) !== 3) return;\ntry {\n  foo({ bar: 1, fuz: 2 });\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -16005,8 +16005,8 @@ try {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("135");try{return Function("asyncTestPassed","\nfunction foo({# bar, baz #}) {\n  if (baz === 42) bar = 27;\n  return bar + baz;\n}\nif (foo({ bar: 1, baz: 2 }) !== 3) return;\ntry {\n  foo({ bar: 1, baz: 42 });\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("135");return Function("asyncTestPassed","'use strict';"+"\nfunction foo({# bar, baz #}) {\n  if (baz === 42) bar = 27;\n  return bar + baz;\n}\nif (foo({ bar: 1, baz: 2 }) !== 3) return;\ntry {\n  foo({ bar: 1, baz: 42 });\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -16127,8 +16127,8 @@ try {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("136");try{return Function("asyncTestPassed","\nfunction foo(| bar, baz |) {\n  return bar + baz;\n}\nif (foo(1, 2) !== 3) return;\ntry {\n  foo(1, 2, 3);\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("136");return Function("asyncTestPassed","'use strict';"+"\nfunction foo(| bar, baz |) {\n  return bar + baz;\n}\nif (foo(1, 2) !== 3) return;\ntry {\n  foo(1, 2, 3);\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -16250,8 +16250,8 @@ try {
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("137");try{return Function("asyncTestPassed","\nfunction foo(# bar, baz #) {\n  if (baz === 42) bar = 27;\n  return bar + baz;\n}\nif (foo(1, 2) !== 3) return;\ntry {\n  foo(1, 42);\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("137");return Function("asyncTestPassed","'use strict';"+"\nfunction foo(# bar, baz #) {\n  if (baz === 42) bar = 27;\n  return bar + baz;\n}\nif (foo(1, 2) !== 3) return;\ntry {\n  foo(1, 42);\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -16369,8 +16369,8 @@ return results.length === 3
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("138");try{return Function("asyncTestPassed","\nvar results = [];\nfor (let code of 'a𠮷b'.codePoints()) results.push(code);\nreturn results.length === 3\n  && results[0].codePoint === 97 && results[0].position === 0\n  && results[1].codePoint === 134071 && results[1].position === 1\n  && results[2].codePoint === 98 && results[2].position === 3;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("138");return Function("asyncTestPassed","'use strict';"+"\nvar results = [];\nfor (let code of 'a𠮷b'.codePoints()) results.push(code);\nreturn results.length === 3\n  && results[0].codePoint === 97 && results[0].position === 0\n  && results[1].codePoint === 134071 && results[1].position === 1\n  && results[2].codePoint === 98 && results[2].position === 3;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -16480,8 +16480,8 @@ return results.length === 3
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Getting_last_item_from_array"><span><a class="anchor" href="#test-Getting_last_item_from_array">&#xA7;</a><a href="https://github.com/keithamus/proposal-array-last">Getting last item from array</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
@@ -16594,8 +16594,8 @@ return [1, 2, 3].lastItem === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("140");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].lastItem === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("140");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].lastItem === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -16708,8 +16708,8 @@ return [1, 2, 3].lastIndex === 2;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("141");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].lastIndex === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("141");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].lastIndex === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -16819,8 +16819,8 @@ return [1, 2, 3].lastIndex === 2;
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Collections_methods"><span><a class="anchor" href="#test-Collections_methods">&#xA7;</a><a href="https://github.com/tc39/proposal-collection-methods">Collections methods</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/26</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/26</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/26</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/26</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/26</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">26/26</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/26</td>
@@ -16938,8 +16938,8 @@ return map.size === 2
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("143");try{return Function("asyncTestPassed","\nvar map = Map.groupBy(new Set([1, 2, 3, 4]), it => it % 2)\nreturn map.size === 2\n  && map.get(0)[0] === 2\n  && map.get(0)[1] === 4\n  && map.get(1)[0] === 1\n  && map.get(1)[1] === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("143");return Function("asyncTestPassed","'use strict';"+"\nvar map = Map.groupBy(new Set([1, 2, 3, 4]), it => it % 2)\nreturn map.size === 2\n  && map.get(0)[0] === 2\n  && map.get(0)[1] === 4\n  && map.get(1)[0] === 1\n  && map.get(1)[1] === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17055,8 +17055,8 @@ return map.size === 2
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("144");try{return Function("asyncTestPassed","\nvar map = Map.keyBy(new Set([{ id: 101 }, { id: 102 }]), it => it.id)\nreturn map.size === 2\n  && map.get(101).id === 101\n  && map.get(102).id === 102;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("144");return Function("asyncTestPassed","'use strict';"+"\nvar map = Map.keyBy(new Set([{ id: 101 }, { id: 102 }]), it => it.id)\nreturn map.size === 2\n  && map.get(101).id === 101\n  && map.get(102).id === 102;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17173,8 +17173,8 @@ return map.size === 2
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("145");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 2], [3, 4], [5, 6], [7, 8]]);\nmap.deleteAll(1, 5)\nreturn map.size === 2\n  && map.get(3) === 4\n  && map.get(7) === 8;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("145");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 2], [3, 4], [5, 6], [7, 8]]);\nmap.deleteAll(1, 5)\nreturn map.size === 2\n  && map.get(3) === 4\n  && map.get(7) === 8;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17287,8 +17287,8 @@ return new Map([[1, 4], [2, 5], [3, 6]]).every(it =&gt; typeof it === &apos;numb
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("146");try{return Function("asyncTestPassed","\nreturn new Map([[1, 4], [2, 5], [3, 6]]).every(it => typeof it === 'number');\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("146");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 4], [2, 5], [3, 6]]).every(it => typeof it === 'number');\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17404,8 +17404,8 @@ return map.size === 2
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("147");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).filter(it => !(it % 2));\nreturn map.size === 2\n  && map.get(1) === 4\n  && map.get(3) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("147");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).filter(it => !(it % 2));\nreturn map.size === 2\n  && map.get(1) === 4\n  && map.get(3) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17518,8 +17518,8 @@ return new Map([[1, 2], [2, 3], [3, 4]]).find(it =&gt; it % 2) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("148");try{return Function("asyncTestPassed","\nreturn new Map([[1, 2], [2, 3], [3, 4]]).find(it => it % 2) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("148");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 2], [2, 3], [3, 4]]).find(it => it % 2) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17632,8 +17632,8 @@ return new Map([[1, 2], [2, 3], [3, 4]]).findKey(it =&gt; it % 2) === 2;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("149");try{return Function("asyncTestPassed","\nreturn new Map([[1, 2], [2, 3], [3, 4]]).findKey(it => it % 2) === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("149");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 2], [2, 3], [3, 4]]).findKey(it => it % 2) === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17747,8 +17747,8 @@ return new Map([[1, 2], [2, NaN]]).includes(2)
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("150");try{return Function("asyncTestPassed","\nreturn new Map([[1, 2], [2, NaN]]).includes(2)\n  && new Map([[1, 2], [2, NaN]]).includes(NaN);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("150");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 2], [2, NaN]]).includes(2)\n  && new Map([[1, 2], [2, NaN]]).includes(NaN);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17862,8 +17862,8 @@ return new Map([[1, 2], [2, NaN]]).keyOf(2) === 1
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("151");try{return Function("asyncTestPassed","\nreturn new Map([[1, 2], [2, NaN]]).keyOf(2) === 1\n  && new Map([[1, 2], [2, NaN]]).keyOf(NaN) === void undefined;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("151");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 2], [2, NaN]]).keyOf(2) === 1\n  && new Map([[1, 2], [2, NaN]]).keyOf(NaN) === void undefined;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -17980,8 +17980,8 @@ return map.size === 3
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("152");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).mapKeys((value, key) => key * key);\nreturn map.size === 3\n  && map.get(1) === 4\n  && map.get(4) === 5\n  && map.get(9) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("152");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).mapKeys((value, key) => key * key);\nreturn map.size === 3\n  && map.get(1) === 4\n  && map.get(4) === 5\n  && map.get(9) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -18098,8 +18098,8 @@ return map.size === 3
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("153");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).mapValues((value, key) => value * value);\nreturn map.size === 3\n  && map.get(1) === 16\n  && map.get(2) === 25\n  && map.get(3) === 36;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("153");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).mapValues((value, key) => value * value);\nreturn map.size === 3\n  && map.get(1) === 16\n  && map.get(2) === 25\n  && map.get(3) === 36;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -18216,8 +18216,8 @@ return map.size === 3
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("154");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 4], [2, 5]]).merge(new Map([[2, 7], [3, 6]]));\nreturn map.size === 3\n  && map.get(1) === 4\n  && map.get(2) === 7\n  && map.get(3) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("154");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 4], [2, 5]]).merge(new Map([[2, 7], [3, 6]]));\nreturn map.size === 3\n  && map.get(1) === 4\n  && map.get(2) === 7\n  && map.get(3) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -18330,8 +18330,8 @@ return new Map([[&apos;a&apos;, 1], [&apos;b&apos;, 2], [&apos;c&apos;, 3], ]).r
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("155");try{return Function("asyncTestPassed","\nreturn new Map([['a', 1], ['b', 2], ['c', 3], ]).reduce(((a, b) => a + b), 1) === 7;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("155");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([['a', 1], ['b', 2], ['c', 3], ]).reduce(((a, b) => a + b), 1) === 7;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -18444,8 +18444,8 @@ return new Map([[1, 4], [2, 5], [3, 6]]).some(it =&gt; it % 2);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("156");try{return Function("asyncTestPassed","\nreturn new Map([[1, 4], [2, 5], [3, 6]]).some(it => it % 2);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("156");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 4], [2, 5], [3, 6]]).some(it => it % 2);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -18562,8 +18562,8 @@ return set.size === 3
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("157");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).addAll(2, 3);\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("157");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).addAll(2, 3);\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -18680,8 +18680,8 @@ return set.deleteAll(2, 3) === true
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("158");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3, 4]);\nreturn set.deleteAll(2, 3) === true\n  && set.size === 2\n  && set.has(1)\n  && set.has(4);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("158");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3, 4]);\nreturn set.deleteAll(2, 3) === true\n  && set.size === 2\n  && set.has(1)\n  && set.has(4);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -18794,8 +18794,8 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("159");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).every(it => typeof it === 'number');\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("159");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).every(it => typeof it === 'number');\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -18911,8 +18911,8 @@ return set.size === 2
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("160");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).filter(it => it % 2);\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("160");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).filter(it => it % 2);\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -19025,8 +19025,8 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("161");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).find(it => !(it % 2)) === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("161");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).find(it => !(it % 2)) === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -19139,8 +19139,8 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("162");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).join('|') === '1|2|3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("162");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).join('|') === '1|2|3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -19257,8 +19257,8 @@ return set.size === 3
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("163");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).map(it => it * it);\nreturn set.size === 3\n  && set.has(1)\n  && set.has(4)\n  && set.has(9);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("163");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).map(it => it * it);\nreturn set.size === 3\n  && set.has(1)\n  && set.has(4)\n  && set.has(9);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -19371,8 +19371,8 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("164");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).reduce((memo, it) => memo + it) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("164");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).reduce((memo, it) => memo + it) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -19485,8 +19485,8 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("165");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).some(it => it % 2);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("165");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).some(it => it % 2);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -19608,8 +19608,8 @@ return !map.has(a)
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("166");try{return Function("asyncTestPassed","\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar map = new WeakMap([[a, 1], [b, 2], [c, 3], [d, 4]]);\nmap.deleteAll(a, c)\nreturn !map.has(a)\n  && map.get(b) === 2\n  && !map.has(c)\n  && map.get(d) === 4;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("166");return Function("asyncTestPassed","'use strict';"+"\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar map = new WeakMap([[a, 1], [b, 2], [c, 3], [d, 4]]);\nmap.deleteAll(a, c)\nreturn !map.has(a)\n  && map.get(b) === 2\n  && !map.has(c)\n  && map.get(d) === 4;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -19731,8 +19731,8 @@ return set.has(a)
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("167");try{return Function("asyncTestPassed","\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar set = new WeakSet([a, b]);\nset.addAll(c, d)\nreturn set.has(a)\n  && set.has(b)\n  && set.has(c)\n  && set.has(d);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("167");return Function("asyncTestPassed","'use strict';"+"\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar set = new WeakSet([a, b]);\nset.addAll(c, d)\nreturn set.has(a)\n  && set.has(b)\n  && set.has(c)\n  && set.has(d);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -19854,8 +19854,8 @@ return !set.has(a)
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("168");try{return Function("asyncTestPassed","\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar set = new WeakSet([a, b, c, d]);\nset.deleteAll(a, c)\nreturn !set.has(a)\n  && set.has(b)\n  && !set.has(c)\n  && set.has(d);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("168");return Function("asyncTestPassed","'use strict';"+"\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar set = new WeakSet([a, b, c, d]);\nset.deleteAll(a, c)\nreturn !set.has(a)\n  && set.has(b)\n  && !set.has(c)\n  && set.has(d);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -19976,8 +19976,8 @@ return second === gen2.next().value;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("169");try{return Function("asyncTestPassed","\nvar gen1 = Math.seededPRNG({ seed: 42 });\nvar gen2 = Math.seededPRNG({ seed: 42 });\nif (!gen1.next || !gen1[Symbol.iterator]) return false;\nvar first = gen1.next().value;\nif (first < 0 || first > 1) return false;\nif (first !== gen2.next().value) return false;\nvar second = gen1.next().value;\nif (first === second) return false;\nreturn second === gen2.next().value;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("169");return Function("asyncTestPassed","'use strict';"+"\nvar gen1 = Math.seededPRNG({ seed: 42 });\nvar gen2 = Math.seededPRNG({ seed: 42 });\nif (!gen1.next || !gen1[Symbol.iterator]) return false;\nvar first = gen1.next().value;\nif (first < 0 || first > 1) return false;\nif (first !== gen2.next().value) return false;\nvar second = gen1.next().value;\nif (first === second) return false;\nreturn second === gen2.next().value;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -20087,8 +20087,8 @@ return second === gen2.next().value;
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-{_BigInt,_Number_}.fromString"><span><a class="anchor" href="#test-{_BigInt,_Number_}.fromString">&#xA7;</a><a href="https://github.com/tc39/proposal-number-fromstring">{ BigInt, Number }.fromString</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/2</td>
@@ -20201,8 +20201,8 @@ return Number.fromString(&apos;42&apos;) === 42;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("171");try{return Function("asyncTestPassed","\nreturn Number.fromString('42') === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("171");return Function("asyncTestPassed","'use strict';"+"\nreturn Number.fromString('42') === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -20315,8 +20315,8 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("172");try{return Function("asyncTestPassed","\nreturn BigInt.fromString('42') === 42n;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("172");return Function("asyncTestPassed","'use strict';"+"\nreturn BigInt.fromString('42') === 42n;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -20426,8 +20426,8 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_iteration"><span><a class="anchor" href="#test-Object_iteration">&#xA7;</a><a href="https://github.com/tc39/proposal-object-iteration">Object iteration</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
-<td class="tally" data-browser="babel6corejs2" data-tally="0">0/3</td>
-<td class="tally" data-browser="babel7corejs2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/3</td>
@@ -20544,8 +20544,8 @@ return [...iterator].join() === &apos;a,c&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("174");try{return Function("asyncTestPassed","\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateKeys(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === 'a,c';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("174");return Function("asyncTestPassed","'use strict';"+"\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateKeys(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === 'a,c';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -20662,8 +20662,8 @@ return [...iterator].join() === &apos;1,3&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("175");try{return Function("asyncTestPassed","\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateValues(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === '1,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("175");return Function("asyncTestPassed","'use strict';"+"\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateValues(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === '1,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -20780,8 +20780,8 @@ return [...iterator].join() === &apos;a,1,c,3&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("176");try{return Function("asyncTestPassed","\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateEntries(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === 'a,1,c,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("176");return Function("asyncTestPassed","'use strict';"+"\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateEntries(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === 'a,1,c,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete" data-browser="tr">No</td>
-<td class="no" data-browser="babel6corejs2">No</td>
-<td class="no" data-browser="babel7corejs2">No</td>
+<td class="no obsolete" data-browser="babel6corejs2">No</td>
+<td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190215">No</td>
@@ -20893,8 +20893,8 @@ return [...iterator].join() === &apos;a,1,c,3&apos;;
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-bind_(::)_operator"><span><a class="anchor" href="#test-bind_(::)_operator">&#xA7;</a><a href="https://github.com/zenparsing/es-function-bind">bind (::) operator</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
-<td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
+<td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
+<td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -21009,8 +21009,8 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("178");try{return Function("asyncTestPassed","\nfunction foo() { this.garply += \"foo\"; return this; }\nvar obj = { garply: \"bar\" };\nreturn typeof obj::foo === \"function\" && obj::foo().garply === \"barfoo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("178");return Function("asyncTestPassed","'use strict';"+"\nfunction foo() { this.garply += \"foo\"; return this; }\nvar obj = { garply: \"bar\" };\nreturn typeof obj::foo === \"function\" && obj::foo().garply === \"barfoo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21124,8 +21124,8 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("179");try{return Function("asyncTestPassed","\nvar obj = { garply: \"bar\", foo: function() { this.garply += \"foo\"; return this; } };\nreturn typeof ::obj.foo === \"function\" && ::obj.foo().garply === \"barfoo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("179");return Function("asyncTestPassed","'use strict';"+"\nvar obj = { garply: \"bar\", foo: function() { this.garply += \"foo\"; return this; } };\nreturn typeof ::obj.foo === \"function\" && ::obj.foo().garply === \"barfoo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21238,8 +21238,8 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("180");try{return Function("asyncTestPassed","\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("180");return Function("asyncTestPassed","'use strict';"+"\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21349,8 +21349,8 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-additional_meta_properties"><span><a class="anchor" href="#test-additional_meta_properties">&#xA7;</a><a href="https://github.com/allenwb/ESideas/blob/master/ES7MetaProps.md">additional meta properties</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -21464,8 +21464,8 @@ return f();
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("182");try{return Function("asyncTestPassed","\nvar f = _ => function.callee === f;\nreturn f();\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("182");return Function("asyncTestPassed","'use strict';"+"\nvar f = _ => function.callee === f;\nreturn f();\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21578,8 +21578,8 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("183");try{return Function("asyncTestPassed","\nreturn (_ => function.count)(1, 2, 3) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("183");return Function("asyncTestPassed","'use strict';"+"\nreturn (_ => function.count)(1, 2, 3) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21697,8 +21697,8 @@ return Array.isArray(arr)
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("184");try{return Function("asyncTestPassed","\nvar arr =  (_ => function.arguments)(1, 2, 3);\nreturn Array.isArray(arr)\n  && arr.length === 3\n  && arr[0] === 1\n  && arr[1] === 2\n  && arr[2] === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("184");return Function("asyncTestPassed","'use strict';"+"\nvar arr =  (_ => function.arguments)(1, 2, 3);\nreturn Array.isArray(arr)\n  && arr.length === 3\n  && arr[0] === 1\n  && arr[1] === 2\n  && arr[2] === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21822,8 +21822,8 @@ return target === C.prototype
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("185");try{return Function("asyncTestPassed","\nvar target, key, index;\nfunction decorator(_target, _key, _index){\n  target = _target;\n  key    = _key;\n  index  = _index;\n}\nclass C {\n  method(@decorator foo){ }\n}\nreturn target === C.prototype\n  && key === 'method'\n  && index === 0;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("185");return Function("asyncTestPassed","'use strict';"+"\nvar target, key, index;\nfunction decorator(_target, _key, _index){\n  target = _target;\n  key    = _key;\n  index  = _index;\n}\nclass C {\n  method(@decorator foo){ }\n}\nreturn target === C.prototype\n  && key === 'method'\n  && index === 0;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -21943,8 +21943,8 @@ return (@inverse function(it){
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("186");try{return Function("asyncTestPassed","\nfunction inverse(f){\n  return function(){\n    return !f.apply(this, arguments);\n  };\n}\nreturn (@inverse function(it){\n  return it % 2;\n})(2);\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("186");return Function("asyncTestPassed","'use strict';"+"\nfunction inverse(f){\n  return function(){\n    return !f.apply(this, arguments);\n  };\n}\nreturn (@inverse function(it){\n  return it % 2;\n})(2);\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -22054,8 +22054,8 @@ return (@inverse function(it){
 </tr>
 <tr class="supertest optional-feature" significance="0.25"><td id="test-Reflect.isCallable_/_Reflect.isConstructor"><span><a class="anchor" href="#test-Reflect.isCallable_/_Reflect.isConstructor">&#xA7;</a><a href="https://github.com/caitp/TC39-Proposals/blob/master/tc39-reflect-isconstructor-iscallable.md">Reflect.isCallable / Reflect.isConstructor</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -22170,8 +22170,8 @@ return Reflect.isCallable(function(){})
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("188");try{return Function("asyncTestPassed","\nreturn Reflect.isCallable(function(){})\n  && Reflect.isCallable(_ => _)\n  && !Reflect.isCallable(class {});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("188");return Function("asyncTestPassed","'use strict';"+"\nreturn Reflect.isCallable(function(){})\n  && Reflect.isCallable(_ => _)\n  && !Reflect.isCallable(class {});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -22286,8 +22286,8 @@ return Reflect.isConstructor(function(){})
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("189");try{return Function("asyncTestPassed","\nreturn Reflect.isConstructor(function(){})\n  && !Reflect.isConstructor(_ => _)\n  && Reflect.isConstructor(class {});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("189");return Function("asyncTestPassed","'use strict';"+"\nreturn Reflect.isConstructor(function(){})\n  && !Reflect.isConstructor(_ => _)\n  && Reflect.isConstructor(class {});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -22397,8 +22397,8 @@ return Reflect.isConstructor(function(){})
 </tr>
 <tr class="supertest optional-feature" significance="1"><td id="test-zones"><span><a class="anchor" href="#test-zones">&#xA7;</a><a href="https://github.com/domenic/zones">zones</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -22511,8 +22511,8 @@ return typeof Zone === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("191");try{return Function("asyncTestPassed","\nreturn typeof Zone === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("191");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -22625,8 +22625,8 @@ return &apos;current&apos; in Zone;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("192");try{return Function("asyncTestPassed","\nreturn 'current' in Zone;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("192");return Function("asyncTestPassed","'use strict';"+"\nreturn 'current' in Zone;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -22739,8 +22739,8 @@ return &apos;name&apos; in Zone.prototype;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("193");try{return Function("asyncTestPassed","\nreturn 'name' in Zone.prototype;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("193");return Function("asyncTestPassed","'use strict';"+"\nreturn 'name' in Zone.prototype;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -22853,8 +22853,8 @@ return &apos;parent&apos; in Zone.prototype;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("194");try{return Function("asyncTestPassed","\nreturn 'parent' in Zone.prototype;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("194");return Function("asyncTestPassed","'use strict';"+"\nreturn 'parent' in Zone.prototype;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -22967,8 +22967,8 @@ return typeof Zone.prototype.fork === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("195");try{return Function("asyncTestPassed","\nreturn typeof Zone.prototype.fork === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("195");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone.prototype.fork === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -23081,8 +23081,8 @@ return typeof Zone.prototype.run === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("196");try{return Function("asyncTestPassed","\nreturn typeof Zone.prototype.run === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("196");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone.prototype.run === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -23195,8 +23195,8 @@ return typeof Zone.prototype.wrap === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("197");try{return Function("asyncTestPassed","\nreturn typeof Zone.prototype.wrap === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("197");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone.prototype.wrap === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -23306,8 +23306,8 @@ return typeof Zone.prototype.wrap === &apos;function&apos;;
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-syntactic_tail_calls"><span><a class="anchor" href="#test-syntactic_tail_calls">&#xA7;</a><a href="https://github.com/tc39/proposal-ptc-syntax">syntactic tail calls</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -23426,8 +23426,8 @@ return (function f(n){
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("199");try{return Function("asyncTestPassed","\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue f(n - 1);\n}(1e6)) === \"foo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("199");return Function("asyncTestPassed","'use strict';"+"\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue f(n - 1);\n}(1e6)) === \"foo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -23553,8 +23553,8 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("200");try{return Function("asyncTestPassed","\n\"use strict\";\nfunction f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue g(n - 1);\n}\nfunction g(n){\n  if (n <= 0) {\n    return  \"bar\";\n  }\n  return continue f(n - 1);\n}\nreturn f(1e6) === \"foo\" && f(1e6+1) === \"bar\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("200");return Function("asyncTestPassed","'use strict';"+"\n\"use strict\";\nfunction f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue g(n - 1);\n}\nfunction g(n){\n  if (n <= 0) {\n    return  \"bar\";\n  }\n  return continue f(n - 1);\n}\nreturn f(1e6) === \"foo\" && f(1e6+1) === \"bar\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -23664,8 +23664,8 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 </tr>
 <tr class="supertest optional-feature" significance="0.25"><td id="test-object_shorthand_improvements"><span><a class="anchor" href="#test-object_shorthand_improvements">&#xA7;</a><a href="https://github.com/rbuckton/proposal-shorthand-improvements">object shorthand improvements</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -23780,8 +23780,8 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("202");try{return Function("asyncTestPassed","\nvar foo = { bar: 42, baz: 33 };\nvar fuz = { foo.bar, foo['baz'] };\nreturn fuz.bar === 42 && fuz.baz === 33;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("202");return Function("asyncTestPassed","'use strict';"+"\nvar foo = { bar: 42, baz: 33 };\nvar fuz = { foo.bar, foo['baz'] };\nreturn fuz.bar === 42 && fuz.baz === 33;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -23897,8 +23897,8 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("203");try{return Function("asyncTestPassed","\nvar foo = { bar: 42, baz: 33 };\nvar fuz = {};\n({ fuz.bar, fuz['baz'] } = foo);\nreturn fuz.bar === 42 && fuz.baz === 33;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("203");return Function("asyncTestPassed","'use strict';"+"\nvar foo = { bar: 42, baz: 33 };\nvar fuz = {};\n({ fuz.bar, fuz['baz'] } = foo);\nreturn fuz.bar === 42 && fuz.baz === 33;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24010,8 +24010,8 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 </tr>
 <tr class="supertest optional-feature" significance="0.5"><td id="test-Metadata_reflection_API"><span><a class="anchor" href="#test-Metadata_reflection_API">&#xA7;</a><a href="https://github.com/rbuckton/ReflectDecorators">Metadata reflection API</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
-<td class="tally not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
+<td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
+<td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -24124,8 +24124,8 @@ return typeof Reflect.defineMetadata === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("205");try{return Function("asyncTestPassed","\nreturn typeof Reflect.defineMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("205");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.defineMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24238,8 +24238,8 @@ return typeof Reflect.hasMetadata === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("206");try{return Function("asyncTestPassed","\nreturn typeof Reflect.hasMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("206");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.hasMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24352,8 +24352,8 @@ return typeof Reflect.hasOwnMetadata === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("207");try{return Function("asyncTestPassed","\nreturn typeof Reflect.hasOwnMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("207");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.hasOwnMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24466,8 +24466,8 @@ return typeof Reflect.getMetadata === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("208");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("208");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24580,8 +24580,8 @@ return typeof Reflect.getOwnMetadata === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("209");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getOwnMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("209");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getOwnMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24694,8 +24694,8 @@ return typeof Reflect.getMetadataKeys === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("210");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getMetadataKeys === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("210");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getMetadataKeys === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24808,8 +24808,8 @@ return typeof Reflect.getOwnMetadataKeys === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("211");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getOwnMetadataKeys === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("211");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getOwnMetadataKeys === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24922,8 +24922,8 @@ return typeof Reflect.deleteMetadata === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("212");try{return Function("asyncTestPassed","\nreturn typeof Reflect.deleteMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("212");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.deleteMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -25036,8 +25036,8 @@ return typeof Reflect.metadata === &apos;function&apos;;
       ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("213");try{return Function("asyncTestPassed","\nreturn typeof Reflect.metadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("213");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.metadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="no obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="yes not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
-<td class="yes not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="closure20190215" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>


### PR DESCRIPTION
Per https://github.com/zloirock/core-js#core-js, `core-js@2` is obsolete. And `babel@6` has been long deprecated, too.