### PR TITLE
Use == instead of === in three tests - broke several engines.

### DIFF
--- a/data-es6.js
+++ b/data-es6.js
@@ -17621,7 +17621,7 @@ exports.tests = [
 
         return typeof symbolObject === "object" &&
           symbolObject instanceof Symbol &&
-          symbolObject === symbol &&
+          symbolObject == symbol && // eslint-disable-line eqeqeq
           symbolObject !== symbol &&
           symbolObject.valueOf() === symbol;
       */},
@@ -18386,7 +18386,7 @@ exports.tests = [
 
         a >= 0;
         b in {};
-        c === 0;
+        c == 0; // eslint-disable-line eqeqeq
         return passed === 3;
       */},
       res: {
@@ -21206,7 +21206,7 @@ exports.tests = [
         var c = new C(true);
         return c instanceof Boolean
           && c instanceof C
-          && c === true;
+          && c == true; // eslint-disable-line eqeqeq
       */},
       res: {
         safari10: true,


### PR DESCRIPTION
This is a partial revert of @ljharb changes in https://github.com/kangax/compat-table/commit/5a9fa240e09beb8cc35f1c9e33d7c530e8a20931

While overall beneficial, it seems that using the identity operator actually breaks those three tests. We have looked into the spec and seems that all three should not pass with the identity operator in place. There might be a better way to fix this, but in the current state, those tests fail on several engines (tested on our own GraalVM 20.0, but also on FF 45, Chrome 80, Node 12.x). I thus suggest to just undo the changes for the moment.