### PR TITLE
Extract data interoplation logic to a separate file

### DIFF
--- a/build-utils/compare-versions.js
+++ b/build-utils/compare-versions.js
@@ -1,0 +1,21 @@
+module.exports = function compareVersions(a, b) {
+  var vA = a.version;
+  var vB = b.version;
+
+  if (!vA && !vB) return 0;
+  if (!vB) return 1;
+  if (!vA) return -1;
+
+  for (var i = 0; i < vA.length && i < vB.length; i++) {
+    if (vA[i] === "tp" && vB[i] === "tp") continue;
+    if (vA[i] === "tp") return 1;
+    if (vB[i] === "tp") return -1;
+    if (vA[i] > vB[i]) return 1;
+    if (vA[i] < vB[i]) return -1;
+  }
+
+  if (vA.length > vB.length) return 1;
+  if (vA.length < vB.length) return -1;
+
+  return 0;
+};

--- a/build-utils/interpolate-all-results.js
+++ b/build-utils/interpolate-all-results.js
@@ -1,0 +1,45 @@
+var parseEnvsVersions = require("./parse-envs-versions");
+
+module.exports = function interpolateAllResults(tests, envs) {
+  var envsTree = buildEnvsTree(envs);
+
+  tests.forEach(function (t) {
+    // Calculate the result totals for tests which consist solely of subtests.
+    [].concat(t.subtests || t).forEach(function (e) {
+      interpolateTestResults(e.res, envsTree);
+    });
+  });
+};
+
+function interpolateTestResults(res, envsTree) {
+  var bid, prevBid;
+  for (bid in envsTree) {
+    if (res[bid] !== undefined) continue;
+
+    prevBid = bid;
+    do {
+      prevBid = envsTree[prevBid];
+    } while (prevBid !== null && res[prevBid] === undefined);
+
+    if (prevBid !== null) res[bid] = res[prevBid];
+  }
+}
+
+// This function returns an object mapping "browser id" -> "parent browser id"
+function buildEnvsTree(data) {
+  var result = {};
+  var envs = parseEnvsVersions(data);
+
+  Object.keys(envs).forEach(function (name) {
+    var id = envs[name][0].id;
+    result[id] = data[id].equals || null;
+
+    for (var i = 1; i < envs[name].length; i++) {
+      id = envs[name][i].id;
+      if (data[id].equals === false) result[id] = null;
+      else result[id] = data[id].equals || envs[name][i - 1].id;
+    }
+  });
+
+  return result;
+}

--- a/build-utils/parse-envs-versions.js
+++ b/build-utils/parse-envs-versions.js
@@ -1,13 +1,11 @@
+var compareVersions = require("./compare-versions");
+
 var RE = {
   engine: /^(\w+?)(tp|[\d_]+)?(?:corejs[23])?$/,
   version: /^(\d{4})(\d{2})(\d{2})$|^(\d+)(?:_(\d+))?(?:_(\d+))?$/
 };
 
-module.exports = buildEnvsTree;
-
-// This function returns an object mapping "browser id" -> "parent browser id"
-function buildEnvsTree(data) {
-  var result = {};
+module.exports = function parseEnvsVersions(data) {
   var envs = Object.create(null);
 
   Object.keys(data).forEach(function (id) {
@@ -18,19 +16,10 @@ function buildEnvsTree(data) {
 
   Object.keys(envs).forEach(function (name) {
     envs[name].sort(compareVersions);
-
-    var id = envs[name][0].id;
-    result[id] = data[id].equals || null;
-
-    for (var i = 1; i < envs[name].length; i++) {
-      id = envs[name][i].id;
-      if (data[id].equals === false) result[id] = null;
-      else result[id] = data[id].equals || envs[name][i - 1].id;
-    }
   });
 
-  return result;
-}
+  return envs;
+};
 
 function parseEnvId(id) {
   var result = { id: id };
@@ -60,24 +49,6 @@ function parseVersion(version) {
   return result;
 }
 
-function compareVersions(a, b) {
-  var vA = a.version;
-  var vB = b.version;
 
-  if (!vA && !vB) return 0;
-  if (!vB) return 1;
-  if (!vA) return -1;
 
-  for (var i = 0; i < vA.length && i < vB.length; i++) {
-    if (vA[i] === "tp" && vB[i] === "tp") continue;
-    if (vA[i] === "tp") return 1;
-    if (vB[i] === "tp") return -1;
-    if (vA[i] > vB[i]) return 1;
-    if (vA[i] < vB[i]) return -1;
-  }
 
-  if (vA.length > vB.length) return 1;
-  if (vA.length < vB.length) return -1;
-
-  return 0;
-}


### PR DESCRIPTION
This PR only moves code around, without adding any feature or fixing any bug.

I extracted all the logic used to interoplate envs/tests data to a separate file, so that consumers of `compat-table` (i.e. Babel) can `require()` that file without needing to re-implement all the logic.

You can see the advantage of this in Babel's `compat-data` build script: it allowed me to delete more than 50% of the code, while also finding some bugs in the old generated data: [diff](https://github.com/babel/babel/compare/master...nicolo-ribaudo:update-compat-table-script#diff-b0170cca6f037004c76ccb91b5798200)

Note that since `compat-table` is not actually meant to be consumed by other programs, this new file shouldn't introduce any backward-compatibility concern, and it can be refactored whenever needed.

Also, I renamed `scripts/build-environments-tree.js` (introduced by #1600) to `build-utils.js`, since the `scripts` folder was inconsistent with all the other files (that are in the top-level folder).