### PR TITLE
Test optional catch on generator throw

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -2994,7 +2994,6 @@ exports.tests = [
           function *foo() {
             try {
               yield;
-              throw new Error();
             }
             catch {
               return true;
@@ -3003,7 +3002,7 @@ exports.tests = [
 
           var it = foo();
           it.next();
-          return it.next().value;
+          return it.throw().value;
         */},
         res: {
           babel7corejs2: true,
@@ -3013,15 +3012,12 @@ exports.tests = [
           firefox2: false,
           firefox57: false,
           firefox58: true,
-          opera10_50: false,
           chrome65: chrome.harmony,
           chrome66: true,
           safari11_1: true,
           safaritp: true,
           webkit: true,
           duktape2_2: false,
-          graalvm19: true,
-          graalvm20: true,
         }
       }
     ]

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -13877,8 +13877,8 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="duktape2_2" data-tally="0">0/3</td>
 <td class="tally" data-browser="duktape2_3" data-tally="0">0/3</td>
-<td class="tally" data-browser="graalvm19" data-tally="1">3/3</td>
-<td class="tally" data-browser="graalvm20" data-tally="1">3/3</td>
+<td class="tally" data-browser="graalvm19" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="graalvm20" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/3</td>
@@ -14149,7 +14149,6 @@ return false;
 function *foo() {
   try {
     yield;
-    throw new Error();
   }
   catch {
     return true;
@@ -14158,8 +14157,8 @@ function *foo() {
 
 var it = foo();
 it.next();
-return it.next().value;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("115");try{return Function("asyncTestPassed","\nfunction *foo() {\n  try {\n    yield;\n    throw new Error();\n  }\n  catch {\n    return true;\n  }\n}\n\nvar it = foo();\nit.next();\nreturn it.next().value;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("115");return Function("asyncTestPassed","'use strict';"+"\nfunction *foo() {\n  try {\n    yield;\n    throw new Error();\n  }\n  catch {\n    return true;\n  }\n}\n\nvar it = foo();\nit.next();\nreturn it.next().value;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+return it.throw().value;
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("115");try{return Function("asyncTestPassed","\nfunction *foo() {\n  try {\n    yield;\n  }\n  catch {\n    return true;\n  }\n}\n\nvar it = foo();\nit.next();\nreturn it.throw().value;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("115");return Function("asyncTestPassed","'use strict';"+"\nfunction *foo() {\n  try {\n    yield;\n  }\n  catch {\n    return true;\n  }\n}\n\nvar it = foo();\nit.next();\nreturn it.throw().value;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -14197,7 +14196,7 @@ return it.next().value;
 <td class="yes" data-browser="firefox75">Yes</td>
 <td class="yes unstable" data-browser="firefox76">Yes</td>
 <td class="yes unstable" data-browser="firefox77">Yes</td>
-<td class="no obsolete" data-browser="opera12_10">No</td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="yes obsolete" data-browser="chrome74">Yes</td>
 <td class="yes obsolete" data-browser="chrome75">Yes</td>
 <td class="yes obsolete" data-browser="chrome76">Yes</td>
@@ -14253,8 +14252,8 @@ return it.next().value;
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="yes" data-browser="graalvm19">Yes</td>
-<td class="yes" data-browser="graalvm20">Yes</td>
+<td class="unknown" data-browser="graalvm19">?</td>
+<td class="unknown" data-browser="graalvm20">?</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>


### PR DESCRIPTION
It seems the current test is actually just testing that a normal throw will be caught by an optional-binding catch. I think it should be testing that resuming the generator with a throw will be properly caught, like how the `await` test is using a rejected promise's throw.