### PR TITLE
TypeScript 3.9 released

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -481,7 +481,7 @@
     "family": "TypeScript",
     "platformtype": "compiler",
     "release": "2018-11-29",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -494,7 +494,7 @@
     "family": "TypeScript",
     "platformtype": "compiler",
     "release": "2019-01-31",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -506,7 +506,7 @@
     "short": "Type-<br />Script +<br /><nobr>core-js 3</nobr>",
     "family": "TypeScript",
     "platformtype": "compiler",
-    "release": "2019-03-29",
+    "obsolete": "very",
     "obsolete": true,
     "test_suites": [
       "es6",
@@ -546,6 +546,32 @@
     "family": "TypeScript",
     "platformtype": "compiler",
     "release": "2019-10-05",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "typescript3_8corejs3": {
+    "full": "TypeScript 3.8 + core-js 3",
+    "short": "Type-<br />Script +<br /><nobr>core-js 3</nobr>",
+    "family": "TypeScript",
+    "platformtype": "compiler",
+    "release": "2019-02-20",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "typescript3_9corejs3": {
+    "full": "TypeScript 3.9 + core-js 3",
+    "short": "Type-<br />Script +<br /><nobr>core-js 3</nobr>",
+    "family": "TypeScript",
+    "platformtype": "compiler",
+    "release": "2020-05-12",
     "obsolete": false,
     "test_suites": [
       "es6",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -139,12 +139,12 @@
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_9corejs2 compiler obsolete" data-browser="typescript2_9corejs2"><a href="#typescript2_9corejs2" class="browser-name"><abbr title="TypeScript 2.9 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript3_2corejs2 compiler obsolete" data-browser="typescript3_2corejs2"><a href="#typescript3_2corejs2" class="browser-name"><abbr title="TypeScript 3.2 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
-<th class="platform typescript3_2corejs3 compiler obsolete" data-browser="typescript3_2corejs3"><a href="#typescript3_2corejs3" class="browser-name"><abbr title="TypeScript 3.2 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
-<th class="platform typescript3_3corejs3 compiler obsolete" data-browser="typescript3_3corejs3"><a href="#typescript3_3corejs3" class="browser-name"><abbr title="TypeScript 3.3 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform typescript3_4corejs3 compiler obsolete" data-browser="typescript3_4corejs3"><a href="#typescript3_4corejs3" class="browser-name"><abbr title="TypeScript 3.4 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform typescript3_5corejs3 compiler obsolete" data-browser="typescript3_5corejs3"><a href="#typescript3_5corejs3" class="browser-name"><abbr title="TypeScript 3.5 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform typescript3_6corejs3 compiler obsolete" data-browser="typescript3_6corejs3"><a href="#typescript3_6corejs3" class="browser-name"><abbr title="TypeScript 3.6 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
-<th class="platform typescript3_7corejs3 compiler" data-browser="typescript3_7corejs3"><a href="#typescript3_7corejs3" class="browser-name"><abbr title="TypeScript 3.7 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
+<th class="platform typescript3_7corejs3 compiler obsolete" data-browser="typescript3_7corejs3"><a href="#typescript3_7corejs3" class="browser-name"><abbr title="TypeScript 3.7 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
+<th class="platform typescript3_8corejs3 compiler obsolete" data-browser="typescript3_8corejs3"><a href="#typescript3_8corejs3" class="browser-name"><abbr title="TypeScript 3.8 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
+<th class="platform typescript3_9corejs3 compiler" data-browser="typescript3_9corejs3"><a href="#typescript3_9corejs3" class="browser-name"><abbr title="TypeScript 3.9 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform es7shim compiler" data-browser="es7shim"><a href="#es7shim" class="browser-name"><abbr title="es7-shim">es7-shim</abbr></a></th>
 <th class="platform ie11 desktop" data-browser="ie11"><a href="#ie11" class="browser-name"><abbr title="Internet Explorer 11">IE 11</abbr></a></th>
 <th class="platform firefox60 desktop obsolete" data-browser="firefox60"><a href="#firefox60" class="browser-name"><abbr title="Firefox 60 Extended Support Release">FF 60 ESR</abbr></a></th>
@@ -262,12 +262,12 @@
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="1">3/3</td>
@@ -382,12 +382,12 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -502,12 +502,12 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -627,12 +627,12 @@ return true;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -744,12 +744,12 @@ return true;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">3/3</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">3/3</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="1">3/3</td>
@@ -868,12 +868,12 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -1010,12 +1010,12 @@ return 24;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -1135,12 +1135,12 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -1264,12 +1264,12 @@ return true;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -1397,12 +1397,12 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -1522,12 +1522,12 @@ return true;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -1643,12 +1643,12 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -1765,12 +1765,12 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -1892,12 +1892,12 @@ return passed;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -2021,12 +2021,12 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -2140,12 +2140,12 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">4/4</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">4/4</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">4/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="1">4/4</td>
@@ -2263,12 +2263,12 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -2390,12 +2390,12 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -2518,12 +2518,12 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -2641,12 +2641,12 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -2758,12 +2758,12 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="1">2/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="1">2/2</td>
@@ -2883,12 +2883,12 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -3008,12 +3008,12 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -3125,12 +3125,12 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="1">2/2</td>
@@ -3245,12 +3245,12 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -3365,12 +3365,12 @@ return Math.min(1,2,3,) === 1;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -3482,12 +3482,12 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="1">16/16</td>
@@ -3613,12 +3613,12 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -3744,12 +3744,12 @@ p.catch(function(result) {
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -3865,12 +3865,12 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -3986,12 +3986,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
-<td class="no obsolete" data-browser="typescript3_2corejs3">No</td>
-<td class="no obsolete" data-browser="typescript3_3corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_4corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_5corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_6corejs3">No</td>
-<td class="no" data-browser="typescript3_7corejs3">No</td>
+<td class="no obsolete" data-browser="typescript3_7corejs3">No</td>
+<td class="no obsolete" data-browser="typescript3_8corejs3">No</td>
+<td class="no" data-browser="typescript3_9corejs3">No</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -4113,12 +4113,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -4242,12 +4242,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -4363,12 +4363,12 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -4489,12 +4489,12 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -4610,12 +4610,12 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -4741,12 +4741,12 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -4872,12 +4872,12 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -5003,12 +5003,12 @@ var p = new C().a();
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -5132,12 +5132,12 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -5254,12 +5254,12 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
-<td class="no obsolete" data-browser="typescript3_2corejs3">No</td>
-<td class="no obsolete" data-browser="typescript3_3corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_4corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_5corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_6corejs3">No</td>
-<td class="no" data-browser="typescript3_7corejs3">No</td>
+<td class="no obsolete" data-browser="typescript3_7corejs3">No</td>
+<td class="no obsolete" data-browser="typescript3_8corejs3">No</td>
+<td class="no" data-browser="typescript3_9corejs3">No</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -5374,12 +5374,12 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
-<td class="no obsolete" data-browser="typescript3_2corejs3">No</td>
-<td class="no obsolete" data-browser="typescript3_3corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_4corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_5corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_6corejs3">No</td>
-<td class="no" data-browser="typescript3_7corejs3">No</td>
+<td class="no obsolete" data-browser="typescript3_7corejs3">No</td>
+<td class="no obsolete" data-browser="typescript3_8corejs3">No</td>
+<td class="no" data-browser="typescript3_9corejs3">No</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -5503,12 +5503,12 @@ p.then(function(result) {
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
-<td class="no obsolete" data-browser="typescript3_2corejs3">No</td>
-<td class="no obsolete" data-browser="typescript3_3corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_4corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_5corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_6corejs3">No</td>
-<td class="no" data-browser="typescript3_7corejs3">No</td>
+<td class="no obsolete" data-browser="typescript3_7corejs3">No</td>
+<td class="no obsolete" data-browser="typescript3_8corejs3">No</td>
+<td class="no" data-browser="typescript3_9corejs3">No</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -5620,12 +5620,12 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/17</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0">0/17</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0">0/17</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/17</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0" data-flagged-tally="1">0/17</td>
@@ -5740,12 +5740,12 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -5860,12 +5860,12 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -5980,12 +5980,12 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -6100,12 +6100,12 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -6220,12 +6220,12 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -6340,12 +6340,12 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -6460,12 +6460,12 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -6580,12 +6580,12 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -6700,12 +6700,12 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -6820,12 +6820,12 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -6940,12 +6940,12 @@ return typeof Atomics.wake === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -7060,12 +7060,12 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -7180,12 +7180,12 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -7300,12 +7300,12 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -7420,12 +7420,12 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -7540,12 +7540,12 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -7660,12 +7660,12 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#fx-shared-memory-spectre-note"><sup>[15]</sup></a></td>
@@ -7785,12 +7785,12 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -7908,12 +7908,12 @@ return (function(){
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -8027,12 +8027,12 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
-<td class="tally not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally" data-browser="ie11" data-tally="0.5" style="background-color:hsl(60,64%,50%)">8/16</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="1">16/16</td>
@@ -8152,12 +8152,12 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -8278,12 +8278,12 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -8404,12 +8404,12 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -8529,12 +8529,12 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -8655,12 +8655,12 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -8781,12 +8781,12 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -8908,12 +8908,12 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -9035,12 +9035,12 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -9163,12 +9163,12 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -9288,12 +9288,12 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -9412,12 +9412,12 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -9539,12 +9539,12 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -9666,12 +9666,12 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -9794,12 +9794,12 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -9919,12 +9919,12 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -10043,12 +10043,12 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -10160,12 +10160,12 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="1">4/4</td>
@@ -10284,12 +10284,12 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -10408,12 +10408,12 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -10537,12 +10537,12 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -10666,12 +10666,12 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -10787,12 +10787,12 @@ return i === 0;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="es7shim" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -10906,12 +10906,12 @@ return i === 0;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="1">2/2</td>
@@ -11027,12 +11027,12 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -11149,12 +11149,12 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -11266,12 +11266,12 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">3/3</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">3/3</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="1">3/3</td>
@@ -11412,12 +11412,12 @@ function check() {
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -11550,12 +11550,12 @@ function check() {
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -11690,12 +11690,12 @@ function check() {
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -11811,12 +11811,12 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -11938,12 +11938,12 @@ return result.groups.year === &apos;2016&apos;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -12059,12 +12059,12 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -12180,12 +12180,12 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -12297,12 +12297,12 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="1">2/2</td>
@@ -12424,12 +12424,12 @@ iterator.next().then(function(step){
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -12561,12 +12561,12 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -12693,12 +12693,12 @@ return false;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -12820,12 +12820,12 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -12943,12 +12943,12 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -13060,12 +13060,12 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">4/4</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">4/4</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">4/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0.5" style="background-color:hsl(60,64%,50%)" data-flagged-tally="1">2/4</td>
@@ -13180,12 +13180,12 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -13300,12 +13300,12 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes" data-browser="es7shim">Yes</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -13420,12 +13420,12 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[16]</sup></a></td>
@@ -13540,12 +13540,12 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[16]</sup></a></td>
@@ -13657,12 +13657,12 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">3/3</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">3/3</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0" data-flagged-tally="0.3333333333333333">0/3</td>
@@ -13777,12 +13777,12 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No<a href="#ffox-flatten-note"><sup>[30]</sup></a></td>
@@ -13899,12 +13899,12 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#firefox-nightly-note"><sup>[16]</sup></a></td>
@@ -14020,12 +14020,12 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -14139,12 +14139,12 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">3/3</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">3/3</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="1">3/3</td>
@@ -14265,12 +14265,12 @@ return false;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -14392,12 +14392,12 @@ return false;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -14523,12 +14523,12 @@ return it.throw().value;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -14640,12 +14640,12 @@ return it.throw().value;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">3/3</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">3/3</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">3/3</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/3</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/3</td>
@@ -14760,12 +14760,12 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -14880,12 +14880,12 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -15001,12 +15001,12 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -15118,12 +15118,12 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/7</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0">0/7</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0">0/7</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/7</td>
 <td class="tally" data-browser="ie11" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="1">7/7</td>
@@ -15240,12 +15240,12 @@ return fn + &apos;&apos; === str;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -15361,12 +15361,12 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -15482,12 +15482,12 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="yes" data-browser="ie11">Yes</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -15603,12 +15603,12 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -15724,12 +15724,12 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -15845,12 +15845,12 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -15966,12 +15966,12 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
@@ -16083,12 +16083,12 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/2</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0">0/2</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0">0/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/2</td>
@@ -16203,12 +16203,12 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -16323,12 +16323,12 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -16444,12 +16444,12 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -16563,12 +16563,12 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/2</td>
@@ -16693,12 +16693,12 @@ return a === &apos;1a2b&apos;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -16818,12 +16818,12 @@ try {
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -16935,12 +16935,12 @@ try {
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/8</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0">0/8</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0">0/8</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/8</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/8</td>
@@ -17055,12 +17055,12 @@ return (1n + 2n) === 3n;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -17175,12 +17175,12 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -17295,12 +17295,12 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -17415,12 +17415,12 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -17538,12 +17538,12 @@ return view[0] === -0x8000000000000000n;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -17661,12 +17661,12 @@ return view[0] === 0n;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -17784,12 +17784,12 @@ return view.getBigInt64(0) === 1n;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -17907,12 +17907,12 @@ return view.getBigUint64(0) === 1n;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -18038,12 +18038,12 @@ Promise.allSettled([
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="unknown" data-browser="ie11">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -18155,12 +18155,12 @@ Promise.allSettled([
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">2/2</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/2</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/2</td>
@@ -18277,12 +18277,12 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -18403,12 +18403,12 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -18520,12 +18520,12 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/4</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">4/4</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">4/4</td>
 <td class="tally" data-browser="es7shim" data-tally="0">0/4</td>
 <td class="tally" data-browser="ie11" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/4</td>
@@ -18642,12 +18642,12 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -18764,12 +18764,12 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -18886,12 +18886,12 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -19010,12 +19010,12 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
@@ -19135,12 +19135,12 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -145,12 +145,12 @@
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_9corejs2 compiler obsolete" data-browser="typescript2_9corejs2"><a href="#typescript2_9corejs2" class="browser-name"><abbr title="TypeScript 2.9 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript3_2corejs2 compiler obsolete" data-browser="typescript3_2corejs2"><a href="#typescript3_2corejs2" class="browser-name"><abbr title="TypeScript 3.2 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
-<th class="platform typescript3_2corejs3 compiler obsolete" data-browser="typescript3_2corejs3"><a href="#typescript3_2corejs3" class="browser-name"><abbr title="TypeScript 3.2 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
-<th class="platform typescript3_3corejs3 compiler obsolete" data-browser="typescript3_3corejs3"><a href="#typescript3_3corejs3" class="browser-name"><abbr title="TypeScript 3.3 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform typescript3_4corejs3 compiler obsolete" data-browser="typescript3_4corejs3"><a href="#typescript3_4corejs3" class="browser-name"><abbr title="TypeScript 3.4 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform typescript3_5corejs3 compiler obsolete" data-browser="typescript3_5corejs3"><a href="#typescript3_5corejs3" class="browser-name"><abbr title="TypeScript 3.5 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform typescript3_6corejs3 compiler obsolete" data-browser="typescript3_6corejs3"><a href="#typescript3_6corejs3" class="browser-name"><abbr title="TypeScript 3.6 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
-<th class="platform typescript3_7corejs3 compiler" data-browser="typescript3_7corejs3"><a href="#typescript3_7corejs3" class="browser-name"><abbr title="TypeScript 3.7 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
+<th class="platform typescript3_7corejs3 compiler obsolete" data-browser="typescript3_7corejs3"><a href="#typescript3_7corejs3" class="browser-name"><abbr title="TypeScript 3.7 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
+<th class="platform typescript3_8corejs3 compiler obsolete" data-browser="typescript3_8corejs3"><a href="#typescript3_8corejs3" class="browser-name"><abbr title="TypeScript 3.8 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
+<th class="platform typescript3_9corejs3 compiler" data-browser="typescript3_9corejs3"><a href="#typescript3_9corejs3" class="browser-name"><abbr title="TypeScript 3.9 + core-js 3">Type-<br>Script +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform firefox60 desktop obsolete" data-browser="firefox60"><a href="#firefox60" class="browser-name"><abbr title="Firefox 60 Extended Support Release">FF 60 ESR</abbr></a></th>
 <th class="platform firefox67 desktop obsolete" data-browser="firefox67"><a href="#firefox67" class="browser-name"><abbr title="Firefox 67">FF 67</abbr></a></th>
 <th class="platform firefox68 desktop" data-browser="firefox68"><a href="#firefox68" class="browser-name"><abbr title="Firefox 68 Extended Support Release">FF 68 ESR</abbr></a></th>
@@ -266,12 +266,12 @@
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/2</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0">0/2</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/2</td>
@@ -386,12 +386,12 @@ return weakref.deref() === O;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -505,12 +505,12 @@ return Object.getPrototypeOf(fg) === FinalizationGroup.prototype;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -620,12 +620,12 @@ return Object.getPrototypeOf(fg) === FinalizationGroup.prototype;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0" data-flagged-tally="0.16666666666666666">0/6</td>
 <td class="tally" data-browser="firefox68" data-tally="0" data-flagged-tally="0.3333333333333333">0/6</td>
@@ -741,12 +741,12 @@ return new C().x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no flagged obsolete" data-browser="firefox67">Flag<a href="#firefox-class-fields-note"><sup>[7]</sup></a></td>
 <td class="no flagged" data-browser="firefox68">Flag<a href="#firefox-class-fields-note"><sup>[7]</sup></a></td>
@@ -868,12 +868,12 @@ return new C(42).x() === 42;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No<a href="#firefox-private-class-fields-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="firefox68">No<a href="#firefox-private-class-fields-note"><sup>[10]</sup></a></td>
@@ -992,12 +992,12 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No<a href="#firefox-private-class-fields-note"><sup>[10]</sup></a></td>
 <td class="no" data-browser="firefox68">No<a href="#firefox-private-class-fields-note"><sup>[10]</sup></a></td>
@@ -1116,12 +1116,12 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="no obsolete" data-browser="typescript3_8corejs3">No</td>
+<td class="no" data-browser="typescript3_9corejs3">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -1240,12 +1240,12 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="no obsolete" data-browser="typescript3_8corejs3">No</td>
+<td class="no" data-browser="typescript3_9corejs3">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -1361,12 +1361,12 @@ return new C().x === 42;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no flagged" data-browser="firefox68">Flag<a href="#firefox-class-fields-note"><sup>[7]</sup></a></td>
@@ -1476,12 +1476,12 @@ return new C().x === 42;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/3</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/3</td>
@@ -1597,12 +1597,12 @@ return C.x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -1721,12 +1721,12 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -1842,12 +1842,12 @@ return C.x === 42;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -1957,12 +1957,12 @@ return C.x === 42;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/4</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0">0/4</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/4</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/4</td>
@@ -2081,12 +2081,12 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown obsolete" data-browser="firefox60">?</td>
 <td class="unknown obsolete" data-browser="firefox67">?</td>
 <td class="unknown" data-browser="firefox68">?</td>
@@ -2205,12 +2205,12 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown obsolete" data-browser="firefox60">?</td>
 <td class="unknown obsolete" data-browser="firefox67">?</td>
 <td class="unknown" data-browser="firefox68">?</td>
@@ -2332,12 +2332,12 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown obsolete" data-browser="firefox60">?</td>
 <td class="unknown obsolete" data-browser="firefox67">?</td>
 <td class="unknown" data-browser="firefox68">?</td>
@@ -2459,12 +2459,12 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="unknown obsolete" data-browser="firefox60">?</td>
 <td class="unknown obsolete" data-browser="firefox67">?</td>
 <td class="unknown" data-browser="firefox68">?</td>
@@ -2578,12 +2578,12 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no flagged" data-browser="firefox68">Flag<a href="#firefox-nightly-note"><sup>[12]</sup></a></td>
@@ -2696,12 +2696,12 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -2820,12 +2820,12 @@ Promise.any([
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -2935,12 +2935,12 @@ Promise.any([
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/2</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0">0/2</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="1">2/2</td>
 <td class="tally" data-browser="firefox68" data-tally="1">2/2</td>
@@ -3059,12 +3059,12 @@ return RegExp.lastMatch === 'x';
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox67">Yes</td>
 <td class="yes" data-browser="firefox68">Yes</td>
@@ -3185,12 +3185,12 @@ return true;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
 <td class="yes obsolete" data-browser="firefox67">Yes</td>
 <td class="yes" data-browser="firefox68">Yes</td>
@@ -3300,12 +3300,12 @@ return true;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/9</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0">0/9</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/9</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0">0/9</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0">0/9</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0">0/9</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/9</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/9</td>
@@ -3424,12 +3424,12 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -3545,12 +3545,12 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -3666,12 +3666,12 @@ return i === 1;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -3790,12 +3790,12 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -3911,12 +3911,12 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -4032,12 +4032,12 @@ return i === 1;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -4156,12 +4156,12 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -4277,12 +4277,12 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -4398,12 +4398,12 @@ return i === 1;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -4520,12 +4520,12 @@ try {
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="no obsolete" data-browser="typescript3_2corejs3">No</td>
-<td class="no obsolete" data-browser="typescript3_3corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_4corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_5corejs3">No</td>
 <td class="no obsolete" data-browser="typescript3_6corejs3">No</td>
-<td class="no" data-browser="typescript3_7corejs3">No</td>
+<td class="no obsolete" data-browser="typescript3_7corejs3">No</td>
+<td class="no obsolete" data-browser="typescript3_8corejs3">No</td>
+<td class="no" data-browser="typescript3_9corejs3">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="yes obsolete" data-browser="firefox67">Yes</td>
 <td class="yes" data-browser="firefox68">Yes</td>
@@ -4646,12 +4646,12 @@ return result === &apos;tromple&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -4761,12 +4761,12 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">1/1</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">1/1</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/1</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/1</td>
@@ -4887,12 +4887,12 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes</td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes</td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes</td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes</td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -5008,12 +5008,12 @@ return typeof Realm === &quot;function&quot;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -5123,12 +5123,12 @@ return typeof Realm === &quot;function&quot;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/4</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0">0/4</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/4</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/4</td>
@@ -5247,12 +5247,12 @@ try {
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -5375,12 +5375,12 @@ try {
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -5498,12 +5498,12 @@ try {
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -5621,12 +5621,12 @@ try {
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -5736,12 +5736,12 @@ try {
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">7/7</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">7/7</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/7</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/7</td>
@@ -5857,12 +5857,12 @@ return set.size === 2
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -5979,12 +5979,12 @@ return set.size === 3
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -6100,12 +6100,12 @@ return set.size === 2
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -6221,12 +6221,12 @@ return set.size === 2
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -6339,12 +6339,12 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -6457,12 +6457,12 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -6575,12 +6575,12 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -6690,12 +6690,12 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/2</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0">0/2</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/2</td>
@@ -6811,12 +6811,12 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -6932,12 +6932,12 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -7047,12 +7047,12 @@ return buffer1.byteLength === 0
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/2</td>
@@ -7168,12 +7168,12 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -7290,12 +7290,12 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -7409,12 +7409,12 @@ return !Array.isTemplateObject([])
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -7524,12 +7524,12 @@ return !Array.isTemplateObject([])
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">35/35</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">35/35</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">35/35</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">35/35</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">35/35</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">35/35</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">35/35</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">35/35</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">35/35</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/35</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/35</td>
@@ -7642,12 +7642,12 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -7762,12 +7762,12 @@ return instance[Symbol.iterator]() === instance;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -7883,12 +7883,12 @@ return &apos;next&apos; in iterator
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -8009,12 +8009,12 @@ return &apos;next&apos; in iterator
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -8127,12 +8127,12 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -8245,12 +8245,12 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -8363,12 +8363,12 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -8481,12 +8481,12 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -8599,12 +8599,12 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -8717,12 +8717,12 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -8837,12 +8837,12 @@ return result === &apos;123&apos;;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -8955,12 +8955,12 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -9073,12 +9073,12 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -9191,12 +9191,12 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -9309,12 +9309,12 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -9428,12 +9428,12 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -9546,12 +9546,12 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -9664,12 +9664,12 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -9784,12 +9784,12 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -9914,12 +9914,12 @@ toArray(iterator).then(it =&gt; {
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -10044,12 +10044,12 @@ toArray(iterator).then(it =&gt; {
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -10174,12 +10174,12 @@ toArray(iterator).then(it =&gt; {
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -10300,12 +10300,12 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -10426,12 +10426,12 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -10546,12 +10546,12 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -10672,12 +10672,12 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -10792,12 +10792,12 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -10918,12 +10918,12 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -11039,12 +11039,12 @@ let result = &apos;&apos;;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -11165,12 +11165,12 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -11285,12 +11285,12 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -11405,12 +11405,12 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -11531,12 +11531,12 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -11651,12 +11651,12 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -11769,12 +11769,12 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -11892,12 +11892,12 @@ return do {
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -12007,12 +12007,12 @@ return do {
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">7/7</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">7/7</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/7</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/7</td>
@@ -12125,12 +12125,12 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -12243,12 +12243,12 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -12361,12 +12361,12 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -12489,12 +12489,12 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -12608,12 +12608,12 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -12726,12 +12726,12 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -12844,12 +12844,12 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -12963,12 +12963,12 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -13085,12 +13085,12 @@ return Math.signbit(NaN) === false
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -13200,12 +13200,12 @@ return Math.signbit(NaN) === false
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">7/7</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">7/7</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/7</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/7</td>
@@ -13320,12 +13320,12 @@ return Math.clamp(2, 4, 6) === 4
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -13438,12 +13438,12 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -13557,12 +13557,12 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -13675,12 +13675,12 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -13793,12 +13793,12 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -13912,12 +13912,12 @@ return Math.radians(90) === Math.PI / 2
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -14030,12 +14030,12 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -14145,12 +14145,12 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">7/7</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">7/7</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/7</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/7</td>
@@ -14263,12 +14263,12 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -14381,12 +14381,12 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -14501,12 +14501,12 @@ return score === 1;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -14626,12 +14626,12 @@ Promise.try(function() {
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -14751,12 +14751,12 @@ Promise.try(function() {
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -14876,12 +14876,12 @@ Promise.try(function() {
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -15001,12 +15001,12 @@ Promise.try(function() {
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -15116,12 +15116,12 @@ Promise.try(function() {
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">8/8</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">8/8</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/8</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/8</td>
@@ -15237,12 +15237,12 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -15360,12 +15360,12 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -15481,12 +15481,12 @@ return C.has(A) + C.has(B);
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -15602,12 +15602,12 @@ return C.has(3) + C.has(4);
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -15723,12 +15723,12 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -15846,12 +15846,12 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -15967,12 +15967,12 @@ return C.has(A) + C.has(B);
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -16088,12 +16088,12 @@ return C.has(A) + C.has(B);
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -16218,12 +16218,12 @@ return result === &apos;Hello, hello!&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no flagged obsolete" data-browser="firefox60">Flag<a href="#ffox-pipeline-note"><sup>[22]</sup></a></td>
 <td class="no flagged obsolete" data-browser="firefox67">Flag<a href="#ffox-pipeline-note"><sup>[22]</sup></a></td>
 <td class="no flagged" data-browser="firefox68">Flag<a href="#ffox-pipeline-note"><sup>[22]</sup></a></td>
@@ -16340,12 +16340,12 @@ return 123i === &apos;string123number123&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -16455,12 +16455,12 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/12</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0">0/12</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/12</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/12</td>
@@ -16577,12 +16577,12 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -16699,12 +16699,12 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -16821,12 +16821,12 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -16943,12 +16943,12 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -17065,12 +17065,12 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -17187,12 +17187,12 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -17309,12 +17309,12 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -17434,12 +17434,12 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -17557,12 +17557,12 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -17679,12 +17679,12 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -17801,12 +17801,12 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -17923,12 +17923,12 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -18038,12 +18038,12 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/8</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0">0/8</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/8</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/8</td>
@@ -18156,12 +18156,12 @@ return Object.isFrozen({# foo: 42 #});
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -18274,12 +18274,12 @@ return Object.isFrozen([# 42 #]);
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -18392,12 +18392,12 @@ return Object.isSealed({| foo: 42 |});
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -18510,12 +18510,12 @@ return Object.isSealed([| 42 |]);
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -18636,12 +18636,12 @@ try {
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -18763,12 +18763,12 @@ try {
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -18889,12 +18889,12 @@ try {
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -19016,12 +19016,12 @@ try {
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -19139,12 +19139,12 @@ return results.length === 3
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -19254,12 +19254,12 @@ return results.length === 3
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">2/2</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">2/2</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/2</td>
@@ -19372,12 +19372,12 @@ return [1, 2, 3].lastItem === 3;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -19490,12 +19490,12 @@ return [1, 2, 3].lastIndex === 2;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -19605,12 +19605,12 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">26/26</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">26/26</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">26/26</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">26/26</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">26/26</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">26/26</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">26/26</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">26/26</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">26/26</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/26</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/26</td>
@@ -19728,12 +19728,12 @@ return map.size === 2
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -19849,12 +19849,12 @@ return map.size === 2
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -19971,12 +19971,12 @@ return map.size === 2
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -20089,12 +20089,12 @@ return new Map([[1, 4], [2, 5], [3, 6]]).every(it =&gt; typeof it === &apos;numb
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -20210,12 +20210,12 @@ return map.size === 2
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -20328,12 +20328,12 @@ return new Map([[1, 2], [2, 3], [3, 4]]).find(it =&gt; it % 2) === 3;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -20446,12 +20446,12 @@ return new Map([[1, 2], [2, 3], [3, 4]]).findKey(it =&gt; it % 2) === 2;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -20565,12 +20565,12 @@ return new Map([[1, 2], [2, NaN]]).includes(2)
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -20684,12 +20684,12 @@ return new Map([[1, 2], [2, NaN]]).keyOf(2) === 1
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -20806,12 +20806,12 @@ return map.size === 3
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -20928,12 +20928,12 @@ return map.size === 3
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -21050,12 +21050,12 @@ return map.size === 3
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -21168,12 +21168,12 @@ return new Map([[&apos;a&apos;, 1], [&apos;b&apos;, 2], [&apos;c&apos;, 3], ]).r
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -21286,12 +21286,12 @@ return new Map([[1, 4], [2, 5], [3, 6]]).some(it =&gt; it % 2);
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -21408,12 +21408,12 @@ return set.size === 3
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -21530,12 +21530,12 @@ return set.deleteAll(2, 3) === true
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -21648,12 +21648,12 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -21769,12 +21769,12 @@ return set.size === 2
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -21887,12 +21887,12 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -22005,12 +22005,12 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -22127,12 +22127,12 @@ return set.size === 3
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -22245,12 +22245,12 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -22363,12 +22363,12 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -22490,12 +22490,12 @@ return !map.has(a)
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -22617,12 +22617,12 @@ return set.has(a)
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -22744,12 +22744,12 @@ return !set.has(a)
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -22870,12 +22870,12 @@ return second === gen2.next().value;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -22985,12 +22985,12 @@ return second === gen2.next().value;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/2</td>
@@ -23103,12 +23103,12 @@ return Number.fromString(&apos;42&apos;) === 42;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -23221,12 +23221,12 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
-<td class="unknown obsolete" data-browser="typescript3_2corejs3">?</td>
-<td class="unknown obsolete" data-browser="typescript3_3corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_4corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_5corejs3">?</td>
 <td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
-<td class="unknown" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown" data-browser="typescript3_9corejs3">?</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
 <td class="no obsolete" data-browser="firefox67">No</td>
 <td class="no" data-browser="firefox68">No</td>
@@ -23336,12 +23336,12 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="typescript3_3corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_4corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_5corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="1">3/3</td>
-<td class="tally" data-browser="typescript3_7corejs3" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">3/3</td>
+<td class="tally" data-browser="typescript3_9corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="firefox60" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="firefox67" data-tally="0">0/3</td>
 <td class="tally" data-browser="firefox68" data-tally="0">0/3</td>
@@ -23458,12 +23458,12 @@ return [...iterator].join() === &apos;a,c&apos;;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="unknown obsolete" data-browser="firefox60">?</td>
 <td class="unknown obsolete" data-browser="firefox67">?</td>
 <td class="unknown" data-browser="firefox68">?</td>
@@ -23580,12 +23580,12 @@ return [...iterator].join() === &apos;1,3&apos;;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="unknown obsolete" data-browser="firefox60">?</td>
 <td class="unknown obsolete" data-browser="firefox67">?</td>
 <td class="unknown" data-browser="firefox68">?</td>
@@ -23702,12 +23702,12 @@ return [...iterator].join() === &apos;a,1,c,3&apos;;
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_2corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete" data-browser="typescript3_3corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_7corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete" data-browser="typescript3_8corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="unknown obsolete" data-browser="firefox60">?</td>
 <td class="unknown obsolete" data-browser="firefox67">?</td>
 <td class="unknown" data-browser="firefox68">?</td>
@@ -23819,12 +23819,12 @@ return [...iterator].join() === &apos;a,1,c,3&apos;;
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -23939,12 +23939,12 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24058,12 +24058,12 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24176,12 +24176,12 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24291,12 +24291,12 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -24410,12 +24410,12 @@ return f();
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24528,12 +24528,12 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24651,12 +24651,12 @@ return Array.isArray(arr)
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24780,12 +24780,12 @@ return target === C.prototype
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -24905,12 +24905,12 @@ return (@inverse function(it){
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -25020,12 +25020,12 @@ return (@inverse function(it){
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -25140,12 +25140,12 @@ return Reflect.isCallable(function(){})
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -25260,12 +25260,12 @@ return Reflect.isConstructor(function(){})
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -25375,12 +25375,12 @@ return Reflect.isConstructor(function(){})
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -25493,12 +25493,12 @@ return typeof Zone === &apos;function&apos;;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -25611,12 +25611,12 @@ return &apos;current&apos; in Zone;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -25729,12 +25729,12 @@ return &apos;name&apos; in Zone.prototype;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -25847,12 +25847,12 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -25965,12 +25965,12 @@ return typeof Zone.prototype.fork === &apos;function&apos;;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -26083,12 +26083,12 @@ return typeof Zone.prototype.run === &apos;function&apos;;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -26201,12 +26201,12 @@ return typeof Zone.prototype.wrap === &apos;function&apos;;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -26316,12 +26316,12 @@ return typeof Zone.prototype.wrap === &apos;function&apos;;
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -26440,12 +26440,12 @@ return (function f(n){
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -26571,12 +26571,12 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -26686,12 +26686,12 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -26806,12 +26806,12 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -26927,12 +26927,12 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -27044,12 +27044,12 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
-<td class="tally obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
-<td class="tally not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
+<td class="tally obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
+<td class="tally not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally not-applicable" data-browser="firefox68" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
@@ -27162,12 +27162,12 @@ return typeof Reflect.defineMetadata === &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -27280,12 +27280,12 @@ return typeof Reflect.hasMetadata === &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -27398,12 +27398,12 @@ return typeof Reflect.hasOwnMetadata === &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -27516,12 +27516,12 @@ return typeof Reflect.getMetadata === &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -27634,12 +27634,12 @@ return typeof Reflect.getOwnMetadata === &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -27752,12 +27752,12 @@ return typeof Reflect.getMetadataKeys === &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -27870,12 +27870,12 @@ return typeof Reflect.getOwnMetadataKeys === &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -27988,12 +27988,12 @@ return typeof Reflect.deleteMetadata === &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
@@ -28106,12 +28106,12 @@ return typeof Reflect.metadata === &apos;function&apos;;
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_2corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes obsolete not-applicable" data-browser="typescript3_3corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_4corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_5corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_6corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
-<td class="yes not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes obsolete not-applicable" data-browser="typescript3_8corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
+<td class="yes not-applicable" data-browser="typescript3_9corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="no obsolete not-applicable" data-browser="firefox60" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="firefox67" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="firefox68" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>


### PR DESCRIPTION
TypeScript 3.9 was released this week.  I also added version 3.8 that was missing.
The release notes for 3.8 mentions private classes support, but I am unable to run the tests.