### PR TITLE
add ?. PrivateIdentifier test

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -905,6 +905,31 @@ exports.tests = [
       }
     },
     {
+      name: 'optional private instance class fields access',
+      exec: function () {/*
+        class C {
+          #x = 42;
+          x(o = this){
+            return o?.#x;
+          }
+        }
+        return new C().x() === 42 && new C().x(null) === void 0;
+      */},
+      res: {
+        ie11: false,
+        firefox2: false,
+        chrome1: false,
+        chrome83: false,
+        chrome84: true,
+        safari1: false,
+        safari13_1: false,
+        opera10_50: false,
+        graalvm20: false,
+        babel7corejs3: false,
+        typescript3_8corejs3: false,
+      }
+    },
+    {
       name: 'computed instance class fields',
       exec: function () {/*
         class C {

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -597,117 +597,117 @@ return Object.getPrototypeOf(fg) === FinalizationGroup.prototype;
 <td class="no flagged" data-browser="opera_mobile55">Flag<a href="#chrome-weakrefs-note"><sup>[5]</sup></a></td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-instance_class_fields"><span><a class="anchor" href="#test-instance_class_fields">&#xA7;</a><a href="https://github.com/tc39/proposal-class-fields">instance class fields</a></span></td>
-<td class="tally obsolete" data-browser="tr" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally" data-browser="babel7corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20200112" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
-<td class="tally obsolete" data-browser="firefox60" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox66" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox67" data-tally="0" data-flagged-tally="0.25">0/4</td>
-<td class="tally" data-browser="firefox68" data-tally="0" data-flagged-tally="0.5">0/4</td>
-<td class="tally obsolete" data-browser="firefox69" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally obsolete" data-browser="firefox70" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally obsolete" data-browser="firefox71" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally obsolete" data-browser="firefox72" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally obsolete" data-browser="firefox73" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally" data-browser="firefox74" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally" data-browser="firefox75" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally unstable" data-browser="firefox76" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally unstable" data-browser="firefox77" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
-<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome74" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome75" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome76" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome77" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome78" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome79" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome80" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome81" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="chrome83" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="chrome84" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="edge17" data-tally="0">0/4</td>
-<td class="tally" data-browser="edge18" data-tally="0">0/4</td>
-<td class="tally" data-browser="edge79" data-tally="1">4/4</td>
-<td class="tally" data-browser="edge80" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="safari12" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/4</td>
-<td class="tally" data-browser="safari13" data-tally="0">0/4</td>
-<td class="tally" data-browser="safari13_1" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="safaritp" data-tally="0" data-flagged-tally="0.5">0/4</td>
-<td class="tally unstable" data-browser="webkit" data-tally="0" data-flagged-tally="0.5">0/4</td>
-<td class="tally obsolete" data-browser="opera61" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera62" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera63" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera64" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera65" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera66" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera67" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node0_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node0_12" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node4" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node6_5" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node7_6" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node8_3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node8_7" data-tally="0">0/4</td>
-<td class="tally" data-browser="node8_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node10_0" data-tally="0" data-flagged-tally="0.75">0/4</td>
-<td class="tally obsolete" data-browser="node10_4" data-tally="0" data-flagged-tally="0.75">0/4</td>
-<td class="tally" data-browser="node10_9" data-tally="0" data-flagged-tally="0.75">0/4</td>
-<td class="tally obsolete" data-browser="node11_0" data-tally="0" data-flagged-tally="0.75">0/4</td>
-<td class="tally obsolete" data-browser="node12_0" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="node12_5" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="node12_9" data-tally="1">4/4</td>
-<td class="tally" data-browser="node12_11" data-tally="1">4/4</td>
-<td class="tally" data-browser="node13_0" data-tally="1">4/4</td>
-<td class="tally" data-browser="node13_2" data-tally="1">4/4</td>
-<td class="tally" data-browser="node14_0" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="duktape2_2" data-tally="0">0/4</td>
-<td class="tally" data-browser="duktape2_3" data-tally="0">0/4</td>
-<td class="tally" data-browser="graalvm19" data-tally="0">0/4</td>
-<td class="tally" data-browser="graalvm20" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ios11" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ios11_3" data-tally="0">0/4</td>
-<td class="tally" data-browser="ios12" data-tally="0">0/4</td>
-<td class="tally" data-browser="ios12_2" data-tally="0">0/4</td>
-<td class="tally" data-browser="ios13" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="samsung6" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="samsung7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="samsung8" data-tally="0">0/4</td>
-<td class="tally" data-browser="samsung9" data-tally="0" data-flagged-tally="0.75">0/4</td>
-<td class="tally" data-browser="samsung10" data-tally="0" data-flagged-tally="0.75">0/4</td>
-<td class="tally" data-browser="samsung11" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera_mobile51" data-tally="0.25" style="background-color:hsl(30,75%,50%)" data-flagged-tally="0.75">1/4</td>
-<td class="tally obsolete" data-browser="opera_mobile52" data-tally="0.5" style="background-color:hsl(60,64%,50%)" data-flagged-tally="1">2/4</td>
-<td class="tally obsolete" data-browser="opera_mobile53" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera_mobile54" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera_mobile55" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally" data-browser="babel7corejs3" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="closure" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="closure20190215" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="closure20190301" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/5</td>
+<td class="tally" data-browser="closure20200112" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally" data-browser="typescript3_7corejs3" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="firefox60" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="firefox66" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="firefox67" data-tally="0" data-flagged-tally="0.2">0/5</td>
+<td class="tally" data-browser="firefox68" data-tally="0" data-flagged-tally="0.4">0/5</td>
+<td class="tally obsolete" data-browser="firefox69" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td class="tally obsolete" data-browser="firefox70" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td class="tally obsolete" data-browser="firefox71" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td class="tally obsolete" data-browser="firefox72" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td class="tally obsolete" data-browser="firefox73" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td class="tally" data-browser="firefox74" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td class="tally" data-browser="firefox75" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td class="tally unstable" data-browser="firefox76" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td class="tally unstable" data-browser="firefox77" data-tally="0.4" style="background-color:hsl(48,68%,50%)">2/5</td>
+<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="chrome74" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="chrome75" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="chrome76" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="chrome77" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="chrome78" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="chrome79" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="chrome80" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="chrome81" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally unstable" data-browser="chrome83" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally unstable" data-browser="chrome84" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="edge15" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="edge17" data-tally="0">0/5</td>
+<td class="tally" data-browser="edge18" data-tally="0">0/5</td>
+<td class="tally" data-browser="edge79" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="edge80" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="safari12" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/5</td>
+<td class="tally" data-browser="safari13" data-tally="0">0/5</td>
+<td class="tally" data-browser="safari13_1" data-tally="0">0/5</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="0" data-flagged-tally="0.4">0/5</td>
+<td class="tally unstable" data-browser="webkit" data-tally="0" data-flagged-tally="0.4">0/5</td>
+<td class="tally obsolete" data-browser="opera61" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="opera62" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="opera63" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="opera64" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="opera65" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="opera66" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="opera67" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node0_10" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node0_12" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node4" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node6_5" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node7" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node7_6" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node8" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node8_3" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node8_7" data-tally="0">0/5</td>
+<td class="tally" data-browser="node8_10" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node10_0" data-tally="0" data-flagged-tally="0.6">0/5</td>
+<td class="tally obsolete" data-browser="node10_4" data-tally="0" data-flagged-tally="0.6">0/5</td>
+<td class="tally" data-browser="node10_9" data-tally="0" data-flagged-tally="0.6">0/5</td>
+<td class="tally obsolete" data-browser="node11_0" data-tally="0" data-flagged-tally="0.6">0/5</td>
+<td class="tally obsolete" data-browser="node12_0" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="node12_5" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="node12_9" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="node12_11" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="node13_0" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="node13_2" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="node14_0" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="duktape2_2" data-tally="0">0/5</td>
+<td class="tally" data-browser="duktape2_3" data-tally="0">0/5</td>
+<td class="tally" data-browser="graalvm19" data-tally="0">0/5</td>
+<td class="tally" data-browser="graalvm20" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="android4_4" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ios11" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ios11_3" data-tally="0">0/5</td>
+<td class="tally" data-browser="ios12" data-tally="0">0/5</td>
+<td class="tally" data-browser="ios12_2" data-tally="0">0/5</td>
+<td class="tally" data-browser="ios13" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="samsung6" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="samsung7" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="samsung8" data-tally="0">0/5</td>
+<td class="tally" data-browser="samsung9" data-tally="0" data-flagged-tally="0.6">0/5</td>
+<td class="tally" data-browser="samsung10" data-tally="0" data-flagged-tally="0.6">0/5</td>
+<td class="tally" data-browser="samsung11" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="opera_mobile51" data-tally="0.2" style="background-color:hsl(24,77%,50%)" data-flagged-tally="0.6">1/5</td>
+<td class="tally obsolete" data-browser="opera_mobile52" data-tally="0.4" style="background-color:hsl(48,68%,50%)" data-flagged-tally="0.8">2/5</td>
+<td class="tally obsolete" data-browser="opera_mobile53" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="opera_mobile54" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="opera_mobile55" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 </tr>
 <tr class="subtest" data-parent="instance_class_fields" id="test-instance_class_fields_public_instance_class_fields_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Public_instance_fields_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-instance_class_fields_public_instance_class_fields_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Public_instance_fields_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a>public instance class fields <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Class_elements#Public_instance_fields" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 class C {
@@ -1075,12 +1075,134 @@ return new C().x() === 42;
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
+<tr class="subtest" data-parent="instance_class_fields" id="test-instance_class_fields_optional_private_instance_class_fields_access"><td><span><a class="anchor" href="#test-instance_class_fields_optional_private_instance_class_fields_access">&#xA7;</a>optional private instance class fields access</span><script data-source="
+class C {
+  #x = 42;
+  x(o = this){
+    return o?.#x;
+  }
+}
+return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\nclass C {\n  #x = 42;\n  x(o = this){\n    return o?.#x;\n  }\n}\nreturn new C().x() === 42 && new C().x(null) === void 0;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  #x = 42;\n  x(o = this){\n    return o?.#x;\n  }\n}\nreturn new C().x() === 42 && new C().x(null) === void 0;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
+<td class="no" data-browser="babel7corejs3">No</td>
+<td class="unknown obsolete" data-browser="closure">?</td>
+<td class="unknown obsolete" data-browser="closure20190215">?</td>
+<td class="unknown obsolete" data-browser="closure20190301">?</td>
+<td class="unknown obsolete" data-browser="closure20190325">?</td>
+<td class="unknown obsolete" data-browser="closure20190709">?</td>
+<td class="unknown obsolete" data-browser="closure20191027">?</td>
+<td class="unknown obsolete" data-browser="closure20200101">?</td>
+<td class="unknown" data-browser="closure20200112">?</td>
+<td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
+<td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
+<td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
+<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
+<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="no obsolete" data-browser="firefox60">No</td>
+<td class="no obsolete" data-browser="firefox66">No</td>
+<td class="no obsolete" data-browser="firefox67">No</td>
+<td class="no" data-browser="firefox68">No</td>
+<td class="no obsolete" data-browser="firefox69">No</td>
+<td class="no obsolete" data-browser="firefox70">No</td>
+<td class="no obsolete" data-browser="firefox71">No</td>
+<td class="no obsolete" data-browser="firefox72">No</td>
+<td class="no obsolete" data-browser="firefox73">No</td>
+<td class="no" data-browser="firefox74">No</td>
+<td class="no" data-browser="firefox75">No</td>
+<td class="no unstable" data-browser="firefox76">No</td>
+<td class="no unstable" data-browser="firefox77">No</td>
+<td class="no obsolete" data-browser="opera12_10">No</td>
+<td class="no obsolete" data-browser="chrome74">No</td>
+<td class="no obsolete" data-browser="chrome75">No</td>
+<td class="no obsolete" data-browser="chrome76">No</td>
+<td class="no obsolete" data-browser="chrome77">No</td>
+<td class="no obsolete" data-browser="chrome78">No</td>
+<td class="no obsolete" data-browser="chrome79">No</td>
+<td class="no" data-browser="chrome80">No</td>
+<td class="no" data-browser="chrome81">No</td>
+<td class="no unstable" data-browser="chrome83">No</td>
+<td class="yes unstable" data-browser="chrome84">Yes</td>
+<td class="no obsolete" data-browser="edge15">No</td>
+<td class="no obsolete" data-browser="edge17">No</td>
+<td class="no" data-browser="edge18">No</td>
+<td class="no" data-browser="edge79">No</td>
+<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="safari11_1">No</td>
+<td class="no obsolete" data-browser="safari12">No</td>
+<td class="no obsolete" data-browser="safari12_1">No</td>
+<td class="no" data-browser="safari13">No</td>
+<td class="no" data-browser="safari13_1">No</td>
+<td class="no unstable" data-browser="safaritp">No</td>
+<td class="no unstable" data-browser="webkit">No</td>
+<td class="no obsolete" data-browser="opera61">No</td>
+<td class="no obsolete" data-browser="opera62">No</td>
+<td class="no obsolete" data-browser="opera63">No</td>
+<td class="no obsolete" data-browser="opera64">No</td>
+<td class="no obsolete" data-browser="opera65">No</td>
+<td class="no" data-browser="opera66">No</td>
+<td class="no" data-browser="opera67">No</td>
+<td class="no obsolete" data-browser="phantom2_1">No</td>
+<td class="no obsolete" data-browser="node0_10">No</td>
+<td class="no obsolete" data-browser="node0_12">No</td>
+<td class="no obsolete" data-browser="node4">No</td>
+<td class="no obsolete" data-browser="node6_5">No</td>
+<td class="no obsolete" data-browser="node7">No</td>
+<td class="no obsolete" data-browser="node7_6">No</td>
+<td class="no obsolete" data-browser="node8">No</td>
+<td class="no obsolete" data-browser="node8_3">No</td>
+<td class="no obsolete" data-browser="node8_7">No</td>
+<td class="no" data-browser="node8_10">No</td>
+<td class="no obsolete" data-browser="node10_0">No</td>
+<td class="no obsolete" data-browser="node10_4">No</td>
+<td class="no" data-browser="node10_9">No</td>
+<td class="no obsolete" data-browser="node11_0">No</td>
+<td class="no obsolete" data-browser="node12_0">No</td>
+<td class="no obsolete" data-browser="node12_5">No</td>
+<td class="no obsolete" data-browser="node12_9">No</td>
+<td class="no" data-browser="node12_11">No</td>
+<td class="no" data-browser="node13_0">No</td>
+<td class="no" data-browser="node13_2">No</td>
+<td class="no" data-browser="node14_0">No</td>
+<td class="unknown obsolete" data-browser="duktape2_0">?</td>
+<td class="unknown obsolete" data-browser="duktape2_1">?</td>
+<td class="unknown obsolete" data-browser="duktape2_2">?</td>
+<td class="unknown" data-browser="duktape2_3">?</td>
+<td class="unknown" data-browser="graalvm19">?</td>
+<td class="no" data-browser="graalvm20">No</td>
+<td class="no obsolete" data-browser="android4_4">No</td>
+<td class="no obsolete" data-browser="android4_4_3">No</td>
+<td class="no obsolete" data-browser="ios10_3">No</td>
+<td class="no obsolete" data-browser="ios11">No</td>
+<td class="no obsolete" data-browser="ios11_3">No</td>
+<td class="no" data-browser="ios12">No</td>
+<td class="no" data-browser="ios12_2">No</td>
+<td class="no" data-browser="ios13">No</td>
+<td class="no obsolete" data-browser="samsung6">No</td>
+<td class="no obsolete" data-browser="samsung7">No</td>
+<td class="no obsolete" data-browser="samsung8">No</td>
+<td class="no" data-browser="samsung9">No</td>
+<td class="no" data-browser="samsung10">No</td>
+<td class="no" data-browser="samsung11">No</td>
+<td class="no obsolete" data-browser="opera_mobile51">No</td>
+<td class="no obsolete" data-browser="opera_mobile52">No</td>
+<td class="no obsolete" data-browser="opera_mobile53">No</td>
+<td class="no" data-browser="opera_mobile54">No</td>
+<td class="no" data-browser="opera_mobile55">No</td>
+</tr>
 <tr class="subtest" data-parent="instance_class_fields" id="test-instance_class_fields_computed_instance_class_fields"><td><span><a class="anchor" href="#test-instance_class_fields_computed_instance_class_fields">&#xA7;</a>computed instance class fields</span><script data-source="
 class C {
   [&apos;x&apos;] = 42;
 }
 return new C().x === 42;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("7");try{return Function("asyncTestPassed","\nclass C {\n  ['x'] = 42;\n}\nreturn new C().x === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("7");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  ['x'] = 42;\n}\nreturn new C().x === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("8");try{return Function("asyncTestPassed","\nclass C {\n  ['x'] = 42;\n}\nreturn new C().x === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("8");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  ['x'] = 42;\n}\nreturn new C().x === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -1312,7 +1434,7 @@ class C {
   static x = &apos;x&apos;;
 }
 return C.x === &apos;x&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("9");try{return Function("asyncTestPassed","\nclass C {\n  static x = 'x';\n}\nreturn C.x === 'x';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("9");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  static x = 'x';\n}\nreturn C.x === 'x';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("10");try{return Function("asyncTestPassed","\nclass C {\n  static x = 'x';\n}\nreturn C.x === 'x';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("10");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  static x = 'x';\n}\nreturn C.x === 'x';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="yes obsolete" data-browser="tr">Yes</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
@@ -1434,7 +1556,7 @@ class C {
   }
 }
 return new C().x() === 42;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("10");try{return Function("asyncTestPassed","\nclass C {\n  static #x = 42;\n  x(){\n    return C.#x;\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("10");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  static #x = 42;\n  x(){\n    return C.#x;\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("11");try{return Function("asyncTestPassed","\nclass C {\n  static #x = 42;\n  x(){\n    return C.#x;\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("11");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  static #x = 42;\n  x(){\n    return C.#x;\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -1553,7 +1675,7 @@ class C {
   static [&apos;x&apos;] = 42;
 }
 return C.x === 42;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("11");try{return Function("asyncTestPassed","\nclass C {\n  static ['x'] = 42;\n}\nreturn C.x === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("11");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  static ['x'] = 42;\n}\nreturn C.x === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("12");try{return Function("asyncTestPassed","\nclass C {\n  static ['x'] = 42;\n}\nreturn C.x === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("12");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  static ['x'] = 42;\n}\nreturn C.x === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -1788,7 +1910,7 @@ class C {
   }
 }
 return new C().x() === 42;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("13");try{return Function("asyncTestPassed","\nclass C {\n  #x() { return 42; }\n  x() {\n    return this.#x();\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("13");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  #x() { return 42; }\n  x() {\n    return this.#x();\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("14");try{return Function("asyncTestPassed","\nclass C {\n  #x() { return 42; }\n  x() {\n    return this.#x();\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("14");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  #x() { return 42; }\n  x() {\n    return this.#x();\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -1910,7 +2032,7 @@ class C {
   }
 }
 return new C().x() === 42;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("14");try{return Function("asyncTestPassed","\nclass C {\n  static #x() { return 42; }\n  x() {\n    return C.#x();\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("14");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  static #x() { return 42; }\n  x() {\n    return C.#x();\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("15");try{return Function("asyncTestPassed","\nclass C {\n  static #x() { return 42; }\n  x() {\n    return C.#x();\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("15");return Function("asyncTestPassed","'use strict';"+"\nclass C {\n  static #x() { return 42; }\n  x() {\n    return C.#x();\n  }\n}\nreturn new C().x() === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -2035,7 +2157,7 @@ class C {
   }
 }
 return new C().x() === 42 &amp;&amp; y;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("15");try{return Function("asyncTestPassed","\nvar y = false;\nclass C {\n  get #x() { return 42; }\n  set #x(x) { y = x; }\n  x() {\n    this.#x = true;\n    return this.#x;\n  }\n}\nreturn new C().x() === 42 && y;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("15");return Function("asyncTestPassed","'use strict';"+"\nvar y = false;\nclass C {\n  get #x() { return 42; }\n  set #x(x) { y = x; }\n  x() {\n    this.#x = true;\n    return this.#x;\n  }\n}\nreturn new C().x() === 42 && y;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nvar y = false;\nclass C {\n  get #x() { return 42; }\n  set #x(x) { y = x; }\n  x() {\n    this.#x = true;\n    return this.#x;\n  }\n}\nreturn new C().x() === 42 && y;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nvar y = false;\nclass C {\n  get #x() { return 42; }\n  set #x(x) { y = x; }\n  x() {\n    this.#x = true;\n    return this.#x;\n  }\n}\nreturn new C().x() === 42 && y;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -2160,7 +2282,7 @@ class C {
   }
 }
 return new C().x() === 42 &amp;&amp; y;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("16");try{return Function("asyncTestPassed","\nvar y = false;\nclass C {\n  static get #x() { return 42; }\n  static set #x(x) { y = x; }\n  x() {\n    C.#x = true;\n    return C.#x;\n  }\n}\nreturn new C().x() === 42 && y;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("16");return Function("asyncTestPassed","'use strict';"+"\nvar y = false;\nclass C {\n  static get #x() { return 42; }\n  static set #x(x) { y = x; }\n  x() {\n    C.#x = true;\n    return C.#x;\n  }\n}\nreturn new C().x() === 42 && y;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");try{return Function("asyncTestPassed","\nvar y = false;\nclass C {\n  static get #x() { return 42; }\n  static set #x(x) { y = x; }\n  x() {\n    C.#x = true;\n    return C.#x;\n  }\n}\nreturn new C().x() === 42 && y;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("17");return Function("asyncTestPassed","'use strict';"+"\nvar y = false;\nclass C {\n  static get #x() { return 42; }\n  static set #x(x) { y = x; }\n  x() {\n    C.#x = true;\n    return C.#x;\n  }\n}\nreturn new C().x() === 42 && y;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -2277,7 +2399,7 @@ return new C().x() === 42 &amp;&amp; y;
 <tr significance="0.25"><td id="test-numeric_separators"><span><a class="anchor" href="#test-numeric_separators">&#xA7;</a><a href="https://github.com/tc39/proposal-numeric-separator">numeric separators</a></span><script data-source="
 return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
   0b1010_0001_1000_0101 === 0b1010000110000101;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("17");try{return Function("asyncTestPassed","\nreturn 1_000_000.000_001 === 1000000.000001 &&\n  0b1010_0001_1000_0101 === 0b1010000110000101;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("17");return Function("asyncTestPassed","'use strict';"+"\nreturn 1_000_000.000_001 === 1000000.000001 &&\n  0b1010_0001_1000_0101 === 0b1010000110000101;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");try{return Function("asyncTestPassed","\nreturn 1_000_000.000_001 === 1000000.000001 &&\n  0b1010_0001_1000_0101 === 0b1010000110000101;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("18");return Function("asyncTestPassed","'use strict';"+"\nreturn 1_000_000.000_001 === 1000000.000001 &&\n  0b1010_0001_1000_0101 === 0b1010000110000101;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -2393,7 +2515,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 </tr>
 <tr significance="0.25"><td id="test-String.prototype.replaceAll"><span><a class="anchor" href="#test-String.prototype.replaceAll">&#xA7;</a><a href="https://github.com/tc39/proposal-string-replace-all">String.prototype.replaceAll</a></span><script data-source="
 return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &apos;) === &apos;q=query string parameters&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("18");try{return Function("asyncTestPassed","\nreturn 'q=query+string+parameters'.replaceAll('+', ' ') === 'q=query string parameters';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("18");return Function("asyncTestPassed","'use strict';"+"\nreturn 'q=query+string+parameters'.replaceAll('+', ' ') === 'q=query string parameters';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");try{return Function("asyncTestPassed","\nreturn 'q=query+string+parameters'.replaceAll('+', ' ') === 'q=query string parameters';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("19");return Function("asyncTestPassed","'use strict';"+"\nreturn 'q=query+string+parameters'.replaceAll('+', ' ') === 'q=query string parameters';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -2515,7 +2637,7 @@ Promise.any([
 ]).then(it =&gt; {
   if (it === 1) asyncTestPassed();
 });
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("19");try{return Function("asyncTestPassed","\nPromise.any([\n  Promise.resolve(1),\n  Promise.reject(2),\n  Promise.resolve(3)\n]).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("19");return Function("asyncTestPassed","'use strict';"+"\nPromise.any([\n  Promise.resolve(1),\n  Promise.reject(2),\n  Promise.resolve(3)\n]).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("20");try{return Function("asyncTestPassed","\nPromise.any([\n  Promise.resolve(1),\n  Promise.reject(2),\n  Promise.resolve(3)\n]).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("20");return Function("asyncTestPassed","'use strict';"+"\nPromise.any([\n  Promise.resolve(1),\n  Promise.reject(2),\n  Promise.resolve(3)\n]).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -3109,7 +3231,7 @@ a ||= 2;
 b ||= 2;
 c ||= 2;
 return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("24");try{return Function("asyncTestPassed","\nlet a;\nlet b = 0;\nlet c = 1;\na ||= 2;\nb ||= 2;\nc ||= 2;\nreturn a === 2 && b === 2 && c === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("24");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet b = 0;\nlet c = 1;\na ||= 2;\nb ||= 2;\nc ||= 2;\nreturn a === 2 && b === 2 && c === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("25");try{return Function("asyncTestPassed","\nlet a;\nlet b = 0;\nlet c = 1;\na ||= 2;\nb ||= 2;\nc ||= 2;\nreturn a === 2 && b === 2 && c === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("25");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet b = 0;\nlet c = 1;\na ||= 2;\nb ||= 2;\nc ||= 2;\nreturn a === 2 && b === 2 && c === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -3228,7 +3350,7 @@ let a = 1;
 let i = 1;
 a ||= ++i;
 return a === 1 &amp;&amp; i === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("25");try{return Function("asyncTestPassed","\nlet a = 1;\nlet i = 1;\na ||= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("25");return Function("asyncTestPassed","'use strict';"+"\nlet a = 1;\nlet i = 1;\na ||= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\nlet a = 1;\nlet i = 1;\na ||= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\nlet a = 1;\nlet i = 1;\na ||= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -3347,7 +3469,7 @@ let i = 1;
 var obj = { get x() { return 1 }, set x(n) { i++; } };
 obj.x ||= 2;
 return i === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("26");try{return Function("asyncTestPassed","\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ||= 2;\nreturn i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("26");return Function("asyncTestPassed","'use strict';"+"\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ||= 2;\nreturn i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");try{return Function("asyncTestPassed","\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ||= 2;\nreturn i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("27");return Function("asyncTestPassed","'use strict';"+"\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ||= 2;\nreturn i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -3469,7 +3591,7 @@ a &amp;&amp;= 2;
 b &amp;&amp;= 2;
 c &amp;&amp;= 2;
 return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("27");try{return Function("asyncTestPassed","\nlet a;\nlet b = 0;\nlet c = 1;\na &&= 2;\nb &&= 2;\nc &&= 2;\nreturn typeof a === 'undefined' && b === 0 && c === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("27");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet b = 0;\nlet c = 1;\na &&= 2;\nb &&= 2;\nc &&= 2;\nreturn typeof a === 'undefined' && b === 0 && c === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nlet a;\nlet b = 0;\nlet c = 1;\na &&= 2;\nb &&= 2;\nc &&= 2;\nreturn typeof a === 'undefined' && b === 0 && c === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet b = 0;\nlet c = 1;\na &&= 2;\nb &&= 2;\nc &&= 2;\nreturn typeof a === 'undefined' && b === 0 && c === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -3588,7 +3710,7 @@ let a;
 let i = 1;
 a &amp;&amp;= ++i;
 return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("28");try{return Function("asyncTestPassed","\nlet a;\nlet i = 1;\na &&= ++i;\nreturn typeof a === 'undefined' && i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("28");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet i = 1;\na &&= ++i;\nreturn typeof a === 'undefined' && i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("29");try{return Function("asyncTestPassed","\nlet a;\nlet i = 1;\na &&= ++i;\nreturn typeof a === 'undefined' && i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("29");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet i = 1;\na &&= ++i;\nreturn typeof a === 'undefined' && i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -3707,7 +3829,7 @@ let i = 1;
 var obj = { get x() { return }, set x(n) { i++; } };
 obj.x &amp;&amp;= 2;
 return i === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("29");try{return Function("asyncTestPassed","\nlet i = 1;\nvar obj = { get x() { return }, set x(n) { i++; } };\nobj.x &&= 2;\nreturn i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("29");return Function("asyncTestPassed","'use strict';"+"\nlet i = 1;\nvar obj = { get x() { return }, set x(n) { i++; } };\nobj.x &&= 2;\nreturn i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\nlet i = 1;\nvar obj = { get x() { return }, set x(n) { i++; } };\nobj.x &&= 2;\nreturn i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\nlet i = 1;\nvar obj = { get x() { return }, set x(n) { i++; } };\nobj.x &&= 2;\nreturn i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -3829,7 +3951,7 @@ a ??= 2;
 b ??= 2;
 c ??= 2;
 return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("30");try{return Function("asyncTestPassed","\nlet a;\nlet b = 0;\nlet c = 1;\na ??= 2;\nb ??= 2;\nc ??= 2;\nreturn a === 2 && b === 0 && c === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("30");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet b = 0;\nlet c = 1;\na ??= 2;\nb ??= 2;\nc ??= 2;\nreturn a === 2 && b === 0 && c === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\nlet a;\nlet b = 0;\nlet c = 1;\na ??= 2;\nb ??= 2;\nc ??= 2;\nreturn a === 2 && b === 0 && c === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet b = 0;\nlet c = 1;\na ??= 2;\nb ??= 2;\nc ??= 2;\nreturn a === 2 && b === 0 && c === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -3948,7 +4070,7 @@ let a = 1;
 let i = 1;
 a ??= ++i;
 return a === 1 &amp;&amp; i === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("31");try{return Function("asyncTestPassed","\nlet a = 1;\nlet i = 1;\na ??= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("31");return Function("asyncTestPassed","'use strict';"+"\nlet a = 1;\nlet i = 1;\na ??= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\nlet a = 1;\nlet i = 1;\na ??= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\nlet a = 1;\nlet i = 1;\na ??= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -4067,7 +4189,7 @@ let i = 1;
 var obj = { get x() { return 1 }, set x(n) { i++; } };
 obj.x ??= 2;
 return i === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("32");try{return Function("asyncTestPassed","\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ??= 2;\nreturn i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("32");return Function("asyncTestPassed","'use strict';"+"\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ??= 2;\nreturn i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("33");try{return Function("asyncTestPassed","\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ??= 2;\nreturn i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("33");return Function("asyncTestPassed","'use strict';"+"\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ??= 2;\nreturn i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -4187,7 +4309,7 @@ try {
 } catch (e) {
   return false
 }
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("33");try{return Function("asyncTestPassed","\ntry {\n  return !eval('#!/wash/your/hands');\n} catch (e) {\n  return false\n}\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("33");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  return !eval('#!/wash/your/hands');\n} catch (e) {\n  return false\n}\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("34");try{return Function("asyncTestPassed","\ntry {\n  return !eval('#!/wash/your/hands');\n} catch (e) {\n  return false\n}\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("34");return Function("asyncTestPassed","'use strict';"+"\ntry {\n  return !eval('#!/wash/your/hands');\n} catch (e) {\n  return false\n}\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -4311,7 +4433,7 @@ function* generator() {
 var iter = generator();
 iter.next(&apos;tromple&apos;);
 return result === &apos;tromple&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("34");try{return Function("asyncTestPassed","\nvar result;\nfunction* generator() {\n  result = function.sent;\n}\nvar iter = generator();\niter.next('tromple');\nreturn result === 'tromple';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("34");return Function("asyncTestPassed","'use strict';"+"\nvar result;\nfunction* generator() {\n  result = function.sent;\n}\nvar iter = generator();\niter.next('tromple');\nreturn result === 'tromple';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("35");try{return Function("asyncTestPassed","\nvar result;\nfunction* generator() {\n  result = function.sent;\n}\nvar iter = generator();\niter.next('tromple');\nreturn result === 'tromple';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("35");return Function("asyncTestPassed","'use strict';"+"\nvar result;\nfunction* generator() {\n  result = function.sent;\n}\nvar iter = generator();\niter.next('tromple');\nreturn result === 'tromple';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
@@ -4548,7 +4670,7 @@ function nonconf(target, name, descriptor) {
   return descriptor;
 }
 return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable === false;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("36");try{return Function("asyncTestPassed","\nclass A {\n  @nonconf\n  get B() {}\n}\nfunction nonconf(target, name, descriptor) {\n  descriptor.configurable = false;\n  return descriptor;\n}\nreturn Object.getOwnPropertyDescriptor(A.prototype, \"B\").configurable === false;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("36");return Function("asyncTestPassed","'use strict';"+"\nclass A {\n  @nonconf\n  get B() {}\n}\nfunction nonconf(target, name, descriptor) {\n  descriptor.configurable = false;\n  return descriptor;\n}\nreturn Object.getOwnPropertyDescriptor(A.prototype, \"B\").configurable === false;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("37");try{return Function("asyncTestPassed","\nclass A {\n  @nonconf\n  get B() {}\n}\nfunction nonconf(target, name, descriptor) {\n  descriptor.configurable = false;\n  return descriptor;\n}\nreturn Object.getOwnPropertyDescriptor(A.prototype, \"B\").configurable === false;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("37");return Function("asyncTestPassed","'use strict';"+"\nclass A {\n  @nonconf\n  get B() {}\n}\nfunction nonconf(target, name, descriptor) {\n  descriptor.configurable = false;\n  return descriptor;\n}\nreturn Object.getOwnPropertyDescriptor(A.prototype, \"B\").configurable === false;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No<a href="#babel-decorators-legacy-note"><sup>[17]</sup></a></td>
@@ -4667,7 +4789,7 @@ return typeof Realm === &quot;function&quot;
   &amp;&amp; [&quot;eval&quot;, &quot;global&quot;, &quot;intrinsics&quot;, &quot;stdlib&quot;, &quot;directEval&quot;, &quot;indirectEval&quot;, &quot;initGlobal&quot;, &quot;nonEval&quot;].every(function(key){
     return key in Realm.prototype;
   });
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("37");try{return Function("asyncTestPassed","\nreturn typeof Realm === \"function\"\n  && [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\", \"indirectEval\", \"initGlobal\", \"nonEval\"].every(function(key){\n    return key in Realm.prototype;\n  });\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("37");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Realm === \"function\"\n  && [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\", \"indirectEval\", \"initGlobal\", \"nonEval\"].every(function(key){\n    return key in Realm.prototype;\n  });\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("38");try{return Function("asyncTestPassed","\nreturn typeof Realm === \"function\"\n  && [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\", \"indirectEval\", \"initGlobal\", \"nonEval\"].every(function(key){\n    return key in Realm.prototype;\n  });\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("38");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Realm === \"function\"\n  && [\"eval\", \"global\", \"intrinsics\", \"stdlib\", \"directEval\", \"indirectEval\", \"initGlobal\", \"nonEval\"].every(function(key){\n    return key in Realm.prototype;\n  });\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -4902,7 +5024,7 @@ try {
 } catch (e) {
   return a + e === 42;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("39");try{return Function("asyncTestPassed","\nvar a, b;\ntry {\n  a = 19 || throw 77;\n  b = 88 && throw 23;\n} catch (e) {\n  return a + e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("39");return Function("asyncTestPassed","'use strict';"+"\nvar a, b;\ntry {\n  a = 19 || throw 77;\n  b = 88 && throw 23;\n} catch (e) {\n  return a + e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("40");try{return Function("asyncTestPassed","\nvar a, b;\ntry {\n  a = 19 || throw 77;\n  b = 88 && throw 23;\n} catch (e) {\n  return a + e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("40");return Function("asyncTestPassed","'use strict';"+"\nvar a, b;\ntry {\n  a = 19 || throw 77;\n  b = 88 && throw 23;\n} catch (e) {\n  return a + e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -5028,7 +5150,7 @@ try {
 } catch (e) {
   return e === 42;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("40");try{return Function("asyncTestPassed","\nfunction fn (arg = throw 42) {\n  return arg;\n}\n\nif (fn(21) !== 21) return false;\n\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("40");return Function("asyncTestPassed","'use strict';"+"\nfunction fn (arg = throw 42) {\n  return arg;\n}\n\nif (fn(21) !== 21) return false;\n\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("41");try{return Function("asyncTestPassed","\nfunction fn (arg = throw 42) {\n  return arg;\n}\n\nif (fn(21) !== 21) return false;\n\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("41");return Function("asyncTestPassed","'use strict';"+"\nfunction fn (arg = throw 42) {\n  return arg;\n}\n\nif (fn(21) !== 21) return false;\n\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -5149,7 +5271,7 @@ try {
 } catch (e) {
   return e === 42;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("41");try{return Function("asyncTestPassed","\nvar fn = () => throw 42;\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("41");return Function("asyncTestPassed","'use strict';"+"\nvar fn = () => throw 42;\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("42");try{return Function("asyncTestPassed","\nvar fn = () => throw 42;\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("42");return Function("asyncTestPassed","'use strict';"+"\nvar fn = () => throw 42;\ntry {\n  fn();\n} catch (e) {\n  return e === 42;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -5270,7 +5392,7 @@ try {
 } catch (e) {
   return e === 21;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("42");try{return Function("asyncTestPassed","\ntrue ? 42 : throw 21;\ntry {\n  false ? 42 : throw 21;\n} catch (e) {\n  return e === 21;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("42");return Function("asyncTestPassed","'use strict';"+"\ntrue ? 42 : throw 21;\ntry {\n  false ? 42 : throw 21;\n} catch (e) {\n  return e === 21;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("43");try{return Function("asyncTestPassed","\ntrue ? 42 : throw 21;\ntry {\n  false ? 42 : throw 21;\n} catch (e) {\n  return e === 21;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("43");return Function("asyncTestPassed","'use strict';"+"\ntrue ? 42 : throw 21;\ntry {\n  false ? 42 : throw 21;\n} catch (e) {\n  return e === 21;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -5502,7 +5624,7 @@ var set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));
 return set.size === 2
   &amp;&amp; set.has(2)
   &amp;&amp; set.has(3);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("44");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));\nreturn set.size === 2\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("44");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));\nreturn set.size === 2\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("45");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));\nreturn set.size === 2\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("45");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).intersection(new Set([2, 3, 4]));\nreturn set.size === 2\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -5622,7 +5744,7 @@ return set.size === 3
   &amp;&amp; set.has(1)
   &amp;&amp; set.has(2)
   &amp;&amp; set.has(3);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("45");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).union(new Set([2, 3]));\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("45");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).union(new Set([2, 3]));\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("46");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).union(new Set([2, 3]));\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("46");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).union(new Set([2, 3]));\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -5741,7 +5863,7 @@ var set = new Set([1, 2, 3]).difference(new Set([3, 4]));
 return set.size === 2
   &amp;&amp; set.has(1)
   &amp;&amp; set.has(2);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("46");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).difference(new Set([3, 4]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(2);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("46");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).difference(new Set([3, 4]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(2);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("47");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).difference(new Set([3, 4]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(2);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("47");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).difference(new Set([3, 4]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(2);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -5860,7 +5982,7 @@ var set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));
 return set.size === 2
   &amp;&amp; set.has(1)
   &amp;&amp; set.has(3);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("47");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("47");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("48");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("48");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).symmetricDifference(new Set([2, 3]));\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -5976,7 +6098,7 @@ return set.size === 2
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.isDisjointFrom"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.isDisjointFrom">&#xA7;</a>Set.prototype.isDisjointFrom</span><script data-source="
 return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("48");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("48");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("49");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("49");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -6092,7 +6214,7 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.isSubsetOf"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.isSubsetOf">&#xA7;</a>Set.prototype.isSubsetOf</span><script data-source="
 return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("49");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("49");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("50");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("50");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -6208,7 +6330,7 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 </tr>
 <tr class="subtest" data-parent="Set_methods" id="test-Set_methods_Set.prototype.isSupersetOf"><td><span><a class="anchor" href="#test-Set_methods_Set.prototype.isSupersetOf">&#xA7;</a>Set.prototype.isSupersetOf</span><script data-source="
 return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("50");try{return Function("asyncTestPassed","\nreturn new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("50");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("51");try{return Function("asyncTestPassed","\nreturn new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("51");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -6440,7 +6562,7 @@ const buffer1 = new Uint8Array([1, 2]).buffer;
 const buffer2 = buffer1.transfer();
 return buffer1.byteLength === 0
   &amp;&amp; buffer2.byteLength === 2;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("52");try{return Function("asyncTestPassed","\nconst buffer1 = new Uint8Array([1, 2]).buffer;\nconst buffer2 = buffer1.transfer();\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("52");return Function("asyncTestPassed","'use strict';"+"\nconst buffer1 = new Uint8Array([1, 2]).buffer;\nconst buffer2 = buffer1.transfer();\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("53");try{return Function("asyncTestPassed","\nconst buffer1 = new Uint8Array([1, 2]).buffer;\nconst buffer2 = buffer1.transfer();\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("53");return Function("asyncTestPassed","'use strict';"+"\nconst buffer1 = new Uint8Array([1, 2]).buffer;\nconst buffer2 = buffer1.transfer();\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -6559,7 +6681,7 @@ const buffer1 = new ArrayBuffer(1024);
 const buffer2 = buffer1.realloc(256);
 return buffer1.byteLength === 0
   &amp;&amp; buffer2.byteLength === 256;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("53");try{return Function("asyncTestPassed","\nconst buffer1 = new ArrayBuffer(1024);\nconst buffer2 = buffer1.realloc(256);\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 256;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("53");return Function("asyncTestPassed","'use strict';"+"\nconst buffer1 = new ArrayBuffer(1024);\nconst buffer2 = buffer1.realloc(256);\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 256;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("54");try{return Function("asyncTestPassed","\nconst buffer1 = new ArrayBuffer(1024);\nconst buffer2 = buffer1.realloc(256);\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 256;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("54");return Function("asyncTestPassed","'use strict';"+"\nconst buffer1 = new ArrayBuffer(1024);\nconst buffer2 = buffer1.realloc(256);\nreturn buffer1.byteLength === 0\n  && buffer2.byteLength === 256;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -6791,7 +6913,7 @@ const map = new Map([[&apos;a&apos;, 1]]);
 if (map.upsert(&apos;a&apos;, it =&gt; 2, () =&gt; 3) !== 2) return false;
 if (map.upsert(&apos;b&apos;, it =&gt; 2, () =&gt; 3) !== 3) return false;
 return Array.from(map).join() === &apos;a,2,b,3&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("55");try{return Function("asyncTestPassed","\nconst map = new Map([['a', 1]]);\nif (map.upsert('a', it => 2, () => 3) !== 2) return false;\nif (map.upsert('b', it => 2, () => 3) !== 3) return false;\nreturn Array.from(map).join() === 'a,2,b,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("55");return Function("asyncTestPassed","'use strict';"+"\nconst map = new Map([['a', 1]]);\nif (map.upsert('a', it => 2, () => 3) !== 2) return false;\nif (map.upsert('b', it => 2, () => 3) !== 3) return false;\nreturn Array.from(map).join() === 'a,2,b,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("56");try{return Function("asyncTestPassed","\nconst map = new Map([['a', 1]]);\nif (map.upsert('a', it => 2, () => 3) !== 2) return false;\nif (map.upsert('b', it => 2, () => 3) !== 3) return false;\nreturn Array.from(map).join() === 'a,2,b,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("56");return Function("asyncTestPassed","'use strict';"+"\nconst map = new Map([['a', 1]]);\nif (map.upsert('a', it => 2, () => 3) !== 2) return false;\nif (map.upsert('b', it => 2, () => 3) !== 3) return false;\nreturn Array.from(map).join() === 'a,2,b,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -6911,7 +7033,7 @@ const map = new WeakMap([[a, 1]]);
 if (map.upsert(a, it =&gt; 2, () =&gt; 3) !== 2) return false;
 if (map.upsert(b, it =&gt; 2, () =&gt; 3) !== 3) return false;
 return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("56");try{return Function("asyncTestPassed","\nconst a = {}, b = {};\nconst map = new WeakMap([[a, 1]]);\nif (map.upsert(a, it => 2, () => 3) !== 2) return false;\nif (map.upsert(b, it => 2, () => 3) !== 3) return false;\nreturn map.get(a) === 2 && map.get(b) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("56");return Function("asyncTestPassed","'use strict';"+"\nconst a = {}, b = {};\nconst map = new WeakMap([[a, 1]]);\nif (map.upsert(a, it => 2, () => 3) !== 2) return false;\nif (map.upsert(b, it => 2, () => 3) !== 3) return false;\nreturn map.get(a) === 2 && map.get(b) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("57");try{return Function("asyncTestPassed","\nconst a = {}, b = {};\nconst map = new WeakMap([[a, 1]]);\nif (map.upsert(a, it => 2, () => 3) !== 2) return false;\nif (map.upsert(b, it => 2, () => 3) !== 3) return false;\nreturn map.get(a) === 2 && map.get(b) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("57");return Function("asyncTestPassed","'use strict';"+"\nconst a = {}, b = {};\nconst map = new WeakMap([[a, 1]]);\nif (map.upsert(a, it => 2, () => 3) !== 2) return false;\nif (map.upsert(b, it => 2, () => 3) !== 3) return false;\nreturn map.get(a) === 2 && map.get(b) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -7028,7 +7150,7 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <tr significance="0.25"><td id="test-Array.isTemplateObject"><span><a class="anchor" href="#test-Array.isTemplateObject">&#xA7;</a><a href="https://github.com/tc39/proposal-array-is-template-object">Array.isTemplateObject</a></span><script data-source="
 return !Array.isTemplateObject([])
   &amp;&amp; Array.isTemplateObject((it =&gt; it)`a{1}c`);
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("57");try{return Function("asyncTestPassed","\nreturn !Array.isTemplateObject([])\n  && Array.isTemplateObject((it => it)`a{1}c`);\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("57");return Function("asyncTestPassed","'use strict';"+"\nreturn !Array.isTemplateObject([])\n  && Array.isTemplateObject((it => it)`a{1}c`);\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("58");try{return Function("asyncTestPassed","\nreturn !Array.isTemplateObject([])\n  && Array.isTemplateObject((it => it)`a{1}c`);\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("58");return Function("asyncTestPassed","'use strict';"+"\nreturn !Array.isTemplateObject([])\n  && Array.isTemplateObject((it => it)`a{1}c`);\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -7257,7 +7379,7 @@ return !Array.isTemplateObject([])
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_instanceof_Iterator"><td><span><a class="anchor" href="#test-Iterator_Helpers_instanceof_Iterator">&#xA7;</a>instanceof Iterator</span><script data-source="
 return [1, 2, 3].values() instanceof Iterator;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("59");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values() instanceof Iterator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("59");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values() instanceof Iterator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("60");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values() instanceof Iterator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("60");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values() instanceof Iterator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -7375,7 +7497,7 @@ return [1, 2, 3].values() instanceof Iterator;
 class Class extends Iterator { }
 const instance = new Class();
 return instance[Symbol.iterator]() === instance;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("60");try{return Function("asyncTestPassed","\nclass Class extends Iterator { }\nconst instance = new Class();\nreturn instance[Symbol.iterator]() === instance;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("60");return Function("asyncTestPassed","'use strict';"+"\nclass Class extends Iterator { }\nconst instance = new Class();\nreturn instance[Symbol.iterator]() === instance;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("61");try{return Function("asyncTestPassed","\nclass Class extends Iterator { }\nconst instance = new Class();\nreturn instance[Symbol.iterator]() === instance;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("61");return Function("asyncTestPassed","'use strict';"+"\nclass Class extends Iterator { }\nconst instance = new Class();\nreturn instance[Symbol.iterator]() === instance;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -7494,7 +7616,7 @@ const iterator = Iterator.from([1, 2, 3]);
 return &apos;next&apos; in iterator
   &amp;&amp; iterator instanceof Iterator
   &amp;&amp; Array.from(iterator).join() === &apos;1,2,3&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("61");try{return Function("asyncTestPassed","\nconst iterator = Iterator.from([1, 2, 3]);\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("61");return Function("asyncTestPassed","'use strict';"+"\nconst iterator = Iterator.from([1, 2, 3]);\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("62");try{return Function("asyncTestPassed","\nconst iterator = Iterator.from([1, 2, 3]);\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("62");return Function("asyncTestPassed","'use strict';"+"\nconst iterator = Iterator.from([1, 2, 3]);\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -7618,7 +7740,7 @@ const iterator = Iterator.from({
 return &apos;next&apos; in iterator
   &amp;&amp; iterator instanceof Iterator
   &amp;&amp; Array.from(iterator).join() === &apos;1,2,3&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("62");try{return Function("asyncTestPassed","\nconst iterator = Iterator.from({\n  i: 0,\n  next() {\n    return { value: ++this.i, done: this.i > 3 };\n  }\n});\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("62");return Function("asyncTestPassed","'use strict';"+"\nconst iterator = Iterator.from({\n  i: 0,\n  next() {\n    return { value: ++this.i, done: this.i > 3 };\n  }\n});\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("63");try{return Function("asyncTestPassed","\nconst iterator = Iterator.from({\n  i: 0,\n  next() {\n    return { value: ++this.i, done: this.i > 3 };\n  }\n});\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("63");return Function("asyncTestPassed","'use strict';"+"\nconst iterator = Iterator.from({\n  i: 0,\n  next() {\n    return { value: ++this.i, done: this.i > 3 };\n  }\n});\nreturn 'next' in iterator\n  && iterator instanceof Iterator\n  && Array.from(iterator).join() === '1,2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -7734,7 +7856,7 @@ return &apos;next&apos; in iterator
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.asIndexedPairs"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.asIndexedPairs">&#xA7;</a>Iterator.prototype.asIndexedPairs</span><script data-source="
 return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,2,3&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("63");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().asIndexedPairs()).join() === '0,1,1,2,2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("63");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().asIndexedPairs()).join() === '0,1,1,2,2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("64");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().asIndexedPairs()).join() === '0,1,1,2,2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("64");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().asIndexedPairs()).join() === '0,1,1,2,2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -7850,7 +7972,7 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.drop"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.drop">&#xA7;</a>Iterator.prototype.drop</span><script data-source="
 return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("64");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().drop(1)).join() === '2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("64");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().drop(1)).join() === '2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("65");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().drop(1)).join() === '2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("65");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().drop(1)).join() === '2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -7966,7 +8088,7 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.every"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.every">&#xA7;</a>Iterator.prototype.every</span><script data-source="
 return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("65");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().every(it => typeof it === 'number');\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("65");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().every(it => typeof it === 'number');\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("66");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().every(it => typeof it === 'number');\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("66");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().every(it => typeof it === 'number');\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -8082,7 +8204,7 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.filter"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.filter">&#xA7;</a>Iterator.prototype.filter</span><script data-source="
 return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1,3&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("66");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().filter(it => it % 2)).join() === '1,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("66");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().filter(it => it % 2)).join() === '1,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("67");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().filter(it => it % 2)).join() === '1,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("67");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().filter(it => it % 2)).join() === '1,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -8198,7 +8320,7 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.find"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.find">&#xA7;</a>Iterator.prototype.find</span><script data-source="
 return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("67");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().find(it => it % 2) === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("67");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().find(it => it % 2) === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("68");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().find(it => it % 2) === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("68");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().find(it => it % 2) === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -8314,7 +8436,7 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.flatMap"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.flatMap">&#xA7;</a>Iterator.prototype.flatMap</span><script data-source="
 return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos;1,0,2,0,3,0&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("68");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().flatMap(it => [it, 0])).join() === '1,0,2,0,3,0';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("68");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().flatMap(it => [it, 0])).join() === '1,0,2,0,3,0';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("69");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().flatMap(it => [it, 0])).join() === '1,0,2,0,3,0';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("69");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().flatMap(it => [it, 0])).join() === '1,0,2,0,3,0';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -8432,7 +8554,7 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 let result = &apos;&apos;;
 [1, 2, 3].values().forEach(it =&gt; result += it);
 return result === &apos;123&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("69");try{return Function("asyncTestPassed","\nlet result = '';\n[1, 2, 3].values().forEach(it => result += it);\nreturn result === '123';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("69");return Function("asyncTestPassed","'use strict';"+"\nlet result = '';\n[1, 2, 3].values().forEach(it => result += it);\nreturn result === '123';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("70");try{return Function("asyncTestPassed","\nlet result = '';\n[1, 2, 3].values().forEach(it => result += it);\nreturn result === '123';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("70");return Function("asyncTestPassed","'use strict';"+"\nlet result = '';\n[1, 2, 3].values().forEach(it => result += it);\nreturn result === '123';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -8548,7 +8670,7 @@ return result === &apos;123&apos;;
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.map"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.map">&#xA7;</a>Iterator.prototype.map</span><script data-source="
 return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4,9&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("70");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().map(it => it * it)).join() === '1,4,9';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("70");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().map(it => it * it)).join() === '1,4,9';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("71");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().map(it => it * it)).join() === '1,4,9';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("71");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().map(it => it * it)).join() === '1,4,9';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -8664,7 +8786,7 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.reduce"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.reduce">&#xA7;</a>Iterator.prototype.reduce</span><script data-source="
 return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("71");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().reduce((a, b) => a + b) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("71");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().reduce((a, b) => a + b) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("72");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().reduce((a, b) => a + b) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("72");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().reduce((a, b) => a + b) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -8780,7 +8902,7 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.some"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.some">&#xA7;</a>Iterator.prototype.some</span><script data-source="
 return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("72");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().some(it => typeof it === 'number');\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("72");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().some(it => typeof it === 'number');\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("73");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].values().some(it => typeof it === 'number');\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("73");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].values().some(it => typeof it === 'number');\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -8896,7 +9018,7 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.take"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.take">&#xA7;</a>Iterator.prototype.take</span><script data-source="
 return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("73");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().take(2)).join() === '1,2';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("73");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().take(2)).join() === '1,2';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("74");try{return Function("asyncTestPassed","\nreturn Array.from([1, 2, 3].values().take(2)).join() === '1,2';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("74");return Function("asyncTestPassed","'use strict';"+"\nreturn Array.from([1, 2, 3].values().take(2)).join() === '1,2';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -9013,7 +9135,7 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype.toArray"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype.toArray">&#xA7;</a>Iterator.prototype.toArray</span><script data-source="
 const array = [1, 2, 3].values().toArray();
 return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("74");try{return Function("asyncTestPassed","\nconst array = [1, 2, 3].values().toArray();\nreturn Array.isArray(array) && array.join() === '1,2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("74");return Function("asyncTestPassed","'use strict';"+"\nconst array = [1, 2, 3].values().toArray();\nreturn Array.isArray(array) && array.join() === '1,2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("75");try{return Function("asyncTestPassed","\nconst array = [1, 2, 3].values().toArray();\nreturn Array.isArray(array) && array.join() === '1,2,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("75");return Function("asyncTestPassed","'use strict';"+"\nconst array = [1, 2, 3].values().toArray();\nreturn Array.isArray(array) && array.join() === '1,2,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -9129,7 +9251,7 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_Iterator.prototype[@@toStringTag]"><td><span><a class="anchor" href="#test-Iterator_Helpers_Iterator.prototype[@@toStringTag]">&#xA7;</a>Iterator.prototype[@@toStringTag]</span><script data-source="
 return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("75");try{return Function("asyncTestPassed","\nreturn Iterator.prototype[Symbol.toStringTag] === 'Iterator';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("75");return Function("asyncTestPassed","'use strict';"+"\nreturn Iterator.prototype[Symbol.toStringTag] === 'Iterator';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("76");try{return Function("asyncTestPassed","\nreturn Iterator.prototype[Symbol.toStringTag] === 'Iterator';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("76");return Function("asyncTestPassed","'use strict';"+"\nreturn Iterator.prototype[Symbol.toStringTag] === 'Iterator';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -9245,7 +9367,7 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_instanceof_AsyncIterator"><td><span><a class="anchor" href="#test-Iterator_Helpers_instanceof_AsyncIterator">&#xA7;</a>instanceof AsyncIterator</span><script data-source="
 return (async function*() {})() instanceof AsyncIterator;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("76");try{return Function("asyncTestPassed","\nreturn (async function*() {})() instanceof AsyncIterator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("76");return Function("asyncTestPassed","'use strict';"+"\nreturn (async function*() {})() instanceof AsyncIterator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("77");try{return Function("asyncTestPassed","\nreturn (async function*() {})() instanceof AsyncIterator;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("77");return Function("asyncTestPassed","'use strict';"+"\nreturn (async function*() {})() instanceof AsyncIterator;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -9363,7 +9485,7 @@ return (async function*() {})() instanceof AsyncIterator;
 class Class extends AsyncIterator { }
 const instance = new Class();
 return instance[Symbol.asyncIterator]() === instance;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("77");try{return Function("asyncTestPassed","\nclass Class extends AsyncIterator { }\nconst instance = new Class();\nreturn instance[Symbol.asyncIterator]() === instance;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("77");return Function("asyncTestPassed","'use strict';"+"\nclass Class extends AsyncIterator { }\nconst instance = new Class();\nreturn instance[Symbol.asyncIterator]() === instance;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("78");try{return Function("asyncTestPassed","\nclass Class extends AsyncIterator { }\nconst instance = new Class();\nreturn instance[Symbol.asyncIterator]() === instance;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("78");return Function("asyncTestPassed","'use strict';"+"\nclass Class extends AsyncIterator { }\nconst instance = new Class();\nreturn instance[Symbol.asyncIterator]() === instance;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -9491,7 +9613,7 @@ if (!(&apos;next&apos; in iterator) || !(iterator instanceof AsyncIterator)) ret
 toArray(iterator).then(it =&gt; {
   if (it.join() === &apos;1,2,3&apos;) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("78");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from(async function*() { yield * [1, 2, 3] }());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("78");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from(async function*() { yield * [1, 2, 3] }());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("79");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from(async function*() { yield * [1, 2, 3] }());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("79");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from(async function*() { yield * [1, 2, 3] }());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -9619,7 +9741,7 @@ if (!(&apos;next&apos; in iterator) || !(iterator instanceof AsyncIterator)) ret
 toArray(iterator).then(it =&gt; {
   if (it.join() === &apos;1,2,3&apos;) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("79");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3]);\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("79");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3]);\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("80");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3]);\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("80");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3]);\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -9747,7 +9869,7 @@ if (!(&apos;next&apos; in iterator) || !(iterator instanceof AsyncIterator)) ret
 toArray(iterator).then(it =&gt; {
   if (it.join() === &apos;1,2,3&apos;) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("80");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3].values());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("80");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3].values());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("81");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3].values());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("81");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\nconst iterator = AsyncIterator.from([1, 2, 3].values());\n\nif (!('next' in iterator) || !(iterator instanceof AsyncIterator)) return false;\n\ntoArray(iterator).then(it => {\n  if (it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -9871,7 +9993,7 @@ async function toArray(iterator) {
 toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&gt; {
   if (it.join() === &apos;0,1,1,2,2,3&apos;) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("81");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it => {\n  if (it.join() === '0,1,1,2,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("81");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it => {\n  if (it.join() === '0,1,1,2,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("82");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it => {\n  if (it.join() === '0,1,1,2,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("82");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it => {\n  if (it.join() === '0,1,1,2,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -9995,7 +10117,7 @@ async function toArray(iterator) {
 toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
   if (it.join() === &apos;2,3&apos;) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("82");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it => {\n  if (it.join() === '2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("82");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it => {\n  if (it.join() === '2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("83");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it => {\n  if (it.join() === '2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("83");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it => {\n  if (it.join() === '2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -10113,7 +10235,7 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 (async function*() { yield * [1, 2, 3] })().every(it =&gt; typeof it === &apos;number&apos;).then(it =&gt; {
   if (it === true) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("83");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().every(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("83");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().every(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("84");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().every(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("84");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().every(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -10237,7 +10359,7 @@ async function toArray(iterator) {
 toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(it =&gt; {
   if (it.join() === &apos;1,3&apos;) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("84");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().filter(it => it % 2)).then(it => {\n  if (it.join() === '1,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("84");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().filter(it => it % 2)).then(it => {\n  if (it.join() === '1,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("85");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().filter(it => it % 2)).then(it => {\n  if (it.join() === '1,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("85");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().filter(it => it % 2)).then(it => {\n  if (it.join() === '1,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -10355,7 +10477,7 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 (async function*() { yield * [1, 2, 3] })().find(it =&gt; it % 2).then(it =&gt; {
   if (it === 1) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("85");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().find(it => it % 2).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("85");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().find(it => it % 2).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("86");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().find(it => it % 2).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("86");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().find(it => it % 2).then(it => {\n  if (it === 1) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -10479,7 +10601,7 @@ async function toArray(iterator) {
 toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).then(it =&gt; {
   if (it.join() === &apos;1,0,2,0,3,0&apos;) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("86");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().flatMap(it => [it, 0])).then(it => {\n  if (it.join() === '1,0,2,0,3,0') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("86");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().flatMap(it => [it, 0])).then(it => {\n  if (it.join() === '1,0,2,0,3,0') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("87");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().flatMap(it => [it, 0])).then(it => {\n  if (it.join() === '1,0,2,0,3,0') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("87");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().flatMap(it => [it, 0])).then(it => {\n  if (it.join() === '1,0,2,0,3,0') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -10598,7 +10720,7 @@ let result = &apos;&apos;;
 (async function*() { yield * [1, 2, 3] })().forEach(it =&gt; result += it).then(() =&gt; {
   if (result === &apos;123&apos;) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("87");try{return Function("asyncTestPassed","\nlet result = '';\n(async function*() { yield * [1, 2, 3] })().forEach(it => result += it).then(() => {\n  if (result === '123') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("87");return Function("asyncTestPassed","'use strict';"+"\nlet result = '';\n(async function*() { yield * [1, 2, 3] })().forEach(it => result += it).then(() => {\n  if (result === '123') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("88");try{return Function("asyncTestPassed","\nlet result = '';\n(async function*() { yield * [1, 2, 3] })().forEach(it => result += it).then(() => {\n  if (result === '123') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("88");return Function("asyncTestPassed","'use strict';"+"\nlet result = '';\n(async function*() { yield * [1, 2, 3] })().forEach(it => result += it).then(() => {\n  if (result === '123') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -10722,7 +10844,7 @@ async function toArray(iterator) {
 toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it =&gt; {
   if (it.join() === &apos;1,4,9&apos;) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("88");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().map(it => it * it)).then(it => {\n  if (it.join() === '1,4,9') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("88");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().map(it => it * it)).then(it => {\n  if (it.join() === '1,4,9') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("89");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().map(it => it * it)).then(it => {\n  if (it.join() === '1,4,9') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("89");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().map(it => it * it)).then(it => {\n  if (it.join() === '1,4,9') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -10840,7 +10962,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 (async function*() { yield * [1, 2, 3] })().reduce((a, b) =&gt; a + b).then(it =&gt; {
   if (it === 6) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("89");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().reduce((a, b) => a + b).then(it => {\n  if (it === 6) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("89");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().reduce((a, b) => a + b).then(it => {\n  if (it === 6) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("90");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().reduce((a, b) => a + b).then(it => {\n  if (it === 6) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("90");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().reduce((a, b) => a + b).then(it => {\n  if (it === 6) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -10958,7 +11080,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 (async function*() { yield * [1, 2, 3] })().some(it =&gt; typeof it === &apos;number&apos;).then(it =&gt; {
   if (it === true) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("90");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().some(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("90");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().some(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("91");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().some(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("91");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().some(it => typeof it === 'number').then(it => {\n  if (it === true) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -11082,7 +11204,7 @@ async function toArray(iterator) {
 toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
   if (it.join() === &apos;1,2&apos;) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("91");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it => {\n  if (it.join() === '1,2') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("91");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it => {\n  if (it.join() === '1,2') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("92");try{return Function("asyncTestPassed","\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it => {\n  if (it.join() === '1,2') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("92");return Function("asyncTestPassed","'use strict';"+"\nasync function toArray(iterator) {\n  const result = [];\n  for await (const it of iterator) result.push(it);\n  return result;\n}\n\ntoArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it => {\n  if (it.join() === '1,2') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -11200,7 +11322,7 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 (async function*() { yield * [1, 2, 3] })().toArray().then(it =&gt; {
   if (Array.isArray(it) &amp;&amp; it.join() === &apos;1,2,3&apos;) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("92");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().toArray().then(it => {\n  if (Array.isArray(it) && it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("92");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().toArray().then(it => {\n  if (Array.isArray(it) && it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("93");try{return Function("asyncTestPassed","\n(async function*() { yield * [1, 2, 3] })().toArray().then(it => {\n  if (Array.isArray(it) && it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("93");return Function("asyncTestPassed","'use strict';"+"\n(async function*() { yield * [1, 2, 3] })().toArray().then(it => {\n  if (Array.isArray(it) && it.join() === '1,2,3') asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -11316,7 +11438,7 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 </tr>
 <tr class="subtest" data-parent="Iterator_Helpers" id="test-Iterator_Helpers_AsyncIterator.prototype[@@toStringTag]"><td><span><a class="anchor" href="#test-Iterator_Helpers_AsyncIterator.prototype[@@toStringTag]">&#xA7;</a>AsyncIterator.prototype[@@toStringTag]</span><script data-source="
 return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("93");try{return Function("asyncTestPassed","\nreturn AsyncIterator.prototype[Symbol.toStringTag] === 'AsyncIterator';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("93");return Function("asyncTestPassed","'use strict';"+"\nreturn AsyncIterator.prototype[Symbol.toStringTag] === 'AsyncIterator';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("94");try{return Function("asyncTestPassed","\nreturn AsyncIterator.prototype[Symbol.toStringTag] === 'AsyncIterator';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("94");return Function("asyncTestPassed","'use strict';"+"\nreturn AsyncIterator.prototype[Symbol.toStringTag] === 'AsyncIterator';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -11437,7 +11559,7 @@ return do {
   let x = 23;
   x + 19;
 } === 42;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("94");try{return Function("asyncTestPassed","\nreturn do {\n  let x = 23;\n  x + 19;\n} === 42;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("94");return Function("asyncTestPassed","'use strict';"+"\nreturn do {\n  let x = 23;\n  x + 19;\n} === 42;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("95");try{return Function("asyncTestPassed","\nreturn do {\n  let x = 23;\n  x + 19;\n} === 42;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("95");return Function("asyncTestPassed","'use strict';"+"\nreturn do {\n  let x = 23;\n  x + 19;\n} === 42;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
@@ -11666,7 +11788,7 @@ return do {
 </tr>
 <tr class="subtest" data-parent="Observable" id="test-Observable_basic_support"><td><span><a class="anchor" href="#test-Observable_basic_support">&#xA7;</a>basic support</span><script data-source="
 return typeof Observable !== &apos;undefined&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("96");try{return Function("asyncTestPassed","\nreturn typeof Observable !== 'undefined';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("96");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Observable !== 'undefined';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("97");try{return Function("asyncTestPassed","\nreturn typeof Observable !== 'undefined';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("97");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Observable !== 'undefined';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -11782,7 +11904,7 @@ return typeof Observable !== &apos;undefined&apos;;
 </tr>
 <tr class="subtest" data-parent="Observable" id="test-Observable_Symbol.observable_well_known_symbol"><td><span><a class="anchor" href="#test-Observable_Symbol.observable_well_known_symbol">&#xA7;</a>Symbol.observable well known symbol</span><script data-source="
 return typeof Symbol.observable === &apos;symbol&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("97");try{return Function("asyncTestPassed","\nreturn typeof Symbol.observable === 'symbol';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("97");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Symbol.observable === 'symbol';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("98");try{return Function("asyncTestPassed","\nreturn typeof Symbol.observable === 'symbol';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("98");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Symbol.observable === 'symbol';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -11898,7 +12020,7 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 </tr>
 <tr class="subtest" data-parent="Observable" id="test-Observable_Observable.prototype.subscribe"><td><span><a class="anchor" href="#test-Observable_Observable.prototype.subscribe">&#xA7;</a>Observable.prototype.subscribe</span><script data-source="
 return &apos;subscribe&apos; in Observable.prototype;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("98");try{return Function("asyncTestPassed","\nreturn 'subscribe' in Observable.prototype;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("98");return Function("asyncTestPassed","'use strict';"+"\nreturn 'subscribe' in Observable.prototype;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("99");try{return Function("asyncTestPassed","\nreturn 'subscribe' in Observable.prototype;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("99");return Function("asyncTestPassed","'use strict';"+"\nreturn 'subscribe' in Observable.prototype;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -12024,7 +12146,7 @@ try { new Observable(false) } catch(e) { primitiveCheckPassed = true }
 try { Observable(function() { }) } catch(e) { newCheckPassed = true }
 
 return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newCheckPassed;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("99");try{return Function("asyncTestPassed","\nif(!(new Observable(function(){}) instanceof Observable))return false;\n\nvar nonCallableCheckPassed,\n    primitiveCheckPassed,\n    newCheckPassed;\n\ntry { new Observable({ }) } catch(e) { nonCallableCheckPassed = true }\ntry { new Observable(false) } catch(e) { primitiveCheckPassed = true }\ntry { Observable(function() { }) } catch(e) { newCheckPassed = true }\n\nreturn nonCallableCheckPassed && primitiveCheckPassed && newCheckPassed;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("99");return Function("asyncTestPassed","'use strict';"+"\nif(!(new Observable(function(){}) instanceof Observable))return false;\n\nvar nonCallableCheckPassed,\n    primitiveCheckPassed,\n    newCheckPassed;\n\ntry { new Observable({ }) } catch(e) { nonCallableCheckPassed = true }\ntry { new Observable(false) } catch(e) { primitiveCheckPassed = true }\ntry { Observable(function() { }) } catch(e) { newCheckPassed = true }\n\nreturn nonCallableCheckPassed && primitiveCheckPassed && newCheckPassed;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("100");try{return Function("asyncTestPassed","\nif(!(new Observable(function(){}) instanceof Observable))return false;\n\nvar nonCallableCheckPassed,\n    primitiveCheckPassed,\n    newCheckPassed;\n\ntry { new Observable({ }) } catch(e) { nonCallableCheckPassed = true }\ntry { new Observable(false) } catch(e) { primitiveCheckPassed = true }\ntry { Observable(function() { }) } catch(e) { newCheckPassed = true }\n\nreturn nonCallableCheckPassed && primitiveCheckPassed && newCheckPassed;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("100");return Function("asyncTestPassed","'use strict';"+"\nif(!(new Observable(function(){}) instanceof Observable))return false;\n\nvar nonCallableCheckPassed,\n    primitiveCheckPassed,\n    newCheckPassed;\n\ntry { new Observable({ }) } catch(e) { nonCallableCheckPassed = true }\ntry { new Observable(false) } catch(e) { primitiveCheckPassed = true }\ntry { Observable(function() { }) } catch(e) { newCheckPassed = true }\n\nreturn nonCallableCheckPassed && primitiveCheckPassed && newCheckPassed;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -12141,7 +12263,7 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <tr class="subtest" data-parent="Observable" id="test-Observable_Observable.prototype[Symbol.observable]"><td><span><a class="anchor" href="#test-Observable_Observable.prototype[Symbol.observable]">&#xA7;</a>Observable.prototype[Symbol.observable]</span><script data-source="
 var o = new Observable(function() { });
 return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]() === o;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("100");try{return Function("asyncTestPassed","\nvar o = new Observable(function() { });\nreturn Symbol.observable in Observable.prototype && o[Symbol.observable]() === o;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("100");return Function("asyncTestPassed","'use strict';"+"\nvar o = new Observable(function() { });\nreturn Symbol.observable in Observable.prototype && o[Symbol.observable]() === o;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("101");try{return Function("asyncTestPassed","\nvar o = new Observable(function() { });\nreturn Symbol.observable in Observable.prototype && o[Symbol.observable]() === o;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("101");return Function("asyncTestPassed","'use strict';"+"\nvar o = new Observable(function() { });\nreturn Symbol.observable in Observable.prototype && o[Symbol.observable]() === o;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -12257,7 +12379,7 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 </tr>
 <tr class="subtest" data-parent="Observable" id="test-Observable_Observable.of"><td><span><a class="anchor" href="#test-Observable_Observable.of">&#xA7;</a>Observable.of</span><script data-source="
 return Observable.of(1, 2, 3) instanceof Observable;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("101");try{return Function("asyncTestPassed","\nreturn Observable.of(1, 2, 3) instanceof Observable;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("101");return Function("asyncTestPassed","'use strict';"+"\nreturn Observable.of(1, 2, 3) instanceof Observable;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("102");try{return Function("asyncTestPassed","\nreturn Observable.of(1, 2, 3) instanceof Observable;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("102");return Function("asyncTestPassed","'use strict';"+"\nreturn Observable.of(1, 2, 3) instanceof Observable;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -12373,7 +12495,7 @@ return Observable.of(1, 2, 3) instanceof Observable;
 </tr>
 <tr class="subtest" data-parent="Observable" id="test-Observable_Observable.from"><td><span><a class="anchor" href="#test-Observable_Observable.from">&#xA7;</a>Observable.from</span><script data-source="
 return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable.from(new Set([1, 2, 3])) instanceof Observable);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("102");try{return Function("asyncTestPassed","\nreturn (Observable.from([1,2,3,4]) instanceof Observable) && (Observable.from(new Set([1, 2, 3])) instanceof Observable);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("102");return Function("asyncTestPassed","'use strict';"+"\nreturn (Observable.from([1,2,3,4]) instanceof Observable) && (Observable.from(new Set([1, 2, 3])) instanceof Observable);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("103");try{return Function("asyncTestPassed","\nreturn (Observable.from([1,2,3,4]) instanceof Observable) && (Observable.from(new Set([1, 2, 3])) instanceof Observable);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("103");return Function("asyncTestPassed","'use strict';"+"\nreturn (Observable.from([1,2,3,4]) instanceof Observable) && (Observable.from(new Set([1, 2, 3])) instanceof Observable);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -12490,7 +12612,7 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <tr significance="0.5"><td id="test-Frozen_Realms_API"><span><a class="anchor" href="#test-Frozen_Realms_API">&#xA7;</a><a href="https://github.com/tc39/proposal-frozen-realms">Frozen Realms API</a></span><script data-source="
 return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
   &amp;&amp; typeof Reflect.Realm.prototype.spawn === &apos;function&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("103");try{return Function("asyncTestPassed","\nreturn typeof Reflect.Realm.immutableRoot === 'function'\n  && typeof Reflect.Realm.prototype.spawn === 'function';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("103");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.Realm.immutableRoot === 'function'\n  && typeof Reflect.Realm.prototype.spawn === 'function';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("104");try{return Function("asyncTestPassed","\nreturn typeof Reflect.Realm.immutableRoot === 'function'\n  && typeof Reflect.Realm.prototype.spawn === 'function';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("104");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.Realm.immutableRoot === 'function'\n  && typeof Reflect.Realm.prototype.spawn === 'function';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -12610,7 +12732,7 @@ return Math.signbit(NaN) === false
   &amp;&amp; Math.signbit(0) === false
   &amp;&amp; Math.signbit(-42) === true
   &amp;&amp; Math.signbit(42) === false;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("104");try{return Function("asyncTestPassed","\nreturn Math.signbit(NaN) === false\n  && Math.signbit(-0) === true\n  && Math.signbit(0) === false\n  && Math.signbit(-42) === true\n  && Math.signbit(42) === false;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("104");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.signbit(NaN) === false\n  && Math.signbit(-0) === true\n  && Math.signbit(0) === false\n  && Math.signbit(-42) === true\n  && Math.signbit(42) === false;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("105");try{return Function("asyncTestPassed","\nreturn Math.signbit(NaN) === false\n  && Math.signbit(-0) === true\n  && Math.signbit(0) === false\n  && Math.signbit(-42) === true\n  && Math.signbit(42) === false;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("105");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.signbit(NaN) === false\n  && Math.signbit(-0) === true\n  && Math.signbit(0) === false\n  && Math.signbit(-42) === true\n  && Math.signbit(42) === false;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -12841,7 +12963,7 @@ return Math.signbit(NaN) === false
 return Math.clamp(2, 4, 6) === 4
   &amp;&amp; Math.clamp(4, 2, 6) === 4
   &amp;&amp; Math.clamp(6, 2, 4) === 4;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("106");try{return Function("asyncTestPassed","\nreturn Math.clamp(2, 4, 6) === 4\n  && Math.clamp(4, 2, 6) === 4\n  && Math.clamp(6, 2, 4) === 4;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("106");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.clamp(2, 4, 6) === 4\n  && Math.clamp(4, 2, 6) === 4\n  && Math.clamp(6, 2, 4) === 4;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("107");try{return Function("asyncTestPassed","\nreturn Math.clamp(2, 4, 6) === 4\n  && Math.clamp(4, 2, 6) === 4\n  && Math.clamp(6, 2, 4) === 4;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("107");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.clamp(2, 4, 6) === 4\n  && Math.clamp(4, 2, 6) === 4\n  && Math.clamp(6, 2, 4) === 4;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -12957,7 +13079,7 @@ return Math.clamp(2, 4, 6) === 4
 </tr>
 <tr class="subtest" data-parent="Math_extensions_proposal" id="test-Math_extensions_proposal_Math.DEG_PER_RAD"><td><span><a class="anchor" href="#test-Math_extensions_proposal_Math.DEG_PER_RAD">&#xA7;</a>Math.DEG_PER_RAD</span><script data-source="
 return Math.DEG_PER_RAD === Math.PI / 180;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("107");try{return Function("asyncTestPassed","\nreturn Math.DEG_PER_RAD === Math.PI / 180;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("107");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.DEG_PER_RAD === Math.PI / 180;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("108");try{return Function("asyncTestPassed","\nreturn Math.DEG_PER_RAD === Math.PI / 180;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("108");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.DEG_PER_RAD === Math.PI / 180;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -13074,7 +13196,7 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <tr class="subtest" data-parent="Math_extensions_proposal" id="test-Math_extensions_proposal_Math.degrees"><td><span><a class="anchor" href="#test-Math_extensions_proposal_Math.degrees">&#xA7;</a>Math.degrees</span><script data-source="
 return Math.degrees(Math.PI / 2) === 90
   &amp;&amp; Math.degrees(Math.PI) === 180;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("108");try{return Function("asyncTestPassed","\nreturn Math.degrees(Math.PI / 2) === 90\n  && Math.degrees(Math.PI) === 180;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("108");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.degrees(Math.PI / 2) === 90\n  && Math.degrees(Math.PI) === 180;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("109");try{return Function("asyncTestPassed","\nreturn Math.degrees(Math.PI / 2) === 90\n  && Math.degrees(Math.PI) === 180;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("109");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.degrees(Math.PI / 2) === 90\n  && Math.degrees(Math.PI) === 180;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -13190,7 +13312,7 @@ return Math.degrees(Math.PI / 2) === 90
 </tr>
 <tr class="subtest" data-parent="Math_extensions_proposal" id="test-Math_extensions_proposal_Math.fscale"><td><span><a class="anchor" href="#test-Math_extensions_proposal_Math.fscale">&#xA7;</a>Math.fscale</span><script data-source="
 return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) / (2 - 1) + 1);
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("109");try{return Function("asyncTestPassed","\nreturn Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) / (2 - 1) + 1);\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("109");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) / (2 - 1) + 1);\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("110");try{return Function("asyncTestPassed","\nreturn Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) / (2 - 1) + 1);\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("110");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) / (2 - 1) + 1);\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -13306,7 +13428,7 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 </tr>
 <tr class="subtest" data-parent="Math_extensions_proposal" id="test-Math_extensions_proposal_Math.RAD_PER_DEG"><td><span><a class="anchor" href="#test-Math_extensions_proposal_Math.RAD_PER_DEG">&#xA7;</a>Math.RAD_PER_DEG</span><script data-source="
 return Math.RAD_PER_DEG === 180 / Math.PI;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("110");try{return Function("asyncTestPassed","\nreturn Math.RAD_PER_DEG === 180 / Math.PI;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("110");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.RAD_PER_DEG === 180 / Math.PI;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("111");try{return Function("asyncTestPassed","\nreturn Math.RAD_PER_DEG === 180 / Math.PI;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("111");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.RAD_PER_DEG === 180 / Math.PI;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -13423,7 +13545,7 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <tr class="subtest" data-parent="Math_extensions_proposal" id="test-Math_extensions_proposal_Math.radians"><td><span><a class="anchor" href="#test-Math_extensions_proposal_Math.radians">&#xA7;</a>Math.radians</span><script data-source="
 return Math.radians(90) === Math.PI / 2
   &amp;&amp; Math.radians(180) === Math.PI;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("111");try{return Function("asyncTestPassed","\nreturn Math.radians(90) === Math.PI / 2\n  && Math.radians(180) === Math.PI;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("111");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.radians(90) === Math.PI / 2\n  && Math.radians(180) === Math.PI;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("112");try{return Function("asyncTestPassed","\nreturn Math.radians(90) === Math.PI / 2\n  && Math.radians(180) === Math.PI;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("112");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.radians(90) === Math.PI / 2\n  && Math.radians(180) === Math.PI;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -13539,7 +13661,7 @@ return Math.radians(90) === Math.PI / 2
 </tr>
 <tr class="subtest" data-parent="Math_extensions_proposal" id="test-Math_extensions_proposal_Math.scale"><td><span><a class="anchor" href="#test-Math_extensions_proposal_Math.scale">&#xA7;</a>Math.scale</span><script data-source="
 return Math.scale(0, 3, 5, 8, 10) === 5;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("112");try{return Function("asyncTestPassed","\nreturn Math.scale(0, 3, 5, 8, 10) === 5;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("112");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.scale(0, 3, 5, 8, 10) === 5;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("113");try{return Function("asyncTestPassed","\nreturn Math.scale(0, 3, 5, 8, 10) === 5;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("113");return Function("asyncTestPassed","'use strict';"+"\nreturn Math.scale(0, 3, 5, 8, 10) === 5;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -13768,7 +13890,7 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 </tr>
 <tr class="subtest" data-parent="Promise.try" id="test-Promise.try_basic_support"><td><span><a class="anchor" href="#test-Promise.try_basic_support">&#xA7;</a>basic support</span><script data-source="
 return typeof Promise.try === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("114");try{return Function("asyncTestPassed","\nreturn typeof Promise.try === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("114");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Promise.try === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("115");try{return Function("asyncTestPassed","\nreturn typeof Promise.try === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("115");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Promise.try === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -13884,7 +14006,7 @@ return typeof Promise.try === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Promise.try" id="test-Promise.try_returns_instance_of_Promise"><td><span><a class="anchor" href="#test-Promise.try_returns_instance_of_Promise">&#xA7;</a>returns instance of Promise</span><script data-source="
 return Promise.try(function () {}) instanceof Promise;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("115");try{return Function("asyncTestPassed","\nreturn Promise.try(function () {}) instanceof Promise;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("115");return Function("asyncTestPassed","'use strict';"+"\nreturn Promise.try(function () {}) instanceof Promise;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("116");try{return Function("asyncTestPassed","\nreturn Promise.try(function () {}) instanceof Promise;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("116");return Function("asyncTestPassed","'use strict';"+"\nreturn Promise.try(function () {}) instanceof Promise;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -14002,7 +14124,7 @@ return Promise.try(function () {}) instanceof Promise;
 var score = 0;
 Promise.try(function () { score++ });
 return score === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("116");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function () { score++ });\nreturn score === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("116");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function () { score++ });\nreturn score === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("117");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function () { score++ });\nreturn score === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("117");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function () { score++ });\nreturn score === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -14125,7 +14247,7 @@ Promise.try(function() {
   score += (val === &apos;foo&apos;);
   if (score === 2) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("117");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return 'foo';\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("117");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return 'foo';\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("118");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return 'foo';\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("118");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return 'foo';\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -14248,7 +14370,7 @@ Promise.try(function() {
   score += (err === &apos;bar&apos;);
   if (score === 2) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("118");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  throw 'bar';\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("118");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  throw 'bar';\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("119");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  throw 'bar';\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("119");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  throw 'bar';\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -14371,7 +14493,7 @@ Promise.try(function() {
   score += (val === &apos;foo&apos;);
   if (score === 2) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("119");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.resolve('foo');\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("119");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.resolve('foo');\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("120");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.resolve('foo');\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("120");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.resolve('foo');\n}).then(function(val) {\n  score += (val === 'foo');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -14494,7 +14616,7 @@ Promise.try(function() {
   score += (err === &apos;bar&apos;);
   if (score === 2) asyncTestPassed();
 });
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("120");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.reject('bar');\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("120");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.reject('bar');\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("121");try{return Function("asyncTestPassed","\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.reject('bar');\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("121");return Function("asyncTestPassed","'use strict';"+"\nvar score = 0;\nPromise.try(function() {\n  score++;\n  return Promise.reject('bar');\n}).catch(function(err) {\n  score += (err === 'bar');\n  if (score === 2) asyncTestPassed();\n});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -14726,7 +14848,7 @@ var A = {};
 var B = {};
 var C = Map.of([A, 1], [B, 2]);
 return C.get(A) + C.get(B) === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("122");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Map.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("122");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Map.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("123");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Map.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("123");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Map.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -14847,7 +14969,7 @@ var C = Map.from([[A, 1], [B, 2]], function (it) {
   return [it[0], it[1] + 1];
 });
 return C.get(A) + C.get(B) === 5;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("123");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Map.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("123");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Map.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("124");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Map.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("124");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Map.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -14966,7 +15088,7 @@ var A = {};
 var B = {};
 var C = Set.of(A, B);
 return C.has(A) + C.has(B);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("124");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Set.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("124");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Set.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("125");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = Set.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("125");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = Set.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -15085,7 +15207,7 @@ var C = Set.from([1, 2], function (it) {
   return it + 2;
 });
 return C.has(3) + C.has(4);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("125");try{return Function("asyncTestPassed","\nvar C = Set.from([1, 2], function (it) {\n  return it + 2;\n});\nreturn C.has(3) + C.has(4);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("125");return Function("asyncTestPassed","'use strict';"+"\nvar C = Set.from([1, 2], function (it) {\n  return it + 2;\n});\nreturn C.has(3) + C.has(4);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("126");try{return Function("asyncTestPassed","\nvar C = Set.from([1, 2], function (it) {\n  return it + 2;\n});\nreturn C.has(3) + C.has(4);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("126");return Function("asyncTestPassed","'use strict';"+"\nvar C = Set.from([1, 2], function (it) {\n  return it + 2;\n});\nreturn C.has(3) + C.has(4);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -15204,7 +15326,7 @@ var A = {};
 var B = {};
 var C = WeakMap.of([A, 1], [B, 2]);
 return C.get(A) + C.get(B) === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("126");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakMap.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("126");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakMap.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("127");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakMap.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("127");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakMap.of([A, 1], [B, 2]);\nreturn C.get(A) + C.get(B) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -15325,7 +15447,7 @@ var C = WeakMap.from([[A, 1], [B, 2]], function (it) {
   return [it[0], it[1] + 1];
 });
 return C.get(A) + C.get(B) === 5;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("127");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakMap.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("127");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakMap.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("128");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakMap.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("128");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakMap.from([[A, 1], [B, 2]], function (it) {\n  return [it[0], it[1] + 1];\n});\nreturn C.get(A) + C.get(B) === 5;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -15444,7 +15566,7 @@ var A = {};
 var B = {};
 var C = WeakSet.of(A, B);
 return C.has(A) + C.has(B);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("128");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakSet.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("128");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakSet.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("129");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakSet.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("129");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakSet.of(A, B);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -15563,7 +15685,7 @@ var A = {};
 var B = {};
 var C = WeakSet.from([A, B]);
 return C.has(A) + C.has(B);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("129");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakSet.from([A, B]);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("129");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakSet.from([A, B]);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("130");try{return Function("asyncTestPassed","\nvar A = {};\nvar B = {};\nvar C = WeakSet.from([A, B]);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("130");return Function("asyncTestPassed","'use strict';"+"\nvar A = {};\nvar B = {};\nvar C = WeakSet.from([A, B]);\nreturn C.has(A) + C.has(B);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -15691,7 +15813,7 @@ var result = &apos;hello&apos;
   |&gt; _ =&gt; _ + &apos;!&apos;;
 
 return result === &apos;Hello, hello!&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("130");try{return Function("asyncTestPassed","\nfunction doubleSay (str) {\n  return str + ', ' + str;\n}\nfunction capitalize (str) {\n  return str[0].toUpperCase() + str.slice(1);\n}\n\nvar result = 'hello'\n  |> doubleSay\n  |> capitalize\n  |> _ => _ + '!';\n\nreturn result === 'Hello, hello!';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("130");return Function("asyncTestPassed","'use strict';"+"\nfunction doubleSay (str) {\n  return str + ', ' + str;\n}\nfunction capitalize (str) {\n  return str[0].toUpperCase() + str.slice(1);\n}\n\nvar result = 'hello'\n  |> doubleSay\n  |> capitalize\n  |> _ => _ + '!';\n\nreturn result === 'Hello, hello!';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("131");try{return Function("asyncTestPassed","\nfunction doubleSay (str) {\n  return str + ', ' + str;\n}\nfunction capitalize (str) {\n  return str[0].toUpperCase() + str.slice(1);\n}\n\nvar result = 'hello'\n  |> doubleSay\n  |> capitalize\n  |> _ => _ + '!';\n\nreturn result === 'Hello, hello!';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("131");return Function("asyncTestPassed","'use strict';"+"\nfunction doubleSay (str) {\n  return str + ', ' + str;\n}\nfunction capitalize (str) {\n  return str[0].toUpperCase() + str.slice(1);\n}\n\nvar result = 'hello'\n  |> doubleSay\n  |> capitalize\n  |> _ => _ + '!';\n\nreturn result === 'Hello, hello!';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -15811,7 +15933,7 @@ function i (str, num) {
 }
 
 return 123i === &apos;string123number123&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("131");try{return Function("asyncTestPassed","\nfunction i (str, num) {\n  return typeof str + str + typeof num + num;\n}\n\nreturn 123i === 'string123number123';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("131");return Function("asyncTestPassed","'use strict';"+"\nfunction i (str, num) {\n  return typeof str + str + typeof num + num;\n}\n\nreturn 123i === 'string123number123';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("132");try{return Function("asyncTestPassed","\nfunction i (str, num) {\n  return typeof str + str + typeof num + num;\n}\n\nreturn 123i === 'string123number123';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("132");return Function("asyncTestPassed","'use strict';"+"\nfunction i (str, num) {\n  return typeof str + str + typeof num + num;\n}\n\nreturn 123i === 'string123number123';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -16044,7 +16166,7 @@ function f(a, b) {
 };
 var p = f(&apos;a&apos;, ?);
 return p(&apos;b&apos;) === &apos;ab&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("133");try{return Function("asyncTestPassed","\nfunction f(a, b) {\n  return a + b;\n};\nvar p = f('a', ?);\nreturn p('b') === 'ab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("133");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b) {\n  return a + b;\n};\nvar p = f('a', ?);\nreturn p('b') === 'ab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("134");try{return Function("asyncTestPassed","\nfunction f(a, b) {\n  return a + b;\n};\nvar p = f('a', ?);\nreturn p('b') === 'ab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("134");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b) {\n  return a + b;\n};\nvar p = f('a', ?);\nreturn p('b') === 'ab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -16164,7 +16286,7 @@ function f(a, b) {
 };
 var p = f(?, &apos;b&apos;);
 return p(&apos;a&apos;) === &apos;ab&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("134");try{return Function("asyncTestPassed","\nfunction f(a, b) {\n  return a + b;\n};\nvar p = f(?, 'b');\nreturn p('a') === 'ab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("134");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b) {\n  return a + b;\n};\nvar p = f(?, 'b');\nreturn p('a') === 'ab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("135");try{return Function("asyncTestPassed","\nfunction f(a, b) {\n  return a + b;\n};\nvar p = f(?, 'b');\nreturn p('a') === 'ab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("135");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b) {\n  return a + b;\n};\nvar p = f(?, 'b');\nreturn p('a') === 'ab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -16284,7 +16406,7 @@ function f(a, b, c) {
 };
 var p = f(?, &apos;b&apos;, ?);
 return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("135");try{return Function("asyncTestPassed","\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f(?, 'b', ?);\nreturn p('a', 'c') === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("135");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f(?, 'b', ?);\nreturn p('a', 'c') === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("136");try{return Function("asyncTestPassed","\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f(?, 'b', ?);\nreturn p('a', 'c') === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("136");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f(?, 'b', ?);\nreturn p('a', 'c') === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -16404,7 +16526,7 @@ function f(a, b, c) {
 };
 var p = f(&apos;a&apos;, ...);
 return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("136");try{return Function("asyncTestPassed","\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f('a', ...);\nreturn p('b', 'c') === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("136");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f('a', ...);\nreturn p('b', 'c') === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("137");try{return Function("asyncTestPassed","\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f('a', ...);\nreturn p('b', 'c') === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("137");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f('a', ...);\nreturn p('b', 'c') === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -16524,7 +16646,7 @@ function f(a, b, c) {
 };
 var p = f(..., &apos;c&apos;);
 return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("137");try{return Function("asyncTestPassed","\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f(..., 'c');\nreturn p('a', 'b') === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("137");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f(..., 'c');\nreturn p('a', 'b') === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("138");try{return Function("asyncTestPassed","\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f(..., 'c');\nreturn p('a', 'b') === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("138");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c) {\n  return a + b + c;\n};\nvar p = f(..., 'c');\nreturn p('a', 'b') === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -16644,7 +16766,7 @@ function f(a, b, c, d, e) {
 };
 var p = f(..., &apos;c&apos;, ...);
 return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("138");try{return Function("asyncTestPassed","\nfunction f(a, b, c, d, e) {\n  return a + b + c + d + e;\n};\nvar p = f(..., 'c', ...);\nreturn p('a', 'b') === 'abcab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("138");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c, d, e) {\n  return a + b + c + d + e;\n};\nvar p = f(..., 'c', ...);\nreturn p('a', 'b') === 'abcab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("139");try{return Function("asyncTestPassed","\nfunction f(a, b, c, d, e) {\n  return a + b + c + d + e;\n};\nvar p = f(..., 'c', ...);\nreturn p('a', 'b') === 'abcab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("139");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c, d, e) {\n  return a + b + c + d + e;\n};\nvar p = f(..., 'c', ...);\nreturn p('a', 'b') === 'abcab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -16764,7 +16886,7 @@ function f(a, b, c, d) {
 };
 var p = f(?, &apos;b&apos;, ...);
 return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("139");try{return Function("asyncTestPassed","\nfunction f(a, b, c, d) {\n  return a + b + c;\n};\nvar p = f(?, 'b', ...);\nreturn p('a', 'c', 'd') === 'abcd';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("139");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c, d) {\n  return a + b + c;\n};\nvar p = f(?, 'b', ...);\nreturn p('a', 'c', 'd') === 'abcd';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("140");try{return Function("asyncTestPassed","\nfunction f(a, b, c, d) {\n  return a + b + c;\n};\nvar p = f(?, 'b', ...);\nreturn p('a', 'c', 'd') === 'abcd';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("140");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b, c, d) {\n  return a + b + c;\n};\nvar p = f(?, 'b', ...);\nreturn p('a', 'c', 'd') === 'abcd';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -16887,7 +17009,7 @@ f = function(a, b) {
   return a + b;
 };
 return p(&apos;a&apos;) === &apos;ab&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("140");try{return Function("asyncTestPassed","\nvar f = function() {\n  throw new Error();\n};\nvar p = f(?, 'b');\nf = function(a, b) {\n  return a + b;\n};\nreturn p('a') === 'ab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("140");return Function("asyncTestPassed","'use strict';"+"\nvar f = function() {\n  throw new Error();\n};\nvar p = f(?, 'b');\nf = function(a, b) {\n  return a + b;\n};\nreturn p('a') === 'ab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("141");try{return Function("asyncTestPassed","\nvar f = function() {\n  throw new Error();\n};\nvar p = f(?, 'b');\nf = function(a, b) {\n  return a + b;\n};\nreturn p('a') === 'ab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("141");return Function("asyncTestPassed","'use strict';"+"\nvar f = function() {\n  throw new Error();\n};\nvar p = f(?, 'b');\nf = function(a, b) {\n  return a + b;\n};\nreturn p('a') === 'ab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -17008,7 +17130,7 @@ o = { x: &apos;c&apos;, f: function(a, b) {
   return a + b + this.x;
 } };
 return p(&apos;a&apos;) === &apos;abc&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("141");try{return Function("asyncTestPassed","\nvar o = {};\nvar p = o.f(?, 'b');\no = { x: 'c', f: function(a, b) {\n  return a + b + this.x;\n} };\nreturn p('a') === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("141");return Function("asyncTestPassed","'use strict';"+"\nvar o = {};\nvar p = o.f(?, 'b');\no = { x: 'c', f: function(a, b) {\n  return a + b + this.x;\n} };\nreturn p('a') === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("142");try{return Function("asyncTestPassed","\nvar o = {};\nvar p = o.f(?, 'b');\no = { x: 'c', f: function(a, b) {\n  return a + b + this.x;\n} };\nreturn p('a') === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("142");return Function("asyncTestPassed","'use strict';"+"\nvar o = {};\nvar p = o.f(?, 'b');\no = { x: 'c', f: function(a, b) {\n  return a + b + this.x;\n} };\nreturn p('a') === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -17128,7 +17250,7 @@ function f(a, b) {
 }
 var o = { f: f(?, &apos;b&apos;) };
 return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("142");try{return Function("asyncTestPassed","\nfunction f(a, b) {\n  return a + b + (this === o);\n}\nvar o = { f: f(?, 'b') };\nreturn o.f('a') === 'abfalse';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("142");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b) {\n  return a + b + (this === o);\n}\nvar o = { f: f(?, 'b') };\nreturn o.f('a') === 'abfalse';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("143");try{return Function("asyncTestPassed","\nfunction f(a, b) {\n  return a + b + (this === o);\n}\nvar o = { f: f(?, 'b') };\nreturn o.f('a') === 'abfalse';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("143");return Function("asyncTestPassed","'use strict';"+"\nfunction f(a, b) {\n  return a + b + (this === o);\n}\nvar o = { f: f(?, 'b') };\nreturn o.f('a') === 'abfalse';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -17248,7 +17370,7 @@ function F(a, b) {
 }
 var p = new F(?, &apos;b&apos;);
 return p(&apos;a&apos;).x === &apos;ab&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("143");try{return Function("asyncTestPassed","\nfunction F(a, b) {\n  this.x = a + b;\n}\nvar p = new F(?, 'b');\nreturn p('a').x === 'ab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("143");return Function("asyncTestPassed","'use strict';"+"\nfunction F(a, b) {\n  this.x = a + b;\n}\nvar p = new F(?, 'b');\nreturn p('a').x === 'ab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("144");try{return Function("asyncTestPassed","\nfunction F(a, b) {\n  this.x = a + b;\n}\nvar p = new F(?, 'b');\nreturn p('a').x === 'ab';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("144");return Function("asyncTestPassed","'use strict';"+"\nfunction F(a, b) {\n  this.x = a + b;\n}\nvar p = new F(?, 'b');\nreturn p('a').x === 'ab';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -17368,7 +17490,7 @@ function F(a, b, c) {
 }
 var p = new F(&apos;a&apos;, ...);
 return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("144");try{return Function("asyncTestPassed","\nfunction F(a, b, c) {\n  this.x = a + b + c;\n}\nvar p = new F('a', ...);\nreturn p('b', 'c').x === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("144");return Function("asyncTestPassed","'use strict';"+"\nfunction F(a, b, c) {\n  this.x = a + b + c;\n}\nvar p = new F('a', ...);\nreturn p('b', 'c').x === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("145");try{return Function("asyncTestPassed","\nfunction F(a, b, c) {\n  this.x = a + b + c;\n}\nvar p = new F('a', ...);\nreturn p('b', 'c').x === 'abc';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("145");return Function("asyncTestPassed","'use strict';"+"\nfunction F(a, b, c) {\n  this.x = a + b + c;\n}\nvar p = new F('a', ...);\nreturn p('b', 'c').x === 'abc';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -17597,7 +17719,7 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 </tr>
 <tr class="subtest" data-parent="Object.freeze_and_Object.seal_syntax" id="test-Object.freeze_and_Object.seal_syntax_Object.freeze_syntax"><td><span><a class="anchor" href="#test-Object.freeze_and_Object.seal_syntax_Object.freeze_syntax">&#xA7;</a>Object.freeze syntax</span><script data-source="
 return Object.isFrozen({# foo: 42 #});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("146");try{return Function("asyncTestPassed","\nreturn Object.isFrozen({# foo: 42 #});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("146");return Function("asyncTestPassed","'use strict';"+"\nreturn Object.isFrozen({# foo: 42 #});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("147");try{return Function("asyncTestPassed","\nreturn Object.isFrozen({# foo: 42 #});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("147");return Function("asyncTestPassed","'use strict';"+"\nreturn Object.isFrozen({# foo: 42 #});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -17713,7 +17835,7 @@ return Object.isFrozen({# foo: 42 #});
 </tr>
 <tr class="subtest" data-parent="Object.freeze_and_Object.seal_syntax" id="test-Object.freeze_and_Object.seal_syntax_Object.freeze_syntax_with_array_literal"><td><span><a class="anchor" href="#test-Object.freeze_and_Object.seal_syntax_Object.freeze_syntax_with_array_literal">&#xA7;</a>Object.freeze syntax with array literal</span><script data-source="
 return Object.isFrozen([# 42 #]);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("147");try{return Function("asyncTestPassed","\nreturn Object.isFrozen([# 42 #]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("147");return Function("asyncTestPassed","'use strict';"+"\nreturn Object.isFrozen([# 42 #]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("148");try{return Function("asyncTestPassed","\nreturn Object.isFrozen([# 42 #]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("148");return Function("asyncTestPassed","'use strict';"+"\nreturn Object.isFrozen([# 42 #]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -17829,7 +17951,7 @@ return Object.isFrozen([# 42 #]);
 </tr>
 <tr class="subtest" data-parent="Object.freeze_and_Object.seal_syntax" id="test-Object.freeze_and_Object.seal_syntax_Object.seal_syntax"><td><span><a class="anchor" href="#test-Object.freeze_and_Object.seal_syntax_Object.seal_syntax">&#xA7;</a>Object.seal syntax</span><script data-source="
 return Object.isSealed({| foo: 42 |});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("148");try{return Function("asyncTestPassed","\nreturn Object.isSealed({| foo: 42 |});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("148");return Function("asyncTestPassed","'use strict';"+"\nreturn Object.isSealed({| foo: 42 |});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("149");try{return Function("asyncTestPassed","\nreturn Object.isSealed({| foo: 42 |});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("149");return Function("asyncTestPassed","'use strict';"+"\nreturn Object.isSealed({| foo: 42 |});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -17945,7 +18067,7 @@ return Object.isSealed({| foo: 42 |});
 </tr>
 <tr class="subtest" data-parent="Object.freeze_and_Object.seal_syntax" id="test-Object.freeze_and_Object.seal_syntax_Object.seal_syntax_with_array_literal"><td><span><a class="anchor" href="#test-Object.freeze_and_Object.seal_syntax_Object.seal_syntax_with_array_literal">&#xA7;</a>Object.seal syntax with array literal</span><script data-source="
 return Object.isSealed([| 42 |]);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("149");try{return Function("asyncTestPassed","\nreturn Object.isSealed([| 42 |]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("149");return Function("asyncTestPassed","'use strict';"+"\nreturn Object.isSealed([| 42 |]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("150");try{return Function("asyncTestPassed","\nreturn Object.isSealed([| 42 |]);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("150");return Function("asyncTestPassed","'use strict';"+"\nreturn Object.isSealed([| 42 |]);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -18069,7 +18191,7 @@ try {
 } catch (e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("150");try{return Function("asyncTestPassed","\nfunction foo({| bar, baz |}) {\n  return bar + baz;\n}\nif (foo({ bar: 1, baz: 2 }) !== 3) return;\ntry {\n  foo({ bar: 1, fuz: 2 });\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("150");return Function("asyncTestPassed","'use strict';"+"\nfunction foo({| bar, baz |}) {\n  return bar + baz;\n}\nif (foo({ bar: 1, baz: 2 }) !== 3) return;\ntry {\n  foo({ bar: 1, fuz: 2 });\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("151");try{return Function("asyncTestPassed","\nfunction foo({| bar, baz |}) {\n  return bar + baz;\n}\nif (foo({ bar: 1, baz: 2 }) !== 3) return;\ntry {\n  foo({ bar: 1, fuz: 2 });\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("151");return Function("asyncTestPassed","'use strict';"+"\nfunction foo({| bar, baz |}) {\n  return bar + baz;\n}\nif (foo({ bar: 1, baz: 2 }) !== 3) return;\ntry {\n  foo({ bar: 1, fuz: 2 });\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -18194,7 +18316,7 @@ try {
 } catch (e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("151");try{return Function("asyncTestPassed","\nfunction foo({# bar, baz #}) {\n  if (baz === 42) bar = 27;\n  return bar + baz;\n}\nif (foo({ bar: 1, baz: 2 }) !== 3) return;\ntry {\n  foo({ bar: 1, baz: 42 });\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("151");return Function("asyncTestPassed","'use strict';"+"\nfunction foo({# bar, baz #}) {\n  if (baz === 42) bar = 27;\n  return bar + baz;\n}\nif (foo({ bar: 1, baz: 2 }) !== 3) return;\ntry {\n  foo({ bar: 1, baz: 42 });\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("152");try{return Function("asyncTestPassed","\nfunction foo({# bar, baz #}) {\n  if (baz === 42) bar = 27;\n  return bar + baz;\n}\nif (foo({ bar: 1, baz: 2 }) !== 3) return;\ntry {\n  foo({ bar: 1, baz: 42 });\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("152");return Function("asyncTestPassed","'use strict';"+"\nfunction foo({# bar, baz #}) {\n  if (baz === 42) bar = 27;\n  return bar + baz;\n}\nif (foo({ bar: 1, baz: 2 }) !== 3) return;\ntry {\n  foo({ bar: 1, baz: 42 });\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -18318,7 +18440,7 @@ try {
 } catch (e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("152");try{return Function("asyncTestPassed","\nfunction foo(| bar, baz |) {\n  return bar + baz;\n}\nif (foo(1, 2) !== 3) return;\ntry {\n  foo(1, 2, 3);\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("152");return Function("asyncTestPassed","'use strict';"+"\nfunction foo(| bar, baz |) {\n  return bar + baz;\n}\nif (foo(1, 2) !== 3) return;\ntry {\n  foo(1, 2, 3);\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("153");try{return Function("asyncTestPassed","\nfunction foo(| bar, baz |) {\n  return bar + baz;\n}\nif (foo(1, 2) !== 3) return;\ntry {\n  foo(1, 2, 3);\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("153");return Function("asyncTestPassed","'use strict';"+"\nfunction foo(| bar, baz |) {\n  return bar + baz;\n}\nif (foo(1, 2) !== 3) return;\ntry {\n  foo(1, 2, 3);\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -18443,7 +18565,7 @@ try {
 } catch (e) {
   return true;
 }
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("153");try{return Function("asyncTestPassed","\nfunction foo(# bar, baz #) {\n  if (baz === 42) bar = 27;\n  return bar + baz;\n}\nif (foo(1, 2) !== 3) return;\ntry {\n  foo(1, 42);\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("153");return Function("asyncTestPassed","'use strict';"+"\nfunction foo(# bar, baz #) {\n  if (baz === 42) bar = 27;\n  return bar + baz;\n}\nif (foo(1, 2) !== 3) return;\ntry {\n  foo(1, 42);\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("154");try{return Function("asyncTestPassed","\nfunction foo(# bar, baz #) {\n  if (baz === 42) bar = 27;\n  return bar + baz;\n}\nif (foo(1, 2) !== 3) return;\ntry {\n  foo(1, 42);\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("154");return Function("asyncTestPassed","'use strict';"+"\nfunction foo(# bar, baz #) {\n  if (baz === 42) bar = 27;\n  return bar + baz;\n}\nif (foo(1, 2) !== 3) return;\ntry {\n  foo(1, 42);\n} catch (e) {\n  return true;\n}\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -18564,7 +18686,7 @@ return results.length === 3
   &amp;&amp; results[0].codePoint === 97 &amp;&amp; results[0].position === 0
   &amp;&amp; results[1].codePoint === 134071 &amp;&amp; results[1].position === 1
   &amp;&amp; results[2].codePoint === 98 &amp;&amp; results[2].position === 3;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("154");try{return Function("asyncTestPassed","\nvar results = [];\nfor (let code of 'a𠮷b'.codePoints()) results.push(code);\nreturn results.length === 3\n  && results[0].codePoint === 97 && results[0].position === 0\n  && results[1].codePoint === 134071 && results[1].position === 1\n  && results[2].codePoint === 98 && results[2].position === 3;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("154");return Function("asyncTestPassed","'use strict';"+"\nvar results = [];\nfor (let code of 'a𠮷b'.codePoints()) results.push(code);\nreturn results.length === 3\n  && results[0].codePoint === 97 && results[0].position === 0\n  && results[1].codePoint === 134071 && results[1].position === 1\n  && results[2].codePoint === 98 && results[2].position === 3;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("155");try{return Function("asyncTestPassed","\nvar results = [];\nfor (let code of 'a𠮷b'.codePoints()) results.push(code);\nreturn results.length === 3\n  && results[0].codePoint === 97 && results[0].position === 0\n  && results[1].codePoint === 134071 && results[1].position === 1\n  && results[2].codePoint === 98 && results[2].position === 3;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("155");return Function("asyncTestPassed","'use strict';"+"\nvar results = [];\nfor (let code of 'a𠮷b'.codePoints()) results.push(code);\nreturn results.length === 3\n  && results[0].codePoint === 97 && results[0].position === 0\n  && results[1].codePoint === 134071 && results[1].position === 1\n  && results[2].codePoint === 98 && results[2].position === 3;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -18793,7 +18915,7 @@ return results.length === 3
 </tr>
 <tr class="subtest" data-parent="Getting_last_item_from_array" id="test-Getting_last_item_from_array_Array.prototype.lastItem"><td><span><a class="anchor" href="#test-Getting_last_item_from_array_Array.prototype.lastItem">&#xA7;</a>Array.prototype.lastItem</span><script data-source="
 return [1, 2, 3].lastItem === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("156");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].lastItem === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("156");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].lastItem === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("157");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].lastItem === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("157");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].lastItem === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -18909,7 +19031,7 @@ return [1, 2, 3].lastItem === 3;
 </tr>
 <tr class="subtest" data-parent="Getting_last_item_from_array" id="test-Getting_last_item_from_array_Array.prototype.lastIndex"><td><span><a class="anchor" href="#test-Getting_last_item_from_array_Array.prototype.lastIndex">&#xA7;</a>Array.prototype.lastIndex</span><script data-source="
 return [1, 2, 3].lastIndex === 2;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("157");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].lastIndex === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("157");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].lastIndex === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("158");try{return Function("asyncTestPassed","\nreturn [1, 2, 3].lastIndex === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("158");return Function("asyncTestPassed","'use strict';"+"\nreturn [1, 2, 3].lastIndex === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -19143,7 +19265,7 @@ return map.size === 2
   &amp;&amp; map.get(0)[1] === 4
   &amp;&amp; map.get(1)[0] === 1
   &amp;&amp; map.get(1)[1] === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("159");try{return Function("asyncTestPassed","\nvar map = Map.groupBy(new Set([1, 2, 3, 4]), it => it % 2)\nreturn map.size === 2\n  && map.get(0)[0] === 2\n  && map.get(0)[1] === 4\n  && map.get(1)[0] === 1\n  && map.get(1)[1] === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("159");return Function("asyncTestPassed","'use strict';"+"\nvar map = Map.groupBy(new Set([1, 2, 3, 4]), it => it % 2)\nreturn map.size === 2\n  && map.get(0)[0] === 2\n  && map.get(0)[1] === 4\n  && map.get(1)[0] === 1\n  && map.get(1)[1] === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("160");try{return Function("asyncTestPassed","\nvar map = Map.groupBy(new Set([1, 2, 3, 4]), it => it % 2)\nreturn map.size === 2\n  && map.get(0)[0] === 2\n  && map.get(0)[1] === 4\n  && map.get(1)[0] === 1\n  && map.get(1)[1] === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("160");return Function("asyncTestPassed","'use strict';"+"\nvar map = Map.groupBy(new Set([1, 2, 3, 4]), it => it % 2)\nreturn map.size === 2\n  && map.get(0)[0] === 2\n  && map.get(0)[1] === 4\n  && map.get(1)[0] === 1\n  && map.get(1)[1] === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -19262,7 +19384,7 @@ var map = Map.keyBy(new Set([{ id: 101 }, { id: 102 }]), it =&gt; it.id)
 return map.size === 2
   &amp;&amp; map.get(101).id === 101
   &amp;&amp; map.get(102).id === 102;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("160");try{return Function("asyncTestPassed","\nvar map = Map.keyBy(new Set([{ id: 101 }, { id: 102 }]), it => it.id)\nreturn map.size === 2\n  && map.get(101).id === 101\n  && map.get(102).id === 102;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("160");return Function("asyncTestPassed","'use strict';"+"\nvar map = Map.keyBy(new Set([{ id: 101 }, { id: 102 }]), it => it.id)\nreturn map.size === 2\n  && map.get(101).id === 101\n  && map.get(102).id === 102;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("161");try{return Function("asyncTestPassed","\nvar map = Map.keyBy(new Set([{ id: 101 }, { id: 102 }]), it => it.id)\nreturn map.size === 2\n  && map.get(101).id === 101\n  && map.get(102).id === 102;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("161");return Function("asyncTestPassed","'use strict';"+"\nvar map = Map.keyBy(new Set([{ id: 101 }, { id: 102 }]), it => it.id)\nreturn map.size === 2\n  && map.get(101).id === 101\n  && map.get(102).id === 102;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -19382,7 +19504,7 @@ map.deleteAll(1, 5)
 return map.size === 2
   &amp;&amp; map.get(3) === 4
   &amp;&amp; map.get(7) === 8;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("161");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 2], [3, 4], [5, 6], [7, 8]]);\nmap.deleteAll(1, 5)\nreturn map.size === 2\n  && map.get(3) === 4\n  && map.get(7) === 8;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("161");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 2], [3, 4], [5, 6], [7, 8]]);\nmap.deleteAll(1, 5)\nreturn map.size === 2\n  && map.get(3) === 4\n  && map.get(7) === 8;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("162");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 2], [3, 4], [5, 6], [7, 8]]);\nmap.deleteAll(1, 5)\nreturn map.size === 2\n  && map.get(3) === 4\n  && map.get(7) === 8;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("162");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 2], [3, 4], [5, 6], [7, 8]]);\nmap.deleteAll(1, 5)\nreturn map.size === 2\n  && map.get(3) === 4\n  && map.get(7) === 8;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -19498,7 +19620,7 @@ return map.size === 2
 </tr>
 <tr class="subtest" data-parent="Collections_methods" id="test-Collections_methods_Map.prototype.every"><td><span><a class="anchor" href="#test-Collections_methods_Map.prototype.every">&#xA7;</a>Map.prototype.every</span><script data-source="
 return new Map([[1, 4], [2, 5], [3, 6]]).every(it =&gt; typeof it === &apos;number&apos;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("162");try{return Function("asyncTestPassed","\nreturn new Map([[1, 4], [2, 5], [3, 6]]).every(it => typeof it === 'number');\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("162");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 4], [2, 5], [3, 6]]).every(it => typeof it === 'number');\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("163");try{return Function("asyncTestPassed","\nreturn new Map([[1, 4], [2, 5], [3, 6]]).every(it => typeof it === 'number');\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("163");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 4], [2, 5], [3, 6]]).every(it => typeof it === 'number');\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -19617,7 +19739,7 @@ var map = new Map([[1, 4], [2, 5], [3, 6]]).filter(it =&gt; !(it % 2));
 return map.size === 2
   &amp;&amp; map.get(1) === 4
   &amp;&amp; map.get(3) === 6;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("163");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).filter(it => !(it % 2));\nreturn map.size === 2\n  && map.get(1) === 4\n  && map.get(3) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("163");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).filter(it => !(it % 2));\nreturn map.size === 2\n  && map.get(1) === 4\n  && map.get(3) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("164");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).filter(it => !(it % 2));\nreturn map.size === 2\n  && map.get(1) === 4\n  && map.get(3) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("164");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).filter(it => !(it % 2));\nreturn map.size === 2\n  && map.get(1) === 4\n  && map.get(3) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -19733,7 +19855,7 @@ return map.size === 2
 </tr>
 <tr class="subtest" data-parent="Collections_methods" id="test-Collections_methods_Map.prototype.find"><td><span><a class="anchor" href="#test-Collections_methods_Map.prototype.find">&#xA7;</a>Map.prototype.find</span><script data-source="
 return new Map([[1, 2], [2, 3], [3, 4]]).find(it =&gt; it % 2) === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("164");try{return Function("asyncTestPassed","\nreturn new Map([[1, 2], [2, 3], [3, 4]]).find(it => it % 2) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("164");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 2], [2, 3], [3, 4]]).find(it => it % 2) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("165");try{return Function("asyncTestPassed","\nreturn new Map([[1, 2], [2, 3], [3, 4]]).find(it => it % 2) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("165");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 2], [2, 3], [3, 4]]).find(it => it % 2) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -19849,7 +19971,7 @@ return new Map([[1, 2], [2, 3], [3, 4]]).find(it =&gt; it % 2) === 3;
 </tr>
 <tr class="subtest" data-parent="Collections_methods" id="test-Collections_methods_Map.prototype.findKey"><td><span><a class="anchor" href="#test-Collections_methods_Map.prototype.findKey">&#xA7;</a>Map.prototype.findKey</span><script data-source="
 return new Map([[1, 2], [2, 3], [3, 4]]).findKey(it =&gt; it % 2) === 2;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("165");try{return Function("asyncTestPassed","\nreturn new Map([[1, 2], [2, 3], [3, 4]]).findKey(it => it % 2) === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("165");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 2], [2, 3], [3, 4]]).findKey(it => it % 2) === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("166");try{return Function("asyncTestPassed","\nreturn new Map([[1, 2], [2, 3], [3, 4]]).findKey(it => it % 2) === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("166");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 2], [2, 3], [3, 4]]).findKey(it => it % 2) === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -19966,7 +20088,7 @@ return new Map([[1, 2], [2, 3], [3, 4]]).findKey(it =&gt; it % 2) === 2;
 <tr class="subtest" data-parent="Collections_methods" id="test-Collections_methods_Map.prototype.includes"><td><span><a class="anchor" href="#test-Collections_methods_Map.prototype.includes">&#xA7;</a>Map.prototype.includes</span><script data-source="
 return new Map([[1, 2], [2, NaN]]).includes(2)
   &amp;&amp; new Map([[1, 2], [2, NaN]]).includes(NaN);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("166");try{return Function("asyncTestPassed","\nreturn new Map([[1, 2], [2, NaN]]).includes(2)\n  && new Map([[1, 2], [2, NaN]]).includes(NaN);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("166");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 2], [2, NaN]]).includes(2)\n  && new Map([[1, 2], [2, NaN]]).includes(NaN);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("167");try{return Function("asyncTestPassed","\nreturn new Map([[1, 2], [2, NaN]]).includes(2)\n  && new Map([[1, 2], [2, NaN]]).includes(NaN);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("167");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 2], [2, NaN]]).includes(2)\n  && new Map([[1, 2], [2, NaN]]).includes(NaN);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -20083,7 +20205,7 @@ return new Map([[1, 2], [2, NaN]]).includes(2)
 <tr class="subtest" data-parent="Collections_methods" id="test-Collections_methods_Map.prototype.keyOf"><td><span><a class="anchor" href="#test-Collections_methods_Map.prototype.keyOf">&#xA7;</a>Map.prototype.keyOf</span><script data-source="
 return new Map([[1, 2], [2, NaN]]).keyOf(2) === 1
   &amp;&amp; new Map([[1, 2], [2, NaN]]).keyOf(NaN) === void undefined;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("167");try{return Function("asyncTestPassed","\nreturn new Map([[1, 2], [2, NaN]]).keyOf(2) === 1\n  && new Map([[1, 2], [2, NaN]]).keyOf(NaN) === void undefined;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("167");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 2], [2, NaN]]).keyOf(2) === 1\n  && new Map([[1, 2], [2, NaN]]).keyOf(NaN) === void undefined;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("168");try{return Function("asyncTestPassed","\nreturn new Map([[1, 2], [2, NaN]]).keyOf(2) === 1\n  && new Map([[1, 2], [2, NaN]]).keyOf(NaN) === void undefined;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("168");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 2], [2, NaN]]).keyOf(2) === 1\n  && new Map([[1, 2], [2, NaN]]).keyOf(NaN) === void undefined;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -20203,7 +20325,7 @@ return map.size === 3
   &amp;&amp; map.get(1) === 4
   &amp;&amp; map.get(4) === 5
   &amp;&amp; map.get(9) === 6;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("168");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).mapKeys((value, key) => key * key);\nreturn map.size === 3\n  && map.get(1) === 4\n  && map.get(4) === 5\n  && map.get(9) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("168");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).mapKeys((value, key) => key * key);\nreturn map.size === 3\n  && map.get(1) === 4\n  && map.get(4) === 5\n  && map.get(9) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("169");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).mapKeys((value, key) => key * key);\nreturn map.size === 3\n  && map.get(1) === 4\n  && map.get(4) === 5\n  && map.get(9) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("169");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).mapKeys((value, key) => key * key);\nreturn map.size === 3\n  && map.get(1) === 4\n  && map.get(4) === 5\n  && map.get(9) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -20323,7 +20445,7 @@ return map.size === 3
   &amp;&amp; map.get(1) === 16
   &amp;&amp; map.get(2) === 25
   &amp;&amp; map.get(3) === 36;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("169");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).mapValues((value, key) => value * value);\nreturn map.size === 3\n  && map.get(1) === 16\n  && map.get(2) === 25\n  && map.get(3) === 36;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("169");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).mapValues((value, key) => value * value);\nreturn map.size === 3\n  && map.get(1) === 16\n  && map.get(2) === 25\n  && map.get(3) === 36;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("170");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).mapValues((value, key) => value * value);\nreturn map.size === 3\n  && map.get(1) === 16\n  && map.get(2) === 25\n  && map.get(3) === 36;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("170");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 4], [2, 5], [3, 6]]).mapValues((value, key) => value * value);\nreturn map.size === 3\n  && map.get(1) === 16\n  && map.get(2) === 25\n  && map.get(3) === 36;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -20443,7 +20565,7 @@ return map.size === 3
   &amp;&amp; map.get(1) === 4
   &amp;&amp; map.get(2) === 7
   &amp;&amp; map.get(3) === 6;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("170");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 4], [2, 5]]).merge(new Map([[2, 7], [3, 6]]));\nreturn map.size === 3\n  && map.get(1) === 4\n  && map.get(2) === 7\n  && map.get(3) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("170");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 4], [2, 5]]).merge(new Map([[2, 7], [3, 6]]));\nreturn map.size === 3\n  && map.get(1) === 4\n  && map.get(2) === 7\n  && map.get(3) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("171");try{return Function("asyncTestPassed","\nvar map = new Map([[1, 4], [2, 5]]).merge(new Map([[2, 7], [3, 6]]));\nreturn map.size === 3\n  && map.get(1) === 4\n  && map.get(2) === 7\n  && map.get(3) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("171");return Function("asyncTestPassed","'use strict';"+"\nvar map = new Map([[1, 4], [2, 5]]).merge(new Map([[2, 7], [3, 6]]));\nreturn map.size === 3\n  && map.get(1) === 4\n  && map.get(2) === 7\n  && map.get(3) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -20559,7 +20681,7 @@ return map.size === 3
 </tr>
 <tr class="subtest" data-parent="Collections_methods" id="test-Collections_methods_Map.prototype.reduce"><td><span><a class="anchor" href="#test-Collections_methods_Map.prototype.reduce">&#xA7;</a>Map.prototype.reduce</span><script data-source="
 return new Map([[&apos;a&apos;, 1], [&apos;b&apos;, 2], [&apos;c&apos;, 3], ]).reduce(((a, b) =&gt; a + b), 1) === 7;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("171");try{return Function("asyncTestPassed","\nreturn new Map([['a', 1], ['b', 2], ['c', 3], ]).reduce(((a, b) => a + b), 1) === 7;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("171");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([['a', 1], ['b', 2], ['c', 3], ]).reduce(((a, b) => a + b), 1) === 7;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("172");try{return Function("asyncTestPassed","\nreturn new Map([['a', 1], ['b', 2], ['c', 3], ]).reduce(((a, b) => a + b), 1) === 7;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("172");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([['a', 1], ['b', 2], ['c', 3], ]).reduce(((a, b) => a + b), 1) === 7;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -20675,7 +20797,7 @@ return new Map([[&apos;a&apos;, 1], [&apos;b&apos;, 2], [&apos;c&apos;, 3], ]).r
 </tr>
 <tr class="subtest" data-parent="Collections_methods" id="test-Collections_methods_Map.prototype.some"><td><span><a class="anchor" href="#test-Collections_methods_Map.prototype.some">&#xA7;</a>Map.prototype.some</span><script data-source="
 return new Map([[1, 4], [2, 5], [3, 6]]).some(it =&gt; it % 2);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("172");try{return Function("asyncTestPassed","\nreturn new Map([[1, 4], [2, 5], [3, 6]]).some(it => it % 2);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("172");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 4], [2, 5], [3, 6]]).some(it => it % 2);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("173");try{return Function("asyncTestPassed","\nreturn new Map([[1, 4], [2, 5], [3, 6]]).some(it => it % 2);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("173");return Function("asyncTestPassed","'use strict';"+"\nreturn new Map([[1, 4], [2, 5], [3, 6]]).some(it => it % 2);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -20795,7 +20917,7 @@ return set.size === 3
   &amp;&amp; set.has(1)
   &amp;&amp; set.has(2)
   &amp;&amp; set.has(3);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("173");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).addAll(2, 3);\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("173");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).addAll(2, 3);\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("174");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2]).addAll(2, 3);\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("174");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2]).addAll(2, 3);\nreturn set.size === 3\n  && set.has(1)\n  && set.has(2)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -20915,7 +21037,7 @@ return set.deleteAll(2, 3) === true
   &amp;&amp; set.size === 2
   &amp;&amp; set.has(1)
   &amp;&amp; set.has(4);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("174");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3, 4]);\nreturn set.deleteAll(2, 3) === true\n  && set.size === 2\n  && set.has(1)\n  && set.has(4);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("174");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3, 4]);\nreturn set.deleteAll(2, 3) === true\n  && set.size === 2\n  && set.has(1)\n  && set.has(4);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("175");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3, 4]);\nreturn set.deleteAll(2, 3) === true\n  && set.size === 2\n  && set.has(1)\n  && set.has(4);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("175");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3, 4]);\nreturn set.deleteAll(2, 3) === true\n  && set.size === 2\n  && set.has(1)\n  && set.has(4);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -21031,7 +21153,7 @@ return set.deleteAll(2, 3) === true
 </tr>
 <tr class="subtest" data-parent="Collections_methods" id="test-Collections_methods_Set.prototype.every"><td><span><a class="anchor" href="#test-Collections_methods_Set.prototype.every">&#xA7;</a>Set.prototype.every</span><script data-source="
 return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("175");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).every(it => typeof it === 'number');\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("175");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).every(it => typeof it === 'number');\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("176");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).every(it => typeof it === 'number');\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("176");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).every(it => typeof it === 'number');\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -21150,7 +21272,7 @@ var set = new Set([1, 2, 3]).filter(it =&gt; it % 2);
 return set.size === 2
   &amp;&amp; set.has(1)
   &amp;&amp; set.has(3);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("176");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).filter(it => it % 2);\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("176");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).filter(it => it % 2);\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("177");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).filter(it => it % 2);\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("177");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).filter(it => it % 2);\nreturn set.size === 2\n  && set.has(1)\n  && set.has(3);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -21266,7 +21388,7 @@ return set.size === 2
 </tr>
 <tr class="subtest" data-parent="Collections_methods" id="test-Collections_methods_Set.prototype.find"><td><span><a class="anchor" href="#test-Collections_methods_Set.prototype.find">&#xA7;</a>Set.prototype.find</span><script data-source="
 return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("177");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).find(it => !(it % 2)) === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("177");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).find(it => !(it % 2)) === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("178");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).find(it => !(it % 2)) === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("178");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).find(it => !(it % 2)) === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -21382,7 +21504,7 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 </tr>
 <tr class="subtest" data-parent="Collections_methods" id="test-Collections_methods_Set.prototype.join"><td><span><a class="anchor" href="#test-Collections_methods_Set.prototype.join">&#xA7;</a>Set.prototype.join</span><script data-source="
 return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("178");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).join('|') === '1|2|3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("178");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).join('|') === '1|2|3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("179");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).join('|') === '1|2|3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("179");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).join('|') === '1|2|3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -21502,7 +21624,7 @@ return set.size === 3
   &amp;&amp; set.has(1)
   &amp;&amp; set.has(4)
   &amp;&amp; set.has(9);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("179");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).map(it => it * it);\nreturn set.size === 3\n  && set.has(1)\n  && set.has(4)\n  && set.has(9);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("179");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).map(it => it * it);\nreturn set.size === 3\n  && set.has(1)\n  && set.has(4)\n  && set.has(9);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("180");try{return Function("asyncTestPassed","\nvar set = new Set([1, 2, 3]).map(it => it * it);\nreturn set.size === 3\n  && set.has(1)\n  && set.has(4)\n  && set.has(9);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("180");return Function("asyncTestPassed","'use strict';"+"\nvar set = new Set([1, 2, 3]).map(it => it * it);\nreturn set.size === 3\n  && set.has(1)\n  && set.has(4)\n  && set.has(9);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -21618,7 +21740,7 @@ return set.size === 3
 </tr>
 <tr class="subtest" data-parent="Collections_methods" id="test-Collections_methods_Set.prototype.reduce"><td><span><a class="anchor" href="#test-Collections_methods_Set.prototype.reduce">&#xA7;</a>Set.prototype.reduce</span><script data-source="
 return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("180");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).reduce((memo, it) => memo + it) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("180");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).reduce((memo, it) => memo + it) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("181");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).reduce((memo, it) => memo + it) === 6;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("181");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).reduce((memo, it) => memo + it) === 6;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -21734,7 +21856,7 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 </tr>
 <tr class="subtest" data-parent="Collections_methods" id="test-Collections_methods_Set.prototype.some"><td><span><a class="anchor" href="#test-Collections_methods_Set.prototype.some">&#xA7;</a>Set.prototype.some</span><script data-source="
 return new Set([1, 2, 3]).some(it =&gt; it % 2);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("181");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).some(it => it % 2);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("181");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).some(it => it % 2);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("182");try{return Function("asyncTestPassed","\nreturn new Set([1, 2, 3]).some(it => it % 2);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("182");return Function("asyncTestPassed","'use strict';"+"\nreturn new Set([1, 2, 3]).some(it => it % 2);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -21859,7 +21981,7 @@ return !map.has(a)
   &amp;&amp; map.get(b) === 2
   &amp;&amp; !map.has(c)
   &amp;&amp; map.get(d) === 4;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("182");try{return Function("asyncTestPassed","\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar map = new WeakMap([[a, 1], [b, 2], [c, 3], [d, 4]]);\nmap.deleteAll(a, c)\nreturn !map.has(a)\n  && map.get(b) === 2\n  && !map.has(c)\n  && map.get(d) === 4;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("182");return Function("asyncTestPassed","'use strict';"+"\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar map = new WeakMap([[a, 1], [b, 2], [c, 3], [d, 4]]);\nmap.deleteAll(a, c)\nreturn !map.has(a)\n  && map.get(b) === 2\n  && !map.has(c)\n  && map.get(d) === 4;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("183");try{return Function("asyncTestPassed","\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar map = new WeakMap([[a, 1], [b, 2], [c, 3], [d, 4]]);\nmap.deleteAll(a, c)\nreturn !map.has(a)\n  && map.get(b) === 2\n  && !map.has(c)\n  && map.get(d) === 4;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("183");return Function("asyncTestPassed","'use strict';"+"\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar map = new WeakMap([[a, 1], [b, 2], [c, 3], [d, 4]]);\nmap.deleteAll(a, c)\nreturn !map.has(a)\n  && map.get(b) === 2\n  && !map.has(c)\n  && map.get(d) === 4;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -21984,7 +22106,7 @@ return set.has(a)
   &amp;&amp; set.has(b)
   &amp;&amp; set.has(c)
   &amp;&amp; set.has(d);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("183");try{return Function("asyncTestPassed","\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar set = new WeakSet([a, b]);\nset.addAll(c, d)\nreturn set.has(a)\n  && set.has(b)\n  && set.has(c)\n  && set.has(d);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("183");return Function("asyncTestPassed","'use strict';"+"\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar set = new WeakSet([a, b]);\nset.addAll(c, d)\nreturn set.has(a)\n  && set.has(b)\n  && set.has(c)\n  && set.has(d);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("184");try{return Function("asyncTestPassed","\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar set = new WeakSet([a, b]);\nset.addAll(c, d)\nreturn set.has(a)\n  && set.has(b)\n  && set.has(c)\n  && set.has(d);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("184");return Function("asyncTestPassed","'use strict';"+"\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar set = new WeakSet([a, b]);\nset.addAll(c, d)\nreturn set.has(a)\n  && set.has(b)\n  && set.has(c)\n  && set.has(d);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -22109,7 +22231,7 @@ return !set.has(a)
   &amp;&amp; set.has(b)
   &amp;&amp; !set.has(c)
   &amp;&amp; set.has(d);
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("184");try{return Function("asyncTestPassed","\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar set = new WeakSet([a, b, c, d]);\nset.deleteAll(a, c)\nreturn !set.has(a)\n  && set.has(b)\n  && !set.has(c)\n  && set.has(d);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("184");return Function("asyncTestPassed","'use strict';"+"\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar set = new WeakSet([a, b, c, d]);\nset.deleteAll(a, c)\nreturn !set.has(a)\n  && set.has(b)\n  && !set.has(c)\n  && set.has(d);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("185");try{return Function("asyncTestPassed","\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar set = new WeakSet([a, b, c, d]);\nset.deleteAll(a, c)\nreturn !set.has(a)\n  && set.has(b)\n  && !set.has(c)\n  && set.has(d);\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("185");return Function("asyncTestPassed","'use strict';"+"\nvar a = {};\nvar b = {};\nvar c = {};\nvar d = {};\nvar set = new WeakSet([a, b, c, d]);\nset.deleteAll(a, c)\nreturn !set.has(a)\n  && set.has(b)\n  && !set.has(c)\n  && set.has(d);\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -22233,7 +22355,7 @@ if (first !== gen2.next().value) return false;
 var second = gen1.next().value;
 if (first === second) return false;
 return second === gen2.next().value;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("185");try{return Function("asyncTestPassed","\nvar gen1 = Math.seededPRNG({ seed: 42 });\nvar gen2 = Math.seededPRNG({ seed: 42 });\nif (!gen1.next || !gen1[Symbol.iterator]) return false;\nvar first = gen1.next().value;\nif (first < 0 || first > 1) return false;\nif (first !== gen2.next().value) return false;\nvar second = gen1.next().value;\nif (first === second) return false;\nreturn second === gen2.next().value;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("185");return Function("asyncTestPassed","'use strict';"+"\nvar gen1 = Math.seededPRNG({ seed: 42 });\nvar gen2 = Math.seededPRNG({ seed: 42 });\nif (!gen1.next || !gen1[Symbol.iterator]) return false;\nvar first = gen1.next().value;\nif (first < 0 || first > 1) return false;\nif (first !== gen2.next().value) return false;\nvar second = gen1.next().value;\nif (first === second) return false;\nreturn second === gen2.next().value;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("186");try{return Function("asyncTestPassed","\nvar gen1 = Math.seededPRNG({ seed: 42 });\nvar gen2 = Math.seededPRNG({ seed: 42 });\nif (!gen1.next || !gen1[Symbol.iterator]) return false;\nvar first = gen1.next().value;\nif (first < 0 || first > 1) return false;\nif (first !== gen2.next().value) return false;\nvar second = gen1.next().value;\nif (first === second) return false;\nreturn second === gen2.next().value;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("186");return Function("asyncTestPassed","'use strict';"+"\nvar gen1 = Math.seededPRNG({ seed: 42 });\nvar gen2 = Math.seededPRNG({ seed: 42 });\nif (!gen1.next || !gen1[Symbol.iterator]) return false;\nvar first = gen1.next().value;\nif (first < 0 || first > 1) return false;\nif (first !== gen2.next().value) return false;\nvar second = gen1.next().value;\nif (first === second) return false;\nreturn second === gen2.next().value;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -22462,7 +22584,7 @@ return second === gen2.next().value;
 </tr>
 <tr class="subtest" data-parent="{_BigInt,_Number_}.fromString" id="test-{_BigInt,_Number_}.fromString_Number.fromString"><td><span><a class="anchor" href="#test-{_BigInt,_Number_}.fromString_Number.fromString">&#xA7;</a>Number.fromString</span><script data-source="
 return Number.fromString(&apos;42&apos;) === 42;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("187");try{return Function("asyncTestPassed","\nreturn Number.fromString('42') === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("187");return Function("asyncTestPassed","'use strict';"+"\nreturn Number.fromString('42') === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("188");try{return Function("asyncTestPassed","\nreturn Number.fromString('42') === 42;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("188");return Function("asyncTestPassed","'use strict';"+"\nreturn Number.fromString('42') === 42;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -22578,7 +22700,7 @@ return Number.fromString(&apos;42&apos;) === 42;
 </tr>
 <tr class="subtest" data-parent="{_BigInt,_Number_}.fromString" id="test-{_BigInt,_Number_}.fromString_BigInt.fromString"><td><span><a class="anchor" href="#test-{_BigInt,_Number_}.fromString_BigInt.fromString">&#xA7;</a>BigInt.fromString</span><script data-source="
 return BigInt.fromString(&apos;42&apos;) === 42n;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("188");try{return Function("asyncTestPassed","\nreturn BigInt.fromString('42') === 42n;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("188");return Function("asyncTestPassed","'use strict';"+"\nreturn BigInt.fromString('42') === 42n;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("189");try{return Function("asyncTestPassed","\nreturn BigInt.fromString('42') === 42n;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("189");return Function("asyncTestPassed","'use strict';"+"\nreturn BigInt.fromString('42') === 42n;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -22811,7 +22933,7 @@ const iterator = Object.iterateKeys(object);
 if (typeof iterator[Symbol.iterator] !== &apos;function&apos; || typeof iterator.next !== &apos;function&apos;) return false;
 delete object.b;
 return [...iterator].join() === &apos;a,c&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("190");try{return Function("asyncTestPassed","\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateKeys(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === 'a,c';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("190");return Function("asyncTestPassed","'use strict';"+"\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateKeys(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === 'a,c';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("191");try{return Function("asyncTestPassed","\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateKeys(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === 'a,c';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("191");return Function("asyncTestPassed","'use strict';"+"\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateKeys(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === 'a,c';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -22931,7 +23053,7 @@ const iterator = Object.iterateValues(object);
 if (typeof iterator[Symbol.iterator] !== &apos;function&apos; || typeof iterator.next !== &apos;function&apos;) return false;
 delete object.b;
 return [...iterator].join() === &apos;1,3&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("191");try{return Function("asyncTestPassed","\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateValues(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === '1,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("191");return Function("asyncTestPassed","'use strict';"+"\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateValues(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === '1,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("192");try{return Function("asyncTestPassed","\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateValues(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === '1,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("192");return Function("asyncTestPassed","'use strict';"+"\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateValues(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === '1,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -23051,7 +23173,7 @@ const iterator = Object.iterateEntries(object);
 if (typeof iterator[Symbol.iterator] !== &apos;function&apos; || typeof iterator.next !== &apos;function&apos;) return false;
 delete object.b;
 return [...iterator].join() === &apos;a,1,c,3&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("192");try{return Function("asyncTestPassed","\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateEntries(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === 'a,1,c,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("192");return Function("asyncTestPassed","'use strict';"+"\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateEntries(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === 'a,1,c,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("193");try{return Function("asyncTestPassed","\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateEntries(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === 'a,1,c,3';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("193");return Function("asyncTestPassed","'use strict';"+"\nconst object = { a: 1, b: 2, c: 3 };\nconst iterator = Object.iterateEntries(object);\nif (typeof iterator[Symbol.iterator] !== 'function' || typeof iterator.next !== 'function') return false;\ndelete object.b;\nreturn [...iterator].join() === 'a,1,c,3';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -23284,7 +23406,7 @@ return [...iterator].join() === &apos;a,1,c,3&apos;;
 function foo() { this.garply += &quot;foo&quot;; return this; }
 var obj = { garply: &quot;bar&quot; };
 return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply === &quot;barfoo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("194");try{return Function("asyncTestPassed","\nfunction foo() { this.garply += \"foo\"; return this; }\nvar obj = { garply: \"bar\" };\nreturn typeof obj::foo === \"function\" && obj::foo().garply === \"barfoo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("194");return Function("asyncTestPassed","'use strict';"+"\nfunction foo() { this.garply += \"foo\"; return this; }\nvar obj = { garply: \"bar\" };\nreturn typeof obj::foo === \"function\" && obj::foo().garply === \"barfoo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("195");try{return Function("asyncTestPassed","\nfunction foo() { this.garply += \"foo\"; return this; }\nvar obj = { garply: \"bar\" };\nreturn typeof obj::foo === \"function\" && obj::foo().garply === \"barfoo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("195");return Function("asyncTestPassed","'use strict';"+"\nfunction foo() { this.garply += \"foo\"; return this; }\nvar obj = { garply: \"bar\" };\nreturn typeof obj::foo === \"function\" && obj::foo().garply === \"barfoo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -23401,7 +23523,7 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <tr class="subtest" data-parent="bind_(::)_operator" id="test-bind_(::)_operator_unary_form"><td><span><a class="anchor" href="#test-bind_(::)_operator_unary_form">&#xA7;</a>unary form</span><script data-source="
 var obj = { garply: &quot;bar&quot;, foo: function() { this.garply += &quot;foo&quot;; return this; } };
 return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply === &quot;barfoo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("195");try{return Function("asyncTestPassed","\nvar obj = { garply: \"bar\", foo: function() { this.garply += \"foo\"; return this; } };\nreturn typeof ::obj.foo === \"function\" && ::obj.foo().garply === \"barfoo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("195");return Function("asyncTestPassed","'use strict';"+"\nvar obj = { garply: \"bar\", foo: function() { this.garply += \"foo\"; return this; } };\nreturn typeof ::obj.foo === \"function\" && ::obj.foo().garply === \"barfoo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("196");try{return Function("asyncTestPassed","\nvar obj = { garply: \"bar\", foo: function() { this.garply += \"foo\"; return this; } };\nreturn typeof ::obj.foo === \"function\" && ::obj.foo().garply === \"barfoo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("196");return Function("asyncTestPassed","'use strict';"+"\nvar obj = { garply: \"bar\", foo: function() { this.garply += \"foo\"; return this; } };\nreturn typeof ::obj.foo === \"function\" && ::obj.foo().garply === \"barfoo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -23517,7 +23639,7 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 </tr>
 <tr significance="0.25" class="optional-feature"><td id="test-String.prototype.at"><span><a class="anchor" href="#test-String.prototype.at">&#xA7;</a><a href="https://github.com/mathiasbynens/String.prototype.at">String.prototype.at</a></span><script data-source="
 return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("196");try{return Function("asyncTestPassed","\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("196");return Function("asyncTestPassed","'use strict';"+"\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("197");try{return Function("asyncTestPassed","\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("197");return Function("asyncTestPassed","'use strict';"+"\nreturn 'a𠮷b'.at(1) === '𠮷';\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -23747,7 +23869,7 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <tr class="subtest" data-parent="additional_meta_properties" id="test-additional_meta_properties_function.callee"><td><span><a class="anchor" href="#test-additional_meta_properties_function.callee">&#xA7;</a>function.callee</span><script data-source="
 var f = _ =&gt; function.callee === f;
 return f();
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("198");try{return Function("asyncTestPassed","\nvar f = _ => function.callee === f;\nreturn f();\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("198");return Function("asyncTestPassed","'use strict';"+"\nvar f = _ => function.callee === f;\nreturn f();\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("199");try{return Function("asyncTestPassed","\nvar f = _ => function.callee === f;\nreturn f();\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("199");return Function("asyncTestPassed","'use strict';"+"\nvar f = _ => function.callee === f;\nreturn f();\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -23863,7 +23985,7 @@ return f();
 </tr>
 <tr class="subtest" data-parent="additional_meta_properties" id="test-additional_meta_properties_function.count"><td><span><a class="anchor" href="#test-additional_meta_properties_function.count">&#xA7;</a>function.count</span><script data-source="
 return (_ =&gt; function.count)(1, 2, 3) === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("199");try{return Function("asyncTestPassed","\nreturn (_ => function.count)(1, 2, 3) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("199");return Function("asyncTestPassed","'use strict';"+"\nreturn (_ => function.count)(1, 2, 3) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("200");try{return Function("asyncTestPassed","\nreturn (_ => function.count)(1, 2, 3) === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("200");return Function("asyncTestPassed","'use strict';"+"\nreturn (_ => function.count)(1, 2, 3) === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -23984,7 +24106,7 @@ return Array.isArray(arr)
   &amp;&amp; arr[0] === 1
   &amp;&amp; arr[1] === 2
   &amp;&amp; arr[2] === 3;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("200");try{return Function("asyncTestPassed","\nvar arr =  (_ => function.arguments)(1, 2, 3);\nreturn Array.isArray(arr)\n  && arr.length === 3\n  && arr[0] === 1\n  && arr[1] === 2\n  && arr[2] === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("200");return Function("asyncTestPassed","'use strict';"+"\nvar arr =  (_ => function.arguments)(1, 2, 3);\nreturn Array.isArray(arr)\n  && arr.length === 3\n  && arr[0] === 1\n  && arr[1] === 2\n  && arr[2] === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("201");try{return Function("asyncTestPassed","\nvar arr =  (_ => function.arguments)(1, 2, 3);\nreturn Array.isArray(arr)\n  && arr.length === 3\n  && arr[0] === 1\n  && arr[1] === 2\n  && arr[2] === 3;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("201");return Function("asyncTestPassed","'use strict';"+"\nvar arr =  (_ => function.arguments)(1, 2, 3);\nreturn Array.isArray(arr)\n  && arr.length === 3\n  && arr[0] === 1\n  && arr[1] === 2\n  && arr[2] === 3;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -24111,7 +24233,7 @@ class C {
 return target === C.prototype
   &amp;&amp; key === &apos;method&apos;
   &amp;&amp; index === 0;
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("201");try{return Function("asyncTestPassed","\nvar target, key, index;\nfunction decorator(_target, _key, _index){\n  target = _target;\n  key = _key;\n  index = _index;\n}\nclass C {\n  method(@decorator foo){ }\n}\nreturn target === C.prototype\n  && key === 'method'\n  && index === 0;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("201");return Function("asyncTestPassed","'use strict';"+"\nvar target, key, index;\nfunction decorator(_target, _key, _index){\n  target = _target;\n  key = _key;\n  index = _index;\n}\nclass C {\n  method(@decorator foo){ }\n}\nreturn target === C.prototype\n  && key === 'method'\n  && index === 0;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("202");try{return Function("asyncTestPassed","\nvar target, key, index;\nfunction decorator(_target, _key, _index){\n  target = _target;\n  key = _key;\n  index = _index;\n}\nclass C {\n  method(@decorator foo){ }\n}\nreturn target === C.prototype\n  && key === 'method'\n  && index === 0;\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("202");return Function("asyncTestPassed","'use strict';"+"\nvar target, key, index;\nfunction decorator(_target, _key, _index){\n  target = _target;\n  key = _key;\n  index = _index;\n}\nclass C {\n  method(@decorator foo){ }\n}\nreturn target === C.prototype\n  && key === 'method'\n  && index === 0;\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -24234,7 +24356,7 @@ function inverse(f){
 return (@inverse function(it){
   return it % 2;
 })(2);
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("202");try{return Function("asyncTestPassed","\nfunction inverse(f){\n  return function(){\n    return !f.apply(this, arguments);\n  };\n}\nreturn (@inverse function(it){\n  return it % 2;\n})(2);\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("202");return Function("asyncTestPassed","'use strict';"+"\nfunction inverse(f){\n  return function(){\n    return !f.apply(this, arguments);\n  };\n}\nreturn (@inverse function(it){\n  return it % 2;\n})(2);\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("203");try{return Function("asyncTestPassed","\nfunction inverse(f){\n  return function(){\n    return !f.apply(this, arguments);\n  };\n}\nreturn (@inverse function(it){\n  return it % 2;\n})(2);\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("203");return Function("asyncTestPassed","'use strict';"+"\nfunction inverse(f){\n  return function(){\n    return !f.apply(this, arguments);\n  };\n}\nreturn (@inverse function(it){\n  return it % 2;\n})(2);\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -24465,7 +24587,7 @@ return (@inverse function(it){
 return Reflect.isCallable(function(){})
   &amp;&amp; Reflect.isCallable(_ =&gt; _)
   &amp;&amp; !Reflect.isCallable(class {});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("204");try{return Function("asyncTestPassed","\nreturn Reflect.isCallable(function(){})\n  && Reflect.isCallable(_ => _)\n  && !Reflect.isCallable(class {});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("204");return Function("asyncTestPassed","'use strict';"+"\nreturn Reflect.isCallable(function(){})\n  && Reflect.isCallable(_ => _)\n  && !Reflect.isCallable(class {});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("205");try{return Function("asyncTestPassed","\nreturn Reflect.isCallable(function(){})\n  && Reflect.isCallable(_ => _)\n  && !Reflect.isCallable(class {});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("205");return Function("asyncTestPassed","'use strict';"+"\nreturn Reflect.isCallable(function(){})\n  && Reflect.isCallable(_ => _)\n  && !Reflect.isCallable(class {});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -24583,7 +24705,7 @@ return Reflect.isCallable(function(){})
 return Reflect.isConstructor(function(){})
   &amp;&amp; !Reflect.isConstructor(_ =&gt; _)
   &amp;&amp; Reflect.isConstructor(class {});
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("205");try{return Function("asyncTestPassed","\nreturn Reflect.isConstructor(function(){})\n  && !Reflect.isConstructor(_ => _)\n  && Reflect.isConstructor(class {});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("205");return Function("asyncTestPassed","'use strict';"+"\nreturn Reflect.isConstructor(function(){})\n  && !Reflect.isConstructor(_ => _)\n  && Reflect.isConstructor(class {});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("206");try{return Function("asyncTestPassed","\nreturn Reflect.isConstructor(function(){})\n  && !Reflect.isConstructor(_ => _)\n  && Reflect.isConstructor(class {});\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("206");return Function("asyncTestPassed","'use strict';"+"\nreturn Reflect.isConstructor(function(){})\n  && !Reflect.isConstructor(_ => _)\n  && Reflect.isConstructor(class {});\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -24812,7 +24934,7 @@ return Reflect.isConstructor(function(){})
 </tr>
 <tr class="subtest" data-parent="zones" id="test-zones_Zone"><td><span><a class="anchor" href="#test-zones_Zone">&#xA7;</a>Zone</span><script data-source="
 return typeof Zone === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("207");try{return Function("asyncTestPassed","\nreturn typeof Zone === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("207");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("208");try{return Function("asyncTestPassed","\nreturn typeof Zone === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("208");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -24928,7 +25050,7 @@ return typeof Zone === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="zones" id="test-zones_Zone.current"><td><span><a class="anchor" href="#test-zones_Zone.current">&#xA7;</a>Zone.current</span><script data-source="
 return &apos;current&apos; in Zone;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("208");try{return Function("asyncTestPassed","\nreturn 'current' in Zone;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("208");return Function("asyncTestPassed","'use strict';"+"\nreturn 'current' in Zone;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("209");try{return Function("asyncTestPassed","\nreturn 'current' in Zone;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("209");return Function("asyncTestPassed","'use strict';"+"\nreturn 'current' in Zone;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -25044,7 +25166,7 @@ return &apos;current&apos; in Zone;
 </tr>
 <tr class="subtest" data-parent="zones" id="test-zones_Zone.prototype.name"><td><span><a class="anchor" href="#test-zones_Zone.prototype.name">&#xA7;</a>Zone.prototype.name</span><script data-source="
 return &apos;name&apos; in Zone.prototype;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("209");try{return Function("asyncTestPassed","\nreturn 'name' in Zone.prototype;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("209");return Function("asyncTestPassed","'use strict';"+"\nreturn 'name' in Zone.prototype;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("210");try{return Function("asyncTestPassed","\nreturn 'name' in Zone.prototype;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("210");return Function("asyncTestPassed","'use strict';"+"\nreturn 'name' in Zone.prototype;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -25160,7 +25282,7 @@ return &apos;name&apos; in Zone.prototype;
 </tr>
 <tr class="subtest" data-parent="zones" id="test-zones_Zone.prototype.parent"><td><span><a class="anchor" href="#test-zones_Zone.prototype.parent">&#xA7;</a>Zone.prototype.parent</span><script data-source="
 return &apos;parent&apos; in Zone.prototype;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("210");try{return Function("asyncTestPassed","\nreturn 'parent' in Zone.prototype;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("210");return Function("asyncTestPassed","'use strict';"+"\nreturn 'parent' in Zone.prototype;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("211");try{return Function("asyncTestPassed","\nreturn 'parent' in Zone.prototype;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("211");return Function("asyncTestPassed","'use strict';"+"\nreturn 'parent' in Zone.prototype;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -25276,7 +25398,7 @@ return &apos;parent&apos; in Zone.prototype;
 </tr>
 <tr class="subtest" data-parent="zones" id="test-zones_Zone.prototype.fork"><td><span><a class="anchor" href="#test-zones_Zone.prototype.fork">&#xA7;</a>Zone.prototype.fork</span><script data-source="
 return typeof Zone.prototype.fork === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("211");try{return Function("asyncTestPassed","\nreturn typeof Zone.prototype.fork === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("211");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone.prototype.fork === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("212");try{return Function("asyncTestPassed","\nreturn typeof Zone.prototype.fork === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("212");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone.prototype.fork === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -25392,7 +25514,7 @@ return typeof Zone.prototype.fork === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="zones" id="test-zones_Zone.prototype.run"><td><span><a class="anchor" href="#test-zones_Zone.prototype.run">&#xA7;</a>Zone.prototype.run</span><script data-source="
 return typeof Zone.prototype.run === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("212");try{return Function("asyncTestPassed","\nreturn typeof Zone.prototype.run === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("212");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone.prototype.run === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("213");try{return Function("asyncTestPassed","\nreturn typeof Zone.prototype.run === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("213");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone.prototype.run === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -25508,7 +25630,7 @@ return typeof Zone.prototype.run === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="zones" id="test-zones_Zone.prototype.wrap"><td><span><a class="anchor" href="#test-zones_Zone.prototype.wrap">&#xA7;</a>Zone.prototype.wrap</span><script data-source="
 return typeof Zone.prototype.wrap === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("213");try{return Function("asyncTestPassed","\nreturn typeof Zone.prototype.wrap === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("213");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone.prototype.wrap === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("214");try{return Function("asyncTestPassed","\nreturn typeof Zone.prototype.wrap === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("214");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Zone.prototype.wrap === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -25743,7 +25865,7 @@ return (function f(n){
   }
   return continue f(n - 1);
 }(1e6)) === &quot;foo&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("215");try{return Function("asyncTestPassed","\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue f(n - 1);\n}(1e6)) === \"foo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("215");return Function("asyncTestPassed","'use strict';"+"\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue f(n - 1);\n}(1e6)) === \"foo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("216");try{return Function("asyncTestPassed","\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue f(n - 1);\n}(1e6)) === \"foo\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("216");return Function("asyncTestPassed","'use strict';"+"\n\"use strict\";\nreturn (function f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue f(n - 1);\n}(1e6)) === \"foo\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -25872,7 +25994,7 @@ function g(n){
   return continue f(n - 1);
 }
 return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("216");try{return Function("asyncTestPassed","\n\"use strict\";\nfunction f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue g(n - 1);\n}\nfunction g(n){\n  if (n <= 0) {\n    return  \"bar\";\n  }\n  return continue f(n - 1);\n}\nreturn f(1e6) === \"foo\" && f(1e6+1) === \"bar\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("216");return Function("asyncTestPassed","'use strict';"+"\n\"use strict\";\nfunction f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue g(n - 1);\n}\nfunction g(n){\n  if (n <= 0) {\n    return  \"bar\";\n  }\n  return continue f(n - 1);\n}\nreturn f(1e6) === \"foo\" && f(1e6+1) === \"bar\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("217");try{return Function("asyncTestPassed","\n\"use strict\";\nfunction f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue g(n - 1);\n}\nfunction g(n){\n  if (n <= 0) {\n    return  \"bar\";\n  }\n  return continue f(n - 1);\n}\nreturn f(1e6) === \"foo\" && f(1e6+1) === \"bar\";\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("217");return Function("asyncTestPassed","'use strict';"+"\n\"use strict\";\nfunction f(n){\n  if (n <= 0) {\n    return  \"foo\";\n  }\n  return continue g(n - 1);\n}\nfunction g(n){\n  if (n <= 0) {\n    return  \"bar\";\n  }\n  return continue f(n - 1);\n}\nreturn f(1e6) === \"foo\" && f(1e6+1) === \"bar\";\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -26103,7 +26225,7 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 var foo = { bar: 42, baz: 33 };
 var fuz = { foo.bar, foo[&apos;baz&apos;] };
 return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("218");try{return Function("asyncTestPassed","\nvar foo = { bar: 42, baz: 33 };\nvar fuz = { foo.bar, foo['baz'] };\nreturn fuz.bar === 42 && fuz.baz === 33;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("218");return Function("asyncTestPassed","'use strict';"+"\nvar foo = { bar: 42, baz: 33 };\nvar fuz = { foo.bar, foo['baz'] };\nreturn fuz.bar === 42 && fuz.baz === 33;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("219");try{return Function("asyncTestPassed","\nvar foo = { bar: 42, baz: 33 };\nvar fuz = { foo.bar, foo['baz'] };\nreturn fuz.bar === 42 && fuz.baz === 33;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("219");return Function("asyncTestPassed","'use strict';"+"\nvar foo = { bar: 42, baz: 33 };\nvar fuz = { foo.bar, foo['baz'] };\nreturn fuz.bar === 42 && fuz.baz === 33;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -26222,7 +26344,7 @@ var foo = { bar: 42, baz: 33 };
 var fuz = {};
 ({ fuz.bar, fuz[&apos;baz&apos;] } = foo);
 return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("219");try{return Function("asyncTestPassed","\nvar foo = { bar: 42, baz: 33 };\nvar fuz = {};\n({ fuz.bar, fuz['baz'] } = foo);\nreturn fuz.bar === 42 && fuz.baz === 33;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("219");return Function("asyncTestPassed","'use strict';"+"\nvar foo = { bar: 42, baz: 33 };\nvar fuz = {};\n({ fuz.bar, fuz['baz'] } = foo);\nreturn fuz.bar === 42 && fuz.baz === 33;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("220");try{return Function("asyncTestPassed","\nvar foo = { bar: 42, baz: 33 };\nvar fuz = {};\n({ fuz.bar, fuz['baz'] } = foo);\nreturn fuz.bar === 42 && fuz.baz === 33;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("220");return Function("asyncTestPassed","'use strict';"+"\nvar foo = { bar: 42, baz: 33 };\nvar fuz = {};\n({ fuz.bar, fuz['baz'] } = foo);\nreturn fuz.bar === 42 && fuz.baz === 33;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -26453,7 +26575,7 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.defineMetadata"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.defineMetadata">&#xA7;</a>Reflect.defineMetadata</span><script data-source="
 return typeof Reflect.defineMetadata === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("221");try{return Function("asyncTestPassed","\nreturn typeof Reflect.defineMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("221");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.defineMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("222");try{return Function("asyncTestPassed","\nreturn typeof Reflect.defineMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("222");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.defineMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -26569,7 +26691,7 @@ return typeof Reflect.defineMetadata === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.hasMetadata"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.hasMetadata">&#xA7;</a>Reflect.hasMetadata</span><script data-source="
 return typeof Reflect.hasMetadata === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("222");try{return Function("asyncTestPassed","\nreturn typeof Reflect.hasMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("222");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.hasMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("223");try{return Function("asyncTestPassed","\nreturn typeof Reflect.hasMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("223");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.hasMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -26685,7 +26807,7 @@ return typeof Reflect.hasMetadata === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.hasOwnMetadata"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.hasOwnMetadata">&#xA7;</a>Reflect.hasOwnMetadata</span><script data-source="
 return typeof Reflect.hasOwnMetadata === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("223");try{return Function("asyncTestPassed","\nreturn typeof Reflect.hasOwnMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("223");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.hasOwnMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("224");try{return Function("asyncTestPassed","\nreturn typeof Reflect.hasOwnMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("224");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.hasOwnMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -26801,7 +26923,7 @@ return typeof Reflect.hasOwnMetadata === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.getMetadata"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.getMetadata">&#xA7;</a>Reflect.getMetadata</span><script data-source="
 return typeof Reflect.getMetadata === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("224");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("224");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("225");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("225");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -26917,7 +27039,7 @@ return typeof Reflect.getMetadata === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.getOwnMetadata"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.getOwnMetadata">&#xA7;</a>Reflect.getOwnMetadata</span><script data-source="
 return typeof Reflect.getOwnMetadata === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("225");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getOwnMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("225");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getOwnMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("226");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getOwnMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("226");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getOwnMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -27033,7 +27155,7 @@ return typeof Reflect.getOwnMetadata === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.getMetadataKeys"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.getMetadataKeys">&#xA7;</a>Reflect.getMetadataKeys</span><script data-source="
 return typeof Reflect.getMetadataKeys === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("226");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getMetadataKeys === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("226");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getMetadataKeys === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("227");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getMetadataKeys === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("227");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getMetadataKeys === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -27149,7 +27271,7 @@ return typeof Reflect.getMetadataKeys === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.getOwnMetadataKeys"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.getOwnMetadataKeys">&#xA7;</a>Reflect.getOwnMetadataKeys</span><script data-source="
 return typeof Reflect.getOwnMetadataKeys === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("227");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getOwnMetadataKeys === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("227");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getOwnMetadataKeys === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("228");try{return Function("asyncTestPassed","\nreturn typeof Reflect.getOwnMetadataKeys === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("228");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.getOwnMetadataKeys === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -27265,7 +27387,7 @@ return typeof Reflect.getOwnMetadataKeys === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.deleteMetadata"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.deleteMetadata">&#xA7;</a>Reflect.deleteMetadata</span><script data-source="
 return typeof Reflect.deleteMetadata === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("228");try{return Function("asyncTestPassed","\nreturn typeof Reflect.deleteMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("228");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.deleteMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("229");try{return Function("asyncTestPassed","\nreturn typeof Reflect.deleteMetadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("229");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.deleteMetadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>
@@ -27381,7 +27503,7 @@ return typeof Reflect.deleteMetadata === &apos;function&apos;;
 </tr>
 <tr class="subtest" data-parent="Metadata_reflection_API" id="test-Metadata_reflection_API_Reflect.metadata"><td><span><a class="anchor" href="#test-Metadata_reflection_API_Reflect.metadata">&#xA7;</a>Reflect.metadata</span><script data-source="
 return typeof Reflect.metadata === &apos;function&apos;;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("229");try{return Function("asyncTestPassed","\nreturn typeof Reflect.metadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("229");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.metadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("230");try{return Function("asyncTestPassed","\nreturn typeof Reflect.metadata === 'function';\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("230");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Reflect.metadata === 'function';\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete not-applicable" data-browser="tr" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[13]</sup></a></td>


### PR DESCRIPTION
Recently `proposal-class-fields` has enabled optional chain support. Created a new subtest for private properties since it is only fixed in V8 8.4.

`preset-env` will use this data to transform `?. PrivateIdentifier` on Chrome 80 - 83, where both optional chaining and private properties are supported.

Tracking bugs
- [V8](https://bugs.chromium.org/p/v8/issues/detail?id=10371)
- TypeScript: TODO
- [Babel](https://github.com/babel/babel/pull/11248)