### PR TITLE
Update babel support data

### DIFF
--- a/build.js
+++ b/build.js
@@ -83,7 +83,7 @@ process.nextTick(function () {
   if (!fs.existsSync('esnext/compilers')) {
     fs.mkdirSync('esnext/compilers');
   }
-  var babel = require('babel-core');
+  var babel = require('@babel/standalone');
   var traceur = require('traceur');
   var esdown = require('esdown');
   var jstransform = require('jstransform/simple');
@@ -128,7 +128,7 @@ process.nextTick(function () {
       target_file: 'es6/compilers/babel.html',
       polyfills: [],
       compiler: function(code) {
-        return babel.transform(code, {presets: ['es2015']}).code;
+        return babel.transform(code, {presets: ['es2015'], sourceType: "script"}).code;
       },
     },
     {
@@ -137,7 +137,7 @@ process.nextTick(function () {
       target_file: 'es6/compilers/babel-core-js.html',
       polyfills: ['node_modules/core-js-bundle/index.js', 'node_modules/regenerator-runtime/runtime.js'],
       compiler: function(code) {
-        return babel.transform(code, {presets: ['es2015']}).code;
+        return babel.transform(code, {presets: ['es2015'], sourceType: "script"}).code;
       },
     },
     {
@@ -300,7 +300,7 @@ process.nextTick(function () {
       target_file: 'esnext/compilers/babel-core-js.html',
       polyfills: ['node_modules/core-js-bundle/index.js', 'node_modules/regenerator-runtime/runtime.js'],
       compiler: function(code) {
-        return babel.transform(code, {presets: ['es2015', 'es2016', 'es2017', 'babel-preset-stage-0']}).code;
+        return babel.transform(code, {presets: [['env', { forceAllTransforms: true }], ['stage-0', { decoratorsBeforeExport: true }]], sourceType: "script"}).code;
       },
     },
     {

--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -578,6 +578,7 @@ exports.tests = [
         res: {
           tr: null,
           babel6corejs2: null,
+          babel7corejs2: babel.regenerator,
           closure: true,
           typescript1corejs2: typescript.downlevelIteration,
           chrome52: null,
@@ -707,6 +708,7 @@ exports.tests = [
         res: {
           tr: null,
           babel6corejs2: null,
+          babel7corejs2: babel.regenerator,
           closure: true,
           typescript1corejs2: typescript.downlevelIteration,
           chrome52: null,
@@ -768,6 +770,7 @@ exports.tests = [
         res: {
           tr: null,
           babel6corejs2: null,
+          babel7corejs2: babel.regenerator,
           closure: true,
           typescript1corejs2: typescript.downlevelIteration,
           chrome52: null,
@@ -835,6 +838,7 @@ exports.tests = [
         res: {
           tr: null,
           babel6corejs2: null,
+          babel7corejs2: babel.regenerator,
           closure: true,
           typescript1corejs2: typescript.downlevelIteration,
           chrome52: null,
@@ -873,6 +877,7 @@ exports.tests = [
         res: {
           tr: null,
           babel6corejs2: null,
+          babel7corejs2: babel.regenerator,
           closure: true,
           typescript1corejs2: typescript.downlevelIteration,
           chrome52: null,
@@ -1778,6 +1783,7 @@ exports.tests = [
      return iter['throw']().value === 'bar';
      */},
     res: {
+      babel7corejs3: true,
       closure20180319: true,
       typescript1corejs2: typescript.downlevelIteration,
       ie11: false,
@@ -3674,6 +3680,7 @@ exports.tests = [
         */},
         res : {
           closure20190215: true,
+          babel7corejs2: true,
           ie11: false,
           firefox2: false,
           firefox61: false,
@@ -3697,6 +3704,7 @@ exports.tests = [
         */},
         res : {
           closure20190215: true,
+          babel7corejs2: true,
           ie11: false,
           firefox2: false,
           firefox61: false,
@@ -4847,6 +4855,7 @@ exports.tests = [
         return a === 2 && b === 2 && c === 1;
       */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -4873,6 +4882,7 @@ exports.tests = [
         return a === 1 && i === 1;
       */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -4899,6 +4909,7 @@ exports.tests = [
         return i === 1;
       */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -4928,6 +4939,7 @@ exports.tests = [
         return typeof a === 'undefined' && b === 0 && c === 2;
       */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -4954,6 +4966,7 @@ exports.tests = [
         return typeof a === 'undefined' && i === 1;
       */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -4980,6 +4993,7 @@ exports.tests = [
         return i === 1;
       */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -5009,6 +5023,7 @@ exports.tests = [
         return a === 2 && b === 0 && c === 1;
       */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -5035,6 +5050,7 @@ exports.tests = [
         return a === 1 && i === 1;
       */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -5061,6 +5077,7 @@ exports.tests = [
         return i === 1;
       */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -5162,6 +5179,7 @@ exports.tests = [
           return new C(42).x() === 42;
         */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox2: false,
           firefox67: firefox.privateClassFields,
@@ -5190,6 +5208,7 @@ exports.tests = [
           return new C().x() === 42;
         */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox2: false,
           firefox67: firefox.privateClassFields,
@@ -5218,6 +5237,7 @@ exports.tests = [
           return new C().x() === 42 && new C().x(null) === void 0;
         */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox2: false,
           firefox80: firefox.privateFields,
@@ -5249,6 +5269,7 @@ exports.tests = [
           return new C().x() === 42 && new C().x(null) === void 0;
         */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox2: false,
           firefox74: firefox.privateClassFields,
@@ -5278,6 +5299,7 @@ exports.tests = [
           return new C().x === 42;
         */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox2: false,
           firefox66: false,
@@ -5342,6 +5364,7 @@ exports.tests = [
           return new C().x() === 42;
         */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox2: false,
           firefox80: firefox.privateFields,
@@ -5365,6 +5388,7 @@ exports.tests = [
           return C.x === 42;
         */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox2: false,
           firefox74: false,
@@ -5399,6 +5423,7 @@ exports.tests = [
           return new C().x() === 42;
         */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox60: false,
           firefox68: false,
@@ -5431,6 +5456,7 @@ exports.tests = [
           return new C().x() === 42;
         */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox60: false,
           firefox68: false,
@@ -5465,6 +5491,7 @@ exports.tests = [
           return new C().x() === 42 && y;
         */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox60: false,
           firefox68: false,
@@ -5499,6 +5526,7 @@ exports.tests = [
           return new C().x() === 42 && y;
         */},
         res: {
+          babel7corejs2: true,
           ie11: false,
           firefox60: false,
           firefox68: false,

--- a/data-es6.js
+++ b/data-es6.js
@@ -19082,6 +19082,7 @@ exports.tests = [
         }
       */},
       res: {
+        babel7corejs2: true,
         closure: false,
         closure20200517: true,
         firefox2: false,

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -1585,7 +1585,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
@@ -4009,8 +4009,8 @@ return Math.min(1,2,3,) === 1;
 <tr class="supertest" significance="1"><td id="test-async_functions"><span><a class="anchor" href="#test-async_functions">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-async-function-definitions">async functions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
-<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
-<td class="tally" data-browser="babel7corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
+<td class="tally" data-browser="babel7corejs3" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
@@ -4311,8 +4311,8 @@ p.catch(function(result) {
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
@@ -4889,8 +4889,8 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
@@ -5176,8 +5176,8 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
@@ -5468,8 +5468,8 @@ p.then(function(result) {
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
@@ -5619,8 +5619,8 @@ p.then(function(result) {
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
+<td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
@@ -18650,8 +18650,8 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <tr class="supertest" significance="0.25"><td id="test-JSON_superset"><span><a class="anchor" href="#test-JSON_superset">&#xA7;</a><a href="https://github.com/tc39/proposal-json-superset">JSON superset</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
-<td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
+<td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
@@ -18790,8 +18790,8 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
@@ -18930,8 +18930,8 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
@@ -23474,8 +23474,8 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <tr class="supertest" significance="0.25"><td id="test-Logical_Assignment"><span><a class="anchor" href="#test-Logical_Assignment">&#xA7;</a><a href="https://github.com/tc39/proposal-logical-assignment/">Logical Assignment</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/9</td>
-<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/9</td>
-<td class="tally" data-browser="babel7corejs3" data-tally="0">0/9</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">9/9</td>
+<td class="tally" data-browser="babel7corejs3" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/9</td>
@@ -23620,8 +23620,8 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -23763,8 +23763,8 @@ return a === 1 &amp;&amp; i === 1;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -23906,8 +23906,8 @@ return i === 1;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -24052,8 +24052,8 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -24195,8 +24195,8 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -24338,8 +24338,8 @@ return i === 1;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -24484,8 +24484,8 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -24627,8 +24627,8 @@ return a === 1 &amp;&amp; i === 1;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -24770,8 +24770,8 @@ return i === 1;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -25050,8 +25050,8 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <tr class="supertest" significance="0.5"><td id="test-instance_class_fields"><span><a class="anchor" href="#test-instance_class_fields">&#xA7;</a><a href="https://github.com/tc39/proposal-class-fields">instance class fields</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
-<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
-<td class="tally" data-browser="babel7corejs3" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">6/6</td>
+<td class="tally" data-browser="babel7corejs3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/6</td>
@@ -25342,8 +25342,8 @@ return new C(42).x() === 42;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -25488,8 +25488,8 @@ return new C().x() === 42;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -25634,7 +25634,7 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
@@ -25780,7 +25780,7 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
@@ -25923,8 +25923,8 @@ return new C().x === 42;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -26060,8 +26060,8 @@ return new C().x === 42;
 <tr class="supertest" significance="0.5"><td id="test-static_class_fields"><span><a class="anchor" href="#test-static_class_fields">&#xA7;</a><a href="https://github.com/tc39/proposal-static-class-features/">static class fields</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally" data-browser="babel7corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
+<td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/3</td>
@@ -26349,8 +26349,8 @@ return new C().x() === 42;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -26492,8 +26492,8 @@ return C.x === 42;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -26629,8 +26629,8 @@ return C.x === 42;
 <tr class="supertest" significance="0.5"><td id="test-private_class_methods"><span><a class="anchor" href="#test-private_class_methods">&#xA7;</a><a href="https://github.com/tc39/proposal-private-methods">private class methods</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/4</td>
-<td class="tally" data-browser="babel7corejs3" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
+<td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/4</td>
@@ -26775,8 +26775,8 @@ return new C().x() === 42;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -26921,8 +26921,8 @@ return new C().x() === 42;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -27070,8 +27070,8 @@ return new C().x() === 42 &amp;&amp; y;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
@@ -27219,8 +27219,8 @@ return new C().x() === 42 &amp;&amp; y;
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
-<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
-<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
+<td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>

--- a/package.json
+++ b/package.json
@@ -12,11 +12,7 @@
   },
   "private": true,
   "dependencies": {
-    "babel-core": "latest",
-    "babel-preset-es2015": "latest",
-    "babel-preset-es2016": "latest",
-    "babel-preset-es2017": "latest",
-    "babel-preset-stage-0": "latest",
+    "@babel/standalone": "latest",
     "chalk": "^1.1.3",
     "cheerio": "^0.20.0",
     "core-js-bundle": "^3.0.0",


### PR DESCRIPTION
This PR should be reviewed by commits.

The first commit updates the test page to Babel 7 so I can check the results on my local browsers.

The second commit updates the test results of babel 7 according to the test page results and my assessment on some `eval` test cases. (See explainers below).

Update rule:
If the transpiled code passes the test without any `corejs` helpers, set `babel7corejs2: true`, otherwise set `babel7corejs3: babel.corejs` since `corejs2` is obsolete and the value of support is marginal.