### PR TITLE
String.prototype.replaceAll is shipped in Firefox 77

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -2343,6 +2343,7 @@ exports.tests = [
       firefox52: false,
       firefox71: false,
       firefox72: firefox.nightly,
+      firefox77: true,
       chrome77: false,
       chrome80: chrome.stringPrototypeReplaceAll,
       safari13_1: true,

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -2672,7 +2672,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no flagged" data-browser="firefox74">Flag<a href="#firefox-nightly-note"><sup>[12]</sup></a></td>
 <td class="no flagged" data-browser="firefox75">Flag<a href="#firefox-nightly-note"><sup>[12]</sup></a></td>
 <td class="no flagged unstable" data-browser="firefox76">Flag<a href="#firefox-nightly-note"><sup>[12]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox77">Flag<a href="#firefox-nightly-note"><sup>[12]</sup></a></td>
+<td class="yes unstable" data-browser="firefox77">Yes</td>
 <td class="unknown obsolete" data-browser="opera12_10">?</td>
 <td class="unknown obsolete" data-browser="chrome74">?</td>
 <td class="unknown obsolete" data-browser="chrome75">?</td>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1608168#c8