### PR TITLE
Update Closure Compiler to v20200517

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -2718,6 +2718,7 @@ exports.tests = [
     res: {
       closure20181008: true,
       closure20200315: false,
+      closure20200517: true,
       ie11: false,
       firefox2: false,
       firefox53: true,

--- a/data-es6.js
+++ b/data-es6.js
@@ -6029,6 +6029,7 @@ exports.tests = [
         ejs: true,
         closure: true,
         closure20200315: false,
+        closure20200517: true,
         typescript1corejs2: true,
         ie11: false,
         edge12: true,
@@ -6143,6 +6144,7 @@ exports.tests = [
         ejs: true,
         closure: true,
         closure20200315: false,
+        closure20200517: true,
         typescript1corejs2: true,
         ie11: false,
         edge12: true,
@@ -6184,6 +6186,7 @@ exports.tests = [
         ejs: true,
         closure: true,
         closure20200315: false,
+        closure20200517: true,
         typescript1corejs2: true,
         ie11: false,
         edge12: true,
@@ -17727,6 +17730,7 @@ exports.tests = [
         return \u{102C0} === 2;
       */},
       res: {
+        closure20200517: true,
         ejs: true,
         ie11: false,
         edge12: true,
@@ -17751,6 +17755,7 @@ exports.tests = [
         return o['\ud800\udec0'] === 2;
       */},
       res: {
+        closure20200517: false,
         ejs: true,
         edge12: true,
         chrome44: true,
@@ -17774,6 +17779,7 @@ exports.tests = [
         return o.\u{102C0} === 2;
       */},
       res: {
+        closure20200517: false,
         edge12: true,
         chrome44: true,
         firefox2: false,
@@ -17805,6 +17811,8 @@ exports.tests = [
         return passed;
       */},
       res: {
+        closure: false,
+        closure20200517: true,
         firefox2: false,
         firefox41: true,
         opera10_50: false,
@@ -17838,6 +17846,8 @@ exports.tests = [
         }
       */},
       res: {
+        closure: false,
+        closure20200517: true,
         firefox2: false,
         firefox41: true,
         opera10_50: false,

--- a/environments.json
+++ b/environments.json
@@ -217,7 +217,7 @@
     "short": "Closure 2019.03",
     "family": "Closure",
     "platformtype": "compiler",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -273,8 +273,20 @@
     ]
   },
   "closure20200315": {
-    "full": "Closure Compiler >=v20200315",
+    "full": "Closure Compiler >=v20200315 <v20200517",
     "short": "Closure 2020.03",
+    "family": "Closure",
+    "platformtype": "compiler",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "closure20200517": {
+    "full": "Closure Compiler >=v20200517",
+    "short": "Closure 2020.05",
     "family": "Closure",
     "platformtype": "compiler",
     "obsolete": false,

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -130,12 +130,12 @@
 <th class="platform babel7corejs3 compiler" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform closure compiler obsolete" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure 2018.02</abbr></a></th>
 <th class="platform closure20190121 compiler obsolete" data-browser="closure20190121"><a href="#closure20190121" class="browser-name"><abbr title="Closure Compiler v20190121">Closure 2019.01</abbr></a></th>
-<th class="platform closure20190325 compiler obsolete" data-browser="closure20190325"><a href="#closure20190325" class="browser-name"><abbr title="Closure Compiler &gt;=v20190325 &lt;v20190709">Closure 2019.03</abbr></a></th>
 <th class="platform closure20190709 compiler obsolete" data-browser="closure20190709"><a href="#closure20190709" class="browser-name"><abbr title="Closure Compiler &gt;=v20190709 &lt;v20191027">Closure 2019.07</abbr></a></th>
 <th class="platform closure20191027 compiler obsolete" data-browser="closure20191027"><a href="#closure20191027" class="browser-name"><abbr title="Closure Compiler &gt;=v20191027 &lt;v20200101">Closure 2019.10</abbr></a></th>
 <th class="platform closure20200101 compiler obsolete" data-browser="closure20200101"><a href="#closure20200101" class="browser-name"><abbr title="Closure Compiler v20200101">Closure 2020.01</abbr></a></th>
 <th class="platform closure20200112 compiler obsolete" data-browser="closure20200112"><a href="#closure20200112" class="browser-name"><abbr title="Closure Compiler &gt;=v20200112 &lt;v20200315">Closure 2020.01</abbr></a></th>
-<th class="platform closure20200315 compiler" data-browser="closure20200315"><a href="#closure20200315" class="browser-name"><abbr title="Closure Compiler &gt;=v20200315">Closure 2020.03</abbr></a></th>
+<th class="platform closure20200315 compiler obsolete" data-browser="closure20200315"><a href="#closure20200315" class="browser-name"><abbr title="Closure Compiler &gt;=v20200315 &lt;v20200517">Closure 2020.03</abbr></a></th>
+<th class="platform closure20200517 compiler" data-browser="closure20200517"><a href="#closure20200517" class="browser-name"><abbr title="Closure Compiler &gt;=v20200517">Closure 2020.05</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_9corejs2 compiler obsolete" data-browser="typescript2_9corejs2"><a href="#typescript2_9corejs2" class="browser-name"><abbr title="TypeScript 2.9 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript3_2corejs2 compiler obsolete" data-browser="typescript3_2corejs2"><a href="#typescript3_2corejs2" class="browser-name"><abbr title="TypeScript 3.2 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -253,12 +253,12 @@
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20200315" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20200517" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -373,12 +373,12 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -493,12 +493,12 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -618,12 +618,12 @@ return true;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -735,12 +735,12 @@ return true;
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20200315" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20200517" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
@@ -859,12 +859,12 @@ return [1, 2, 3].includes(1)
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1001,12 +1001,12 @@ return 24;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1126,12 +1126,12 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1255,12 +1255,12 @@ return true;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1388,12 +1388,12 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -1513,12 +1513,12 @@ return true;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1634,12 +1634,12 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -1756,12 +1756,12 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -1883,12 +1883,12 @@ return passed;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2012,12 +2012,12 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2131,12 +2131,12 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="closure20200315" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="closure20200517" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">4/4</td>
@@ -2254,12 +2254,12 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2381,12 +2381,12 @@ return Array.isArray(e)
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2509,12 +2509,12 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2632,12 +2632,12 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2749,12 +2749,12 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200315" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -2874,12 +2874,12 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2999,12 +2999,12 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -3116,12 +3116,12 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200315" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -3236,12 +3236,12 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -3356,12 +3356,12 @@ return Math.min(1,2,3,) === 1;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -3473,12 +3473,12 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="babel7corejs3" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
-<td class="tally" data-browser="closure20200315" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
+<td class="tally" data-browser="closure20200517" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
@@ -3604,12 +3604,12 @@ p.then(function(result) {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3735,12 +3735,12 @@ p.catch(function(result) {
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -3856,12 +3856,12 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
-<td class="no" data-browser="closure20200315">No</td>
+<td class="no obsolete" data-browser="closure20200315">No</td>
+<td class="no" data-browser="closure20200517">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3977,12 +3977,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
-<td class="no" data-browser="closure20200315">No</td>
+<td class="no obsolete" data-browser="closure20200315">No</td>
+<td class="no" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -4104,12 +4104,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4233,12 +4233,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4354,12 +4354,12 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4480,12 +4480,12 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4601,12 +4601,12 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
-<td class="no" data-browser="closure20200315">No</td>
+<td class="no obsolete" data-browser="closure20200315">No</td>
+<td class="no" data-browser="closure20200517">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4732,12 +4732,12 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4863,12 +4863,12 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4994,12 +4994,12 @@ var p = new C().a();
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -5123,12 +5123,12 @@ p.then(function(result) {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -5245,12 +5245,12 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
-<td class="no" data-browser="closure20200315">No</td>
+<td class="no obsolete" data-browser="closure20200315">No</td>
+<td class="no" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -5365,12 +5365,12 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
-<td class="no" data-browser="closure20200315">No</td>
+<td class="no obsolete" data-browser="closure20200315">No</td>
+<td class="no" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -5494,12 +5494,12 @@ p.then(function(result) {
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
-<td class="no" data-browser="closure20200315">No</td>
+<td class="no obsolete" data-browser="closure20200315">No</td>
+<td class="no" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -5611,12 +5611,12 @@ p.then(function(result) {
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/17</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/17</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/17</td>
@@ -5731,12 +5731,12 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -5851,12 +5851,12 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -5971,12 +5971,12 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6091,12 +6091,12 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6211,12 +6211,12 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6331,12 +6331,12 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6451,12 +6451,12 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6571,12 +6571,12 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6691,12 +6691,12 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6811,12 +6811,12 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6931,12 +6931,12 @@ return typeof Atomics.wake === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7051,12 +7051,12 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7171,12 +7171,12 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7291,12 +7291,12 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7411,12 +7411,12 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7531,12 +7531,12 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7651,12 +7651,12 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7776,12 +7776,12 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7899,12 +7899,12 @@ return (function(){
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8018,12 +8018,12 @@ return (function(){
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -8143,12 +8143,12 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8269,12 +8269,12 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8395,12 +8395,12 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8520,12 +8520,12 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8646,12 +8646,12 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8772,12 +8772,12 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -8899,12 +8899,12 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9026,12 +9026,12 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9154,12 +9154,12 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9279,12 +9279,12 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9403,12 +9403,12 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9530,12 +9530,12 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9657,12 +9657,12 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9785,12 +9785,12 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9910,12 +9910,12 @@ return true;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10034,12 +10034,12 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10151,12 +10151,12 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -10275,12 +10275,12 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -10399,12 +10399,12 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -10528,12 +10528,12 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -10657,12 +10657,12 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -10778,12 +10778,12 @@ return i === 0;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -10897,12 +10897,12 @@ return i === 0;
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -11018,12 +11018,12 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="closure20190325">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190709">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20191027">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200101">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200112">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="closure20200315">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="closure20200315">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="closure20200517">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -11140,12 +11140,12 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="closure20190325">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20190709">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20191027">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200101">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200112">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="closure20200315">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="closure20200315">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="closure20200517">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -11257,12 +11257,12 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20200315" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20200517" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
@@ -11403,12 +11403,12 @@ function check() {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11541,12 +11541,12 @@ function check() {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11681,12 +11681,12 @@ function check() {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11802,12 +11802,12 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
-<td class="no" data-browser="closure20200315">No</td>
+<td class="no obsolete" data-browser="closure20200315">No</td>
+<td class="no" data-browser="closure20200517">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -11929,12 +11929,12 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -12050,12 +12050,12 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -12171,12 +12171,12 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -12288,12 +12288,12 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200315" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -12415,12 +12415,12 @@ iterator.next().then(function(step){
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -12552,12 +12552,12 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -12684,12 +12684,12 @@ return false;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -12811,12 +12811,12 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="no" data-browser="closure20200315">No</td>
+<td class="no obsolete" data-browser="closure20200315">No</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -12934,12 +12934,12 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -13051,12 +13051,12 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">4/4</td>
-<td class="tally" data-browser="closure20200315" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="1">4/4</td>
+<td class="tally" data-browser="closure20200517" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">4/4</td>
@@ -13171,12 +13171,12 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13291,12 +13291,12 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13411,12 +13411,12 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="no obsolete" data-browser="closure20190325">No<a href="#closure-string-trimstart-note"><sup>[27]</sup></a></td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13531,12 +13531,12 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="no obsolete" data-browser="closure20190325">No<a href="#closure-string-trimend-note"><sup>[28]</sup></a></td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13641,19 +13641,19 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="test-Array.prototype.{flat,_flatMap}"><span><a class="anchor" href="#test-Array.prototype.{flat,_flatMap}">&#xA7;</a><a href="https://tc39.github.io/proposal-flatMap/">Array.prototype.{flat, flatMap}</a><a href="#flatten-compat-issue-note"><sup>[29]</sup></a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-Array.prototype.{flat,_flatMap}"><span><a class="anchor" href="#test-Array.prototype.{flat,_flatMap}">&#xA7;</a><a href="https://tc39.github.io/proposal-flatMap/">Array.prototype.{flat, flatMap}</a><a href="#flatten-compat-issue-note"><sup>[27]</sup></a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20200315" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20200517" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -13768,12 +13768,12 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -13785,7 +13785,7 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox60">No<a href="#ffox-flatten-note"><sup>[30]</sup></a></td>
+<td class="no obsolete" data-browser="firefox60">No<a href="#ffox-flatten-note"><sup>[28]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox67">Yes</td>
 <td class="yes" data-browser="firefox68">Yes</td>
 <td class="yes obsolete" data-browser="firefox69">Yes</td>
@@ -13890,12 +13890,12 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -14011,12 +14011,12 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -14130,12 +14130,12 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20200315" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20200517" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
@@ -14256,12 +14256,12 @@ return false;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -14383,12 +14383,12 @@ return false;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -14514,12 +14514,12 @@ return it.throw().value;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -14631,12 +14631,12 @@ return it.throw().value;
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20200315" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20200517" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/3</td>
@@ -14751,12 +14751,12 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -14871,12 +14871,12 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -14992,12 +14992,12 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -15109,12 +15109,12 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/7</td>
@@ -15231,12 +15231,12 @@ return fn + &apos;&apos; === str;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -15352,12 +15352,12 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -15473,12 +15473,12 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -15594,12 +15594,12 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -15715,12 +15715,12 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -15836,12 +15836,12 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -15957,12 +15957,12 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16074,12 +16074,12 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200315" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -16194,12 +16194,12 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16314,12 +16314,12 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="yes obsolete" data-browser="closure20190325">Yes</td>
 <td class="yes obsolete" data-browser="closure20190709">Yes</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16435,12 +16435,12 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -16554,12 +16554,12 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200315" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -16684,12 +16684,12 @@ return a === &apos;1a2b&apos;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -16773,7 +16773,7 @@ return a === &apos;1a2b&apos;
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
 <td class="yes" data-browser="graalvm19">Yes</td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[29]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -16809,12 +16809,12 @@ try {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -16898,7 +16898,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
 <td class="no" data-browser="graalvm19">No</td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[29]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -16926,12 +16926,12 @@ try {
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/8</td>
@@ -17046,12 +17046,12 @@ return (1n + 2n) === 3n;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17064,7 +17064,7 @@ return (1n + 2n) === 3n;
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
-<td class="no flagged obsolete" data-browser="firefox67">Flag<a href="#firefox-bigint-note"><sup>[32]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox67">Flag<a href="#firefox-bigint-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="firefox68">Yes</td>
 <td class="yes obsolete" data-browser="firefox69">Yes</td>
 <td class="yes obsolete" data-browser="firefox70">Yes</td>
@@ -17166,12 +17166,12 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17184,7 +17184,7 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
-<td class="no flagged obsolete" data-browser="firefox67">Flag<a href="#firefox-bigint-note"><sup>[32]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox67">Flag<a href="#firefox-bigint-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="firefox68">Yes</td>
 <td class="yes obsolete" data-browser="firefox69">Yes</td>
 <td class="yes obsolete" data-browser="firefox70">Yes</td>
@@ -17286,12 +17286,12 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17304,7 +17304,7 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
-<td class="no flagged obsolete" data-browser="firefox67">Flag<a href="#firefox-bigint-note"><sup>[32]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox67">Flag<a href="#firefox-bigint-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="firefox68">Yes</td>
 <td class="yes obsolete" data-browser="firefox69">Yes</td>
 <td class="yes obsolete" data-browser="firefox70">Yes</td>
@@ -17406,12 +17406,12 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17424,7 +17424,7 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
-<td class="no flagged obsolete" data-browser="firefox67">Flag<a href="#firefox-bigint-note"><sup>[32]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox67">Flag<a href="#firefox-bigint-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="firefox68">Yes</td>
 <td class="yes obsolete" data-browser="firefox69">Yes</td>
 <td class="yes obsolete" data-browser="firefox70">Yes</td>
@@ -17529,12 +17529,12 @@ return view[0] === -0x8000000000000000n;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17652,12 +17652,12 @@ return view[0] === 0n;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17775,12 +17775,12 @@ return view.getBigInt64(0) === 1n;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17793,7 +17793,7 @@ return view.getBigInt64(0) === 1n;
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
-<td class="no flagged obsolete" data-browser="firefox67">Flag<a href="#firefox-bigint-note"><sup>[32]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox67">Flag<a href="#firefox-bigint-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="firefox68">Yes</td>
 <td class="yes obsolete" data-browser="firefox69">Yes</td>
 <td class="yes obsolete" data-browser="firefox70">Yes</td>
@@ -17898,12 +17898,12 @@ return view.getBigUint64(0) === 1n;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17916,7 +17916,7 @@ return view.getBigUint64(0) === 1n;
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox60">No</td>
-<td class="no flagged obsolete" data-browser="firefox67">Flag<a href="#firefox-bigint-note"><sup>[32]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox67">Flag<a href="#firefox-bigint-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="firefox68">Yes</td>
 <td class="yes obsolete" data-browser="firefox69">Yes</td>
 <td class="yes obsolete" data-browser="firefox70">Yes</td>
@@ -18029,12 +18029,12 @@ Promise.allSettled([
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="yes obsolete" data-browser="closure20191027">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -18118,7 +18118,7 @@ Promise.allSettled([
 <td class="unknown obsolete" data-browser="duktape2_2">?</td>
 <td class="unknown" data-browser="duktape2_3">?</td>
 <td class="no" data-browser="graalvm19">No</td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[29]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -18146,12 +18146,12 @@ Promise.allSettled([
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200315" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -18268,12 +18268,12 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -18394,12 +18394,12 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
@@ -18511,12 +18511,12 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/4</td>
@@ -18633,12 +18633,12 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18668,8 +18668,8 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="unknown obsolete" data-browser="chrome75">?</td>
 <td class="unknown obsolete" data-browser="chrome76">?</td>
 <td class="no obsolete" data-browser="chrome77">No</td>
-<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="chrome80">Yes</td>
 <td class="yes" data-browser="chrome81">Yes</td>
 <td class="yes unstable" data-browser="chrome83">Yes</td>
@@ -18677,7 +18677,7 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
-<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
 <td class="yes unstable" data-browser="edge83">Yes</td>
@@ -18692,8 +18692,8 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="unknown obsolete" data-browser="opera62">?</td>
 <td class="unknown obsolete" data-browser="opera63">?</td>
 <td class="no obsolete" data-browser="opera64">No</td>
-<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
-<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="opera67">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -18714,8 +18714,8 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="unknown obsolete" data-browser="node12_5">?</td>
 <td class="unknown obsolete" data-browser="node12_9">?</td>
 <td class="no" data-browser="node12_11">No</td>
-<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
-<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="node14_0">Yes</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
@@ -18755,12 +18755,12 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18790,8 +18790,8 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="unknown obsolete" data-browser="chrome75">?</td>
 <td class="unknown obsolete" data-browser="chrome76">?</td>
 <td class="no obsolete" data-browser="chrome77">No</td>
-<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="chrome80">Yes</td>
 <td class="yes" data-browser="chrome81">Yes</td>
 <td class="yes unstable" data-browser="chrome83">Yes</td>
@@ -18799,7 +18799,7 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
-<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
 <td class="yes unstable" data-browser="edge83">Yes</td>
@@ -18814,8 +18814,8 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="unknown obsolete" data-browser="opera62">?</td>
 <td class="unknown obsolete" data-browser="opera63">?</td>
 <td class="no obsolete" data-browser="opera64">No</td>
-<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
-<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="opera67">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -18836,8 +18836,8 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="unknown obsolete" data-browser="node12_5">?</td>
 <td class="unknown obsolete" data-browser="node12_9">?</td>
 <td class="no" data-browser="node12_11">No</td>
-<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
-<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="node14_0">Yes</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
@@ -18877,12 +18877,12 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18912,8 +18912,8 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="unknown obsolete" data-browser="chrome75">?</td>
 <td class="unknown obsolete" data-browser="chrome76">?</td>
 <td class="no obsolete" data-browser="chrome77">No</td>
-<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="chrome80">Yes</td>
 <td class="yes" data-browser="chrome81">Yes</td>
 <td class="yes unstable" data-browser="chrome83">Yes</td>
@@ -18921,7 +18921,7 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
-<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
 <td class="yes unstable" data-browser="edge83">Yes</td>
@@ -18936,8 +18936,8 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="unknown obsolete" data-browser="opera62">?</td>
 <td class="unknown obsolete" data-browser="opera63">?</td>
 <td class="no obsolete" data-browser="opera64">No</td>
-<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
-<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="opera67">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -18958,8 +18958,8 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="unknown obsolete" data-browser="node12_5">?</td>
 <td class="unknown obsolete" data-browser="node12_9">?</td>
 <td class="no" data-browser="node12_11">No</td>
-<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
-<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="node14_0">Yes</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
@@ -19001,12 +19001,12 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -19036,8 +19036,8 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="unknown obsolete" data-browser="chrome75">?</td>
 <td class="unknown obsolete" data-browser="chrome76">?</td>
 <td class="no obsolete" data-browser="chrome77">No</td>
-<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="chrome80">Yes</td>
 <td class="yes" data-browser="chrome81">Yes</td>
 <td class="yes unstable" data-browser="chrome83">Yes</td>
@@ -19045,7 +19045,7 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
-<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
 <td class="yes unstable" data-browser="edge83">Yes</td>
@@ -19060,8 +19060,8 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="unknown obsolete" data-browser="opera62">?</td>
 <td class="unknown obsolete" data-browser="opera63">?</td>
 <td class="no obsolete" data-browser="opera64">No</td>
-<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
-<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="opera67">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -19082,8 +19082,8 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="unknown obsolete" data-browser="node12_5">?</td>
 <td class="unknown obsolete" data-browser="node12_9">?</td>
 <td class="no" data-browser="node12_11">No</td>
-<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
-<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[33]</sup></a></td>
+<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[31]</sup></a></td>
 <td class="yes" data-browser="node14_0">Yes</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
@@ -19126,12 +19126,12 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
-<td class="yes" data-browser="closure20200315">Yes</td>
+<td class="yes obsolete" data-browser="closure20200315">Yes</td>
+<td class="yes" data-browser="closure20200517">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -19161,8 +19161,8 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="unknown obsolete" data-browser="chrome75">?</td>
 <td class="unknown obsolete" data-browser="chrome76">?</td>
 <td class="no obsolete" data-browser="chrome77">No</td>
-<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-nullish-note"><sup>[34]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-nullish-note"><sup>[34]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-nullish-note"><sup>[32]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-nullish-note"><sup>[32]</sup></a></td>
 <td class="yes" data-browser="chrome80">Yes</td>
 <td class="yes" data-browser="chrome81">Yes</td>
 <td class="yes unstable" data-browser="chrome83">Yes</td>
@@ -19170,7 +19170,7 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
-<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-nullish-note"><sup>[34]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-nullish-note"><sup>[32]</sup></a></td>
 <td class="yes" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
 <td class="yes unstable" data-browser="edge83">Yes</td>
@@ -19185,8 +19185,8 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="unknown obsolete" data-browser="opera62">?</td>
 <td class="unknown obsolete" data-browser="opera63">?</td>
 <td class="no obsolete" data-browser="opera64">No</td>
-<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-nullish-note"><sup>[34]</sup></a></td>
-<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-nullish-note"><sup>[34]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-nullish-note"><sup>[32]</sup></a></td>
+<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-nullish-note"><sup>[32]</sup></a></td>
 <td class="yes" data-browser="opera67">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -19207,15 +19207,15 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="unknown obsolete" data-browser="node12_5">?</td>
 <td class="unknown obsolete" data-browser="node12_9">?</td>
 <td class="no" data-browser="node12_11">No</td>
-<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-nullish-note"><sup>[34]</sup></a></td>
-<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-nullish-note"><sup>[34]</sup></a></td>
+<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-nullish-note"><sup>[32]</sup></a></td>
+<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-nullish-note"><sup>[32]</sup></a></td>
 <td class="yes" data-browser="node14_0">Yes</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
 <td class="unknown obsolete" data-browser="duktape2_2">?</td>
 <td class="unknown" data-browser="duktape2_3">?</td>
 <td class="no" data-browser="graalvm19">No</td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[29]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -19240,7 +19240,7 @@ return (null ?? 42) === 42 &amp;&amp;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="chrome-experimental-note">  <sup>[4]</sup> The feature have to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="babel-core-js-note">  <sup>[5]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="typescript-downlevel-iteration-note">  <sup>[9]</sup> Requires the <code>downlevelIteration</code> compile option.</p><p id="strict-fn-non-strict-params-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[12]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[13]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="babel-regenerator-note">  <sup>[14]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="fx-shared-memory-spectre-note">  <sup>[15]</sup> The feature was <a href="https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.  It can be enabled via <code>javascript.options.shared_memory</code> setting under <code>about:config</code></p><p id="firefox-nightly-note">  <sup>[16]</sup> The feature is available only in Firefox Nightly builds.</p><p id="firefox-beta-note">  <sup>[17]</sup> The feature is available only in Firefox Beta, Firefox Developer Edition and Firefox Nightly builds.</p><p id="edge-experimental-flag-note">  <sup>[18]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="edg-shared-memory-spectre-note">  <sup>[19]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="sf-shared-memory-spectre-note">  <sup>[20]</sup> The feature was <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-sharedmem-note">  <sup>[21]</sup> The feature have to be enabled via &quot;Experimental enabled SharedArrayBuffer support in JavaScript.&quot; setting under <code>about:flags</code></p><p id="chr-shared-memory-spectre-note">  <sup>[22]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-harmony-note">  <sup>[23]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="closure-object-assign-note">  <sup>[24]</sup> Requires native support for <code>Object.assign</code></p><p id="chrome-promise-note">  <sup>[25]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-promise-finally&quot;</code> flag</p><p id="typescript-es6-note">  <sup>[26]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="closure-string-trimstart-note">  <sup>[27]</sup> Requires native support for String.prototype.trimLeft.</p><p id="closure-string-trimend-note">  <sup>[28]</sup> Requires native support for String.prototype.trimRight.</p><p id="flatten-compat-issue-note">  <sup>[29]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="ffox-flatten-note">  <sup>[30]</sup> Older Firefox Nightly builds support only the obsolete draft function name <code>Array.prototype.flatten()</code>.</p><p id="graalvm-es2020-note">  <sup>[31]</sup> The feature have to be enabled via <code>--js.ecmascript-version=2020</code> flag</p><p id="firefox-bigint-note">  <sup>[32]</sup> The feature have to be enabled via <code>javascript.options.bigint</code> setting under <code>about:config</code>.</p><p id="chrome-optional-chaining-note">  <sup>[33]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony-optional-chaining&quot;</code> flag</p><p id="chrome-nullish-note">  <sup>[34]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony-nullish&quot;</code> flag</p></div>
+    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="chrome-experimental-note">  <sup>[4]</sup> The feature have to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="babel-core-js-note">  <sup>[5]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="typescript-downlevel-iteration-note">  <sup>[9]</sup> Requires the <code>downlevelIteration</code> compile option.</p><p id="strict-fn-non-strict-params-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[12]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[13]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="babel-regenerator-note">  <sup>[14]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="fx-shared-memory-spectre-note">  <sup>[15]</sup> The feature was <a href="https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.  It can be enabled via <code>javascript.options.shared_memory</code> setting under <code>about:config</code></p><p id="firefox-nightly-note">  <sup>[16]</sup> The feature is available only in Firefox Nightly builds.</p><p id="firefox-beta-note">  <sup>[17]</sup> The feature is available only in Firefox Beta, Firefox Developer Edition and Firefox Nightly builds.</p><p id="edge-experimental-flag-note">  <sup>[18]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="edg-shared-memory-spectre-note">  <sup>[19]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="sf-shared-memory-spectre-note">  <sup>[20]</sup> The feature was <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-sharedmem-note">  <sup>[21]</sup> The feature have to be enabled via &quot;Experimental enabled SharedArrayBuffer support in JavaScript.&quot; setting under <code>about:flags</code></p><p id="chr-shared-memory-spectre-note">  <sup>[22]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-harmony-note">  <sup>[23]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="closure-object-assign-note">  <sup>[24]</sup> Requires native support for <code>Object.assign</code></p><p id="chrome-promise-note">  <sup>[25]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-promise-finally&quot;</code> flag</p><p id="typescript-es6-note">  <sup>[26]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="flatten-compat-issue-note">  <sup>[27]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="ffox-flatten-note">  <sup>[28]</sup> Older Firefox Nightly builds support only the obsolete draft function name <code>Array.prototype.flatten()</code>.</p><p id="graalvm-es2020-note">  <sup>[29]</sup> The feature have to be enabled via <code>--js.ecmascript-version=2020</code> flag</p><p id="firefox-bigint-note">  <sup>[30]</sup> The feature have to be enabled via <code>javascript.options.bigint</code> setting under <code>about:config</code>.</p><p id="chrome-optional-chaining-note">  <sup>[31]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony-optional-chaining&quot;</code> flag</p><p id="chrome-nullish-note">  <sup>[32]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony-nullish&quot;</code> flag</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
 </body>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -136,12 +136,12 @@
 <th class="platform babel7corejs3 compiler" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
 <th class="platform closure compiler obsolete" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure 2018.02</abbr></a></th>
 <th class="platform closure20190121 compiler obsolete" data-browser="closure20190121"><a href="#closure20190121" class="browser-name"><abbr title="Closure Compiler v20190121">Closure 2019.01</abbr></a></th>
-<th class="platform closure20190325 compiler obsolete" data-browser="closure20190325"><a href="#closure20190325" class="browser-name"><abbr title="Closure Compiler &gt;=v20190325 &lt;v20190709">Closure 2019.03</abbr></a></th>
 <th class="platform closure20190709 compiler obsolete" data-browser="closure20190709"><a href="#closure20190709" class="browser-name"><abbr title="Closure Compiler &gt;=v20190709 &lt;v20191027">Closure 2019.07</abbr></a></th>
 <th class="platform closure20191027 compiler obsolete" data-browser="closure20191027"><a href="#closure20191027" class="browser-name"><abbr title="Closure Compiler &gt;=v20191027 &lt;v20200101">Closure 2019.10</abbr></a></th>
 <th class="platform closure20200101 compiler obsolete" data-browser="closure20200101"><a href="#closure20200101" class="browser-name"><abbr title="Closure Compiler v20200101">Closure 2020.01</abbr></a></th>
 <th class="platform closure20200112 compiler obsolete" data-browser="closure20200112"><a href="#closure20200112" class="browser-name"><abbr title="Closure Compiler &gt;=v20200112 &lt;v20200315">Closure 2020.01</abbr></a></th>
-<th class="platform closure20200315 compiler" data-browser="closure20200315"><a href="#closure20200315" class="browser-name"><abbr title="Closure Compiler &gt;=v20200315">Closure 2020.03</abbr></a></th>
+<th class="platform closure20200315 compiler obsolete" data-browser="closure20200315"><a href="#closure20200315" class="browser-name"><abbr title="Closure Compiler &gt;=v20200315 &lt;v20200517">Closure 2020.03</abbr></a></th>
+<th class="platform closure20200517 compiler" data-browser="closure20200517"><a href="#closure20200517" class="browser-name"><abbr title="Closure Compiler &gt;=v20200517">Closure 2020.05</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_9corejs2 compiler obsolete" data-browser="typescript2_9corejs2"><a href="#typescript2_9corejs2" class="browser-name"><abbr title="TypeScript 2.9 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript3_2corejs2 compiler obsolete" data-browser="typescript3_2corejs2"><a href="#typescript3_2corejs2" class="browser-name"><abbr title="TypeScript 3.2 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -257,12 +257,12 @@
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -377,12 +377,12 @@ return weakref.deref() === O;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -496,12 +496,12 @@ return Object.getPrototypeOf(fg) === FinalizationGroup.prototype;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -611,12 +611,12 @@ return Object.getPrototypeOf(fg) === FinalizationGroup.prototype;
 <td class="tally" data-browser="babel7corejs3" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/6</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/6</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/6</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
@@ -732,12 +732,12 @@ return new C().x === &apos;x&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -859,12 +859,12 @@ return new C(42).x() === 42;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -983,12 +983,12 @@ return new C().x() === 42;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1107,12 +1107,12 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1231,12 +1231,12 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1352,12 +1352,12 @@ return new C().x === 42;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1467,12 +1467,12 @@ return new C().x === 42;
 <td class="tally" data-browser="babel7corejs3" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -1588,12 +1588,12 @@ return C.x === &apos;x&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -1712,12 +1712,12 @@ return new C().x() === 42;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1833,12 +1833,12 @@ return C.x === 42;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1948,12 +1948,12 @@ return C.x === 42;
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/4</td>
@@ -2072,12 +2072,12 @@ return new C().x() === 42;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2196,12 +2196,12 @@ return new C().x() === 42;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2323,12 +2323,12 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2450,12 +2450,12 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2569,12 +2569,12 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -2687,12 +2687,12 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -2811,12 +2811,12 @@ Promise.any([
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -2926,12 +2926,12 @@ Promise.any([
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -3050,12 +3050,12 @@ return RegExp.lastMatch === 'x';
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3176,12 +3176,12 @@ return true;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3291,12 +3291,12 @@ return true;
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/9</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/9</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/9</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/9</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/9</td>
@@ -3415,12 +3415,12 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3536,12 +3536,12 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3657,12 +3657,12 @@ return i === 1;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3781,12 +3781,12 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3902,12 +3902,12 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4023,12 +4023,12 @@ return i === 1;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4147,12 +4147,12 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4268,12 +4268,12 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4389,12 +4389,12 @@ return i === 1;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4511,12 +4511,12 @@ try {
 <td class="no" data-browser="babel7corejs3">No</td>
 <td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
-<td class="no obsolete" data-browser="closure20190325">No</td>
 <td class="no obsolete" data-browser="closure20190709">No</td>
 <td class="no obsolete" data-browser="closure20191027">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
-<td class="no" data-browser="closure20200315">No</td>
+<td class="no obsolete" data-browser="closure20200315">No</td>
+<td class="no" data-browser="closure20200517">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4637,12 +4637,12 @@ return result === &apos;tromple&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4752,12 +4752,12 @@ return result === &apos;tromple&apos;;
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/1</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/1</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">1/1</td>
@@ -4878,12 +4878,12 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no" data-browser="babel7corejs3">No<a href="#babel-decorators-legacy-note"><sup>[21]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -4999,12 +4999,12 @@ return typeof Realm === &quot;function&quot;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -5114,12 +5114,12 @@ return typeof Realm === &quot;function&quot;
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/4</td>
@@ -5238,12 +5238,12 @@ try {
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -5366,12 +5366,12 @@ try {
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -5489,12 +5489,12 @@ try {
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -5612,12 +5612,12 @@ try {
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -5727,12 +5727,12 @@ try {
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/7</td>
@@ -5848,12 +5848,12 @@ return set.size === 2
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -5970,12 +5970,12 @@ return set.size === 3
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -6091,12 +6091,12 @@ return set.size === 2
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -6212,12 +6212,12 @@ return set.size === 2
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -6330,12 +6330,12 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -6448,12 +6448,12 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -6566,12 +6566,12 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -6681,12 +6681,12 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -6802,12 +6802,12 @@ return buffer1.byteLength === 0
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6923,12 +6923,12 @@ return buffer1.byteLength === 0
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7038,12 +7038,12 @@ return buffer1.byteLength === 0
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -7159,12 +7159,12 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -7281,12 +7281,12 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -7400,12 +7400,12 @@ return !Array.isTemplateObject([])
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -7515,12 +7515,12 @@ return !Array.isTemplateObject([])
 <td class="tally" data-browser="babel7corejs3" data-tally="1">35/35</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/35</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/35</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/35</td>
@@ -7633,12 +7633,12 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -7753,12 +7753,12 @@ return instance[Symbol.iterator]() === instance;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -7874,12 +7874,12 @@ return &apos;next&apos; in iterator
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -8000,12 +8000,12 @@ return &apos;next&apos; in iterator
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -8118,12 +8118,12 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -8236,12 +8236,12 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -8354,12 +8354,12 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -8472,12 +8472,12 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -8590,12 +8590,12 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -8708,12 +8708,12 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -8828,12 +8828,12 @@ return result === &apos;123&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -8946,12 +8946,12 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -9064,12 +9064,12 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -9182,12 +9182,12 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -9300,12 +9300,12 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -9419,12 +9419,12 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -9537,12 +9537,12 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -9655,12 +9655,12 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -9775,12 +9775,12 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -9905,12 +9905,12 @@ toArray(iterator).then(it =&gt; {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -10035,12 +10035,12 @@ toArray(iterator).then(it =&gt; {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -10165,12 +10165,12 @@ toArray(iterator).then(it =&gt; {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -10291,12 +10291,12 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -10417,12 +10417,12 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -10537,12 +10537,12 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -10663,12 +10663,12 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -10783,12 +10783,12 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -10909,12 +10909,12 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -11030,12 +11030,12 @@ let result = &apos;&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -11156,12 +11156,12 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -11276,12 +11276,12 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -11396,12 +11396,12 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -11522,12 +11522,12 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -11642,12 +11642,12 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -11760,12 +11760,12 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -11883,12 +11883,12 @@ return do {
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -11998,12 +11998,12 @@ return do {
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">7/7</td>
@@ -12116,12 +12116,12 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -12234,12 +12234,12 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -12352,12 +12352,12 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -12480,12 +12480,12 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -12599,12 +12599,12 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -12717,12 +12717,12 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -12835,12 +12835,12 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -12954,12 +12954,12 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -13076,12 +13076,12 @@ return Math.signbit(NaN) === false
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -13191,12 +13191,12 @@ return Math.signbit(NaN) === false
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">7/7</td>
@@ -13311,12 +13311,12 @@ return Math.clamp(2, 4, 6) === 4
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -13429,12 +13429,12 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -13548,12 +13548,12 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -13666,12 +13666,12 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -13784,12 +13784,12 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -13903,12 +13903,12 @@ return Math.radians(90) === Math.PI / 2
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -14021,12 +14021,12 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -14136,12 +14136,12 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">7/7</td>
@@ -14254,12 +14254,12 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -14372,12 +14372,12 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -14492,12 +14492,12 @@ return score === 1;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -14617,12 +14617,12 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -14742,12 +14742,12 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -14867,12 +14867,12 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -14992,12 +14992,12 @@ Promise.try(function() {
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -15107,12 +15107,12 @@ Promise.try(function() {
 <td class="tally" data-browser="babel7corejs3" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">8/8</td>
@@ -15228,12 +15228,12 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -15351,12 +15351,12 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -15472,12 +15472,12 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -15593,12 +15593,12 @@ return C.has(3) + C.has(4);
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -15714,12 +15714,12 @@ return C.get(A) + C.get(B) === 3;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -15837,12 +15837,12 @@ return C.get(A) + C.get(B) === 5;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -15958,12 +15958,12 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -16079,12 +16079,12 @@ return C.has(A) + C.has(B);
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -16209,12 +16209,12 @@ return result === &apos;Hello, hello!&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16331,12 +16331,12 @@ return 123i === &apos;string123number123&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16446,12 +16446,12 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/12</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/12</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/12</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/12</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/12</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/12</td>
@@ -16568,12 +16568,12 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16690,12 +16690,12 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16812,12 +16812,12 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16934,12 +16934,12 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17056,12 +17056,12 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17178,12 +17178,12 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17300,12 +17300,12 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17425,12 +17425,12 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17548,12 +17548,12 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17670,12 +17670,12 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17792,12 +17792,12 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17914,12 +17914,12 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18029,12 +18029,12 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/8</td>
@@ -18147,12 +18147,12 @@ return Object.isFrozen({# foo: 42 #});
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18265,12 +18265,12 @@ return Object.isFrozen([# 42 #]);
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18383,12 +18383,12 @@ return Object.isSealed({| foo: 42 |});
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18501,12 +18501,12 @@ return Object.isSealed([| 42 |]);
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18627,12 +18627,12 @@ try {
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18754,12 +18754,12 @@ try {
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18880,12 +18880,12 @@ try {
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -19007,12 +19007,12 @@ try {
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -19130,12 +19130,12 @@ return results.length === 3
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -19245,12 +19245,12 @@ return results.length === 3
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -19363,12 +19363,12 @@ return [1, 2, 3].lastItem === 3;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -19481,12 +19481,12 @@ return [1, 2, 3].lastIndex === 2;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -19596,12 +19596,12 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally" data-browser="babel7corejs3" data-tally="1">26/26</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/26</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/26</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/26</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/26</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/26</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/26</td>
@@ -19719,12 +19719,12 @@ return map.size === 2
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -19840,12 +19840,12 @@ return map.size === 2
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -19962,12 +19962,12 @@ return map.size === 2
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -20080,12 +20080,12 @@ return new Map([[1, 4], [2, 5], [3, 6]]).every(it =&gt; typeof it === &apos;numb
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -20201,12 +20201,12 @@ return map.size === 2
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -20319,12 +20319,12 @@ return new Map([[1, 2], [2, 3], [3, 4]]).find(it =&gt; it % 2) === 3;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -20437,12 +20437,12 @@ return new Map([[1, 2], [2, 3], [3, 4]]).findKey(it =&gt; it % 2) === 2;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -20556,12 +20556,12 @@ return new Map([[1, 2], [2, NaN]]).includes(2)
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -20675,12 +20675,12 @@ return new Map([[1, 2], [2, NaN]]).keyOf(2) === 1
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -20797,12 +20797,12 @@ return map.size === 3
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -20919,12 +20919,12 @@ return map.size === 3
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -21041,12 +21041,12 @@ return map.size === 3
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -21159,12 +21159,12 @@ return new Map([[&apos;a&apos;, 1], [&apos;b&apos;, 2], [&apos;c&apos;, 3], ]).r
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -21277,12 +21277,12 @@ return new Map([[1, 4], [2, 5], [3, 6]]).some(it =&gt; it % 2);
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -21399,12 +21399,12 @@ return set.size === 3
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -21521,12 +21521,12 @@ return set.deleteAll(2, 3) === true
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -21639,12 +21639,12 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -21760,12 +21760,12 @@ return set.size === 2
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -21878,12 +21878,12 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -21996,12 +21996,12 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -22118,12 +22118,12 @@ return set.size === 3
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -22236,12 +22236,12 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -22354,12 +22354,12 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -22481,12 +22481,12 @@ return !map.has(a)
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -22608,12 +22608,12 @@ return set.has(a)
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -22735,12 +22735,12 @@ return !set.has(a)
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -22861,12 +22861,12 @@ return second === gen2.next().value;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -22976,12 +22976,12 @@ return second === gen2.next().value;
 <td class="tally" data-browser="babel7corejs3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -23094,12 +23094,12 @@ return Number.fromString(&apos;42&apos;) === 42;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -23212,12 +23212,12 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="unknown" data-browser="babel7corejs3">?</td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -23327,12 +23327,12 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="closure20190325" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190709" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20191027" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20200315" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20200517" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/3</td>
@@ -23449,12 +23449,12 @@ return [...iterator].join() === &apos;a,c&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -23571,12 +23571,12 @@ return [...iterator].join() === &apos;1,3&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -23693,12 +23693,12 @@ return [...iterator].join() === &apos;a,1,c,3&apos;;
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
-<td class="unknown obsolete" data-browser="closure20190325">?</td>
 <td class="unknown obsolete" data-browser="closure20190709">?</td>
 <td class="unknown obsolete" data-browser="closure20191027">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
-<td class="unknown" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown" data-browser="closure20200517">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[15]</sup></a></td>
@@ -23810,12 +23810,12 @@ return [...iterator].join() === &apos;a,1,c,3&apos;;
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">2/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -23930,12 +23930,12 @@ return typeof obj::foo === &quot;function&quot; &amp;&amp; obj::foo().garply ===
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -24049,12 +24049,12 @@ return typeof ::obj.foo === &quot;function&quot; &amp;&amp; ::obj.foo().garply =
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -24167,12 +24167,12 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -24282,12 +24282,12 @@ return &apos;a&#x20BB7;b&apos;.at(1) === &apos;&#x20BB7;&apos;;
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -24401,12 +24401,12 @@ return f();
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -24519,12 +24519,12 @@ return (_ =&gt; function.count)(1, 2, 3) === 3;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -24642,12 +24642,12 @@ return Array.isArray(arr)
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -24771,12 +24771,12 @@ return target === C.prototype
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -24896,12 +24896,12 @@ return (@inverse function(it){
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -25011,12 +25011,12 @@ return (@inverse function(it){
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -25131,12 +25131,12 @@ return Reflect.isCallable(function(){})
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -25251,12 +25251,12 @@ return Reflect.isConstructor(function(){})
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -25366,12 +25366,12 @@ return Reflect.isConstructor(function(){})
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -25484,12 +25484,12 @@ return typeof Zone === &apos;function&apos;;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -25602,12 +25602,12 @@ return &apos;current&apos; in Zone;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -25720,12 +25720,12 @@ return &apos;name&apos; in Zone.prototype;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -25838,12 +25838,12 @@ return &apos;parent&apos; in Zone.prototype;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -25956,12 +25956,12 @@ return typeof Zone.prototype.fork === &apos;function&apos;;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -26074,12 +26074,12 @@ return typeof Zone.prototype.run === &apos;function&apos;;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -26192,12 +26192,12 @@ return typeof Zone.prototype.wrap === &apos;function&apos;;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -26307,12 +26307,12 @@ return typeof Zone.prototype.wrap === &apos;function&apos;;
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -26431,12 +26431,12 @@ return (function f(n){
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -26562,12 +26562,12 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -26677,12 +26677,12 @@ return f(1e6) === &quot;foo&quot; &amp;&amp; f(1e6+1) === &quot;bar&quot;;
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -26797,12 +26797,12 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -26918,12 +26918,12 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet reached ECMA TC39 stage 1, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -27035,12 +27035,12 @@ return fuz.bar === 42 &amp;&amp; fuz.baz === 33;
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
-<td class="tally not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
+<td class="tally not-applicable" data-browser="closure20200517" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">9/9</td>
@@ -27153,12 +27153,12 @@ return typeof Reflect.defineMetadata === &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -27271,12 +27271,12 @@ return typeof Reflect.hasMetadata === &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -27389,12 +27389,12 @@ return typeof Reflect.hasOwnMetadata === &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -27507,12 +27507,12 @@ return typeof Reflect.getMetadata === &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -27625,12 +27625,12 @@ return typeof Reflect.getOwnMetadata === &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -27743,12 +27743,12 @@ return typeof Reflect.getMetadataKeys === &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -27861,12 +27861,12 @@ return typeof Reflect.getOwnMetadataKeys === &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -27979,12 +27979,12 @@ return typeof Reflect.deleteMetadata === &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
@@ -28097,12 +28097,12 @@ return typeof Reflect.metadata === &apos;function&apos;;
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[14]</sup></a></td>
 <td class="unknown obsolete not-applicable" data-browser="closure" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20190325" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190709" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20191027" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20200517" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This proposal has not yet been accepted by ECMA Technical Committee 39, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[16]</sup></a></td>


### PR DESCRIPTION
- fix tagged template (broken in v20200315)
- support `new.target`

https://github.com/google/closure-compiler/wiki/Releases#may-17-2020-v20200517