### PR TITLE
Edge 83 release

### DIFF
--- a/environments.json
+++ b/environments.json
@@ -2310,7 +2310,7 @@
     "family": "Chakra",
     "short": "Edge 15",
     "release": "2017-04-11",
-    "obsolete": true
+    "obsolete": "very"
   },
   "edge16": {
     "full": "Microsoft Edge 16",
@@ -2349,22 +2349,24 @@
     "retire": "2020-04-13",
     "short": "Edge 80",
     "equals": "chrome80",
-    "obsolete": false
+    "obsolete": true
   },
   "edge81": {
     "full": "Microsoft Edge 81",
     "family": "V8",
     "release": "2020-04-13",
+    "retire": "2020-05-21",
     "short": "Edge 81",
     "equals": "chrome81",
     "obsolete": false
   },
   "edge83": {
-    "full": "Microsoft Edge 83 Beta",
+    "full": "Microsoft Edge 83",
     "family": "V8",
-    "short": "Edge 83 Beta",
+    "short": "Edge 83",
+    "release": "2020-05-21",
     "equals": "chrome83",
-    "unstable": true
+    "obsolete": false
   },
   "safari1": {
     "full": "Safari 1.0",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -171,13 +171,12 @@
 <th class="platform chrome83 desktop" data-browser="chrome83"><a href="#chrome83" class="browser-name"><abbr title="Chrome 83">CH 83</abbr></a></th>
 <th class="platform chrome84 desktop unstable" data-browser="chrome84"><a href="#chrome84" class="browser-name"><abbr title="Chrome 84 Beta">CH 84</abbr></a></th>
 <th class="platform chrome85 desktop unstable" data-browser="chrome85"><a href="#chrome85" class="browser-name"><abbr title="Chrome 85 Canary">CH 85</abbr></a></th>
-<th class="platform edge15 desktop obsolete" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge 15">Edge 15</abbr></a></th>
 <th class="platform edge17 desktop obsolete" data-browser="edge17"><a href="#edge17" class="browser-name"><abbr title="Microsoft Edge 17">Edge 17</abbr></a></th>
 <th class="platform edge18 desktop" data-browser="edge18"><a href="#edge18" class="browser-name"><abbr title="Microsoft Edge 18">Edge 18</abbr></a></th>
 <th class="platform edge79 desktop obsolete" data-browser="edge79"><a href="#edge79" class="browser-name"><abbr title="Microsoft Edge 79">Edge 79</abbr></a></th>
-<th class="platform edge80 desktop" data-browser="edge80"><a href="#edge80" class="browser-name"><abbr title="Microsoft Edge 80">Edge 80</abbr></a></th>
+<th class="platform edge80 desktop obsolete" data-browser="edge80"><a href="#edge80" class="browser-name"><abbr title="Microsoft Edge 80">Edge 80</abbr></a></th>
 <th class="platform edge81 desktop" data-browser="edge81"><a href="#edge81" class="browser-name"><abbr title="Microsoft Edge 81">Edge 81</abbr></a></th>
-<th class="platform edge83 desktop unstable" data-browser="edge83"><a href="#edge83" class="browser-name"><abbr title="Microsoft Edge 83 Beta">Edge 83 Beta</abbr></a></th>
+<th class="platform edge83 desktop" data-browser="edge83"><a href="#edge83" class="browser-name"><abbr title="Microsoft Edge 83">Edge 83</abbr></a></th>
 <th class="platform safari11_1 desktop obsolete" data-browser="safari11_1"><a href="#safari11_1" class="browser-name"><abbr title="Safari 11.1">SF 11.1</abbr></a></th>
 <th class="platform safari12 desktop obsolete" data-browser="safari12"><a href="#safari12" class="browser-name"><abbr title="Safari 12">SF 12</abbr></a></th>
 <th class="platform safari12_1 desktop obsolete" data-browser="safari12_1"><a href="#safari12_1" class="browser-name"><abbr title="Safari 12.1">SF&#xA0;12.1</abbr></a></th>
@@ -244,7 +243,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="118">2016 features</td>
+      <tr class="category"><td colspan="117">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -294,13 +293,12 @@
 <td class="tally" data-browser="chrome83" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge18" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">3/3</td>
-<td class="tally" data-browser="edge80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge81" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge83" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">3/3</td>
@@ -414,13 +412,12 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -534,13 +531,12 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -659,13 +655,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -776,13 +771,12 @@ return true;
 <td class="tally" data-browser="chrome83" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge18" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">3/3</td>
-<td class="tally" data-browser="edge80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge81" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge83" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">3/3</td>
@@ -900,13 +894,12 @@ return [1, 2, 3].includes(1)
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1042,13 +1035,12 @@ return 24;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1167,13 +1159,12 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1236,7 +1227,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="118">2016 misc</td>
+<tr class="category"><td colspan="117">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -1296,13 +1287,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1429,13 +1419,12 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1554,13 +1543,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1675,13 +1663,12 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1797,13 +1784,12 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1924,13 +1910,12 @@ return passed;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2053,13 +2038,12 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2122,7 +2106,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="118">2017 features</td>
+<tr class="category"><td colspan="117">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
@@ -2172,13 +2156,12 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="chrome83" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge18" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">4/4</td>
-<td class="tally" data-browser="edge80" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge81" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">4/4</td>
+<td class="tally" data-browser="edge83" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">4/4</td>
@@ -2295,13 +2278,12 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2422,13 +2404,12 @@ return Array.isArray(e)
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2550,13 +2531,12 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2673,13 +2653,12 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2790,13 +2769,12 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="chrome83" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge18" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">2/2</td>
-<td class="tally" data-browser="edge80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge81" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge83" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">2/2</td>
@@ -2915,13 +2893,12 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3040,13 +3017,12 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3157,13 +3133,12 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="chrome83" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge18" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">2/2</td>
-<td class="tally" data-browser="edge80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge81" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge83" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">2/2</td>
@@ -3277,13 +3252,12 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3397,13 +3371,12 @@ return Math.min(1,2,3,) === 1;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3514,13 +3487,12 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="chrome83" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">16/16</td>
 <td class="tally" data-browser="edge18" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">16/16</td>
-<td class="tally" data-browser="edge80" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">16/16</td>
 <td class="tally" data-browser="edge81" data-tally="1">16/16</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">16/16</td>
+<td class="tally" data-browser="edge83" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">16/16</td>
@@ -3645,13 +3617,12 @@ p.then(function(result) {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3776,13 +3747,12 @@ p.catch(function(result) {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3897,13 +3867,12 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4018,13 +3987,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4145,13 +4113,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4274,13 +4241,12 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4395,13 +4361,12 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4521,13 +4486,12 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4642,13 +4606,12 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4773,13 +4736,12 @@ p.then(function(result) {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4904,13 +4866,12 @@ p.then(function(result) {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -5035,13 +4996,12 @@ var p = new C().a();
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -5164,13 +5124,12 @@ p.then(function(result) {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -5286,13 +5245,12 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -5406,13 +5364,12 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -5535,13 +5492,12 @@ p.then(function(result) {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -5652,13 +5608,12 @@ p.then(function(result) {
 <td class="tally" data-browser="chrome83" data-tally="1">17/17</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">17/17</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0" data-flagged-tally="1">0/17</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/17</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">17/17</td>
-<td class="tally" data-browser="edge80" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">17/17</td>
 <td class="tally" data-browser="edge81" data-tally="1">17/17</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">17/17</td>
+<td class="tally" data-browser="edge83" data-tally="1">17/17</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/17</td>
@@ -5772,20 +5727,19 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -5797,15 +5751,15 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -5824,14 +5778,14 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
-<td class="no obsolete" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -5892,20 +5846,19 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -5924,8 +5877,8 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -5944,14 +5897,14 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
-<td class="no obsolete" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -6012,20 +5965,19 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -6037,15 +5989,15 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -6064,14 +6016,14 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
-<td class="no obsolete" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -6132,20 +6084,19 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -6164,8 +6115,8 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -6184,14 +6135,14 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
-<td class="no obsolete" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -6252,20 +6203,19 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -6277,15 +6227,15 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -6304,14 +6254,14 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
-<td class="no obsolete" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -6372,20 +6322,19 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -6397,15 +6346,15 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -6425,13 +6374,13 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes obsolete" data-browser="ios11">Yes</td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -6492,20 +6441,19 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -6517,15 +6465,15 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -6545,13 +6493,13 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes obsolete" data-browser="ios11">Yes</td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -6612,20 +6560,19 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -6637,15 +6584,15 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -6665,13 +6612,13 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes obsolete" data-browser="ios11">Yes</td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -6732,20 +6679,19 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -6757,15 +6703,15 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -6785,13 +6731,13 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes obsolete" data-browser="ios11">Yes</td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -6852,20 +6798,19 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -6877,15 +6822,15 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -6905,13 +6850,13 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes obsolete" data-browser="ios11">Yes</td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -6972,20 +6917,19 @@ return typeof Atomics.wake === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -6997,15 +6941,15 @@ return typeof Atomics.wake === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -7025,13 +6969,13 @@ return typeof Atomics.wake === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes obsolete" data-browser="ios11">Yes</td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -7092,20 +7036,19 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -7117,15 +7060,15 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -7145,13 +7088,13 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes obsolete" data-browser="ios11">Yes</td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -7212,20 +7155,19 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -7237,15 +7179,15 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -7265,13 +7207,13 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes obsolete" data-browser="ios11">Yes</td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -7332,20 +7274,19 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -7357,15 +7298,15 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -7385,13 +7326,13 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes obsolete" data-browser="ios11">Yes</td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -7452,20 +7393,19 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -7477,15 +7417,15 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -7505,13 +7445,13 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes obsolete" data-browser="ios11">Yes</td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -7572,20 +7512,19 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -7597,15 +7536,15 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -7625,13 +7564,13 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes obsolete" data-browser="ios11">Yes</td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -7692,20 +7631,19 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[18]</sup></a></td>
-<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
-<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="edge17">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
+<td class="no" data-browser="edge18">No<a href="#edg-shared-memory-spectre-note"><sup>[18]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
-<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
+<td class="yes" data-browser="edge83">Yes</td>
+<td class="no obsolete" data-browser="safari11_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no obsolete" data-browser="safari12_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="safari13_1">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="safaritp">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no unstable" data-browser="webkit">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="yes obsolete" data-browser="opera61">Yes</td>
 <td class="yes obsolete" data-browser="opera62">Yes</td>
 <td class="yes obsolete" data-browser="opera63">Yes</td>
@@ -7717,15 +7655,15 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="yes obsolete" data-browser="node8_3">Yes</td>
 <td class="yes obsolete" data-browser="node8_7">Yes</td>
 <td class="yes" data-browser="node8_10">Yes</td>
-<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="node10_0">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="node10_4">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="node10_9">Yes</td>
 <td class="yes obsolete" data-browser="node11_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
@@ -7745,13 +7683,13 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
 <td class="yes obsolete" data-browser="ios11">Yes</td>
-<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[20]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[21]</sup></a></td>
-<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
-<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[22]</sup></a></td>
+<td class="no obsolete" data-browser="ios11_3">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
+<td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
+<td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
@@ -7761,7 +7699,7 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="118">2017 misc</td>
+<tr class="category"><td colspan="117">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-RegExp_u_flag,_case_folding"><span><a class="anchor" href="#test-RegExp_u_flag,_case_folding">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/525">RegExp &quot;u&quot; flag, case folding</a></span><script data-source="
 return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/\W/iu)
@@ -7817,13 +7755,12 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -7940,13 +7877,12 @@ return (function(){
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8009,7 +7945,7 @@ return (function(){
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="118">2017 annex b</td>
+<tr class="category"><td colspan="117">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -8059,13 +7995,12 @@ return (function(){
 <td class="tally" data-browser="chrome83" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">16/16</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally" data-browser="edge18" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">16/16</td>
-<td class="tally" data-browser="edge80" data-tally="1">16/16</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">16/16</td>
 <td class="tally" data-browser="edge81" data-tally="1">16/16</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">16/16</td>
+<td class="tally" data-browser="edge83" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">16/16</td>
@@ -8184,13 +8119,12 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8310,13 +8244,12 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8436,13 +8369,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8465,8 +8397,8 @@ return true;
 <td class="unknown obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node7_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node10_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -8561,13 +8493,12 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8687,13 +8618,12 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8813,13 +8743,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8842,8 +8771,8 @@ return true;
 <td class="unknown obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node7_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node10_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -8940,13 +8869,12 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -9067,13 +8995,12 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -9195,13 +9122,12 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -9320,13 +9246,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -9349,8 +9274,8 @@ return true;
 <td class="unknown obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node7_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node10_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -9444,13 +9369,12 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -9571,13 +9495,12 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -9698,13 +9621,12 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -9826,13 +9748,12 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -9951,13 +9872,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -9980,8 +9900,8 @@ return true;
 <td class="unknown obsolete not-applicable" data-browser="node7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node7_6" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node8" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete not-applicable" data-browser="node8_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes not-applicable" data-browser="node8_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete not-applicable" data-browser="node10_4" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -10075,13 +9995,12 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -10192,13 +10111,12 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally" data-browser="chrome83" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge18" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">4/4</td>
-<td class="tally" data-browser="edge80" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge81" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">4/4</td>
+<td class="tally" data-browser="edge83" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">4/4</td>
@@ -10316,13 +10234,12 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -10440,13 +10357,12 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -10569,13 +10485,12 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -10698,13 +10613,12 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -10819,13 +10733,12 @@ return i === 0;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -10888,7 +10801,7 @@ return i === 0;
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="118">2018 features</td>
+<tr class="category"><td colspan="117">2018 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -10938,13 +10851,12 @@ return i === 0;
 <td class="tally" data-browser="chrome83" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">2/2</td>
-<td class="tally" data-browser="edge80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge81" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge83" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">2/2</td>
@@ -11017,13 +10929,13 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="closure20190709">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="closure20191027">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="closure20200101">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="closure20200112">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="closure20200315">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="closure20200517">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190709">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="closure20191027">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="closure20200101">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="closure20200112">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="closure20200315">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no" data-browser="closure20200517">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -11059,13 +10971,12 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -11139,13 +11050,13 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
 <td class="yes obsolete" data-browser="closure">Yes</td>
-<td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="closure20190709">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="closure20191027">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="closure20200101">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="closure20200112">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no obsolete" data-browser="closure20200315">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
-<td class="no" data-browser="closure20200517">No<a href="#closure-object-assign-note"><sup>[24]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="closure20190709">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="closure20191027">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="closure20200101">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="closure20200112">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="closure20200315">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no" data-browser="closure20200517">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -11181,13 +11092,12 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -11298,13 +11208,12 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="chrome83" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge18" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">3/3</td>
-<td class="tally" data-browser="edge80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge81" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge83" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">3/3</td>
@@ -11444,13 +11353,12 @@ function check() {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -11474,8 +11382,8 @@ function check() {
 <td class="unknown obsolete" data-browser="node7_6">?</td>
 <td class="unknown obsolete" data-browser="node8">?</td>
 <td class="unknown obsolete" data-browser="node8_3">?</td>
-<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
-<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
 <td class="yes" data-browser="node10_9">Yes</td>
@@ -11582,13 +11490,12 @@ function check() {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -11612,8 +11519,8 @@ function check() {
 <td class="unknown obsolete" data-browser="node7_6">?</td>
 <td class="unknown obsolete" data-browser="node8">?</td>
 <td class="unknown obsolete" data-browser="node8_3">?</td>
-<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
-<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
 <td class="yes" data-browser="node10_9">Yes</td>
@@ -11722,13 +11629,12 @@ function check() {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -11752,8 +11658,8 @@ function check() {
 <td class="unknown obsolete" data-browser="node7_6">?</td>
 <td class="unknown obsolete" data-browser="node8">?</td>
 <td class="unknown obsolete" data-browser="node8_3">?</td>
-<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
-<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[25]</sup></a></td>
+<td class="no obsolete" data-browser="node8_7">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
+<td class="no" data-browser="node8_10">No<a href="#chrome-promise-note"><sup>[24]</sup></a></td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
 <td class="yes" data-browser="node10_9">Yes</td>
@@ -11843,13 +11749,12 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -11872,8 +11777,8 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="unknown obsolete" data-browser="node7">?</td>
 <td class="unknown obsolete" data-browser="node7_6">?</td>
 <td class="unknown obsolete" data-browser="node8">?</td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
@@ -11970,13 +11875,12 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -11999,9 +11903,9 @@ return result.groups.year === &apos;2016&apos;
 <td class="unknown obsolete" data-browser="node7">?</td>
 <td class="unknown obsolete" data-browser="node7_6">?</td>
 <td class="unknown obsolete" data-browser="node8">?</td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
 <td class="yes" data-browser="node10_9">Yes</td>
@@ -12028,7 +11932,7 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
-<td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
@@ -12091,13 +11995,12 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -12116,12 +12019,12 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
 <td class="unknown obsolete" data-browser="node4">?</td>
-<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node6_5">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node7_6">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
@@ -12148,7 +12051,7 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
 <td class="yes" data-browser="samsung10">Yes</td>
@@ -12212,13 +12115,12 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -12241,9 +12143,9 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="unknown obsolete" data-browser="node7">?</td>
 <td class="unknown obsolete" data-browser="node7_6">?</td>
 <td class="unknown obsolete" data-browser="node8">?</td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
 <td class="yes" data-browser="node10_9">Yes</td>
@@ -12269,8 +12171,8 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
@@ -12329,13 +12231,12 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="chrome83" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">2/2</td>
-<td class="tally" data-browser="edge80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge81" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge83" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">2/2</td>
@@ -12456,13 +12357,12 @@ iterator.next().then(function(step){
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -12487,7 +12387,7 @@ iterator.next().then(function(step){
 <td class="unknown obsolete" data-browser="node8">?</td>
 <td class="unknown obsolete" data-browser="node8_3">?</td>
 <td class="unknown obsolete" data-browser="node8_7">?</td>
-<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
 <td class="yes" data-browser="node10_9">Yes</td>
@@ -12593,13 +12493,12 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -12624,7 +12523,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="unknown obsolete" data-browser="node8">?</td>
 <td class="unknown obsolete" data-browser="node8_3">?</td>
 <td class="unknown obsolete" data-browser="node8_7">?</td>
-<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
 <td class="yes" data-browser="node10_9">Yes</td>
@@ -12662,7 +12561,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="118">2018 misc</td>
+<tr class="category"><td colspan="117">2018 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets">&#xA7;</a><a href="https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var p = new Proxy({}, {
@@ -12725,13 +12624,12 @@ return false;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="unknown obsolete" data-browser="edge15">?</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -12852,13 +12750,12 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -12881,8 +12778,8 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="unknown obsolete" data-browser="node7">?</td>
 <td class="unknown obsolete" data-browser="node7_6">?</td>
 <td class="unknown obsolete" data-browser="node8">?</td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes" data-browser="node8_10">Yes</td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
@@ -12909,7 +12806,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
 <td class="yes" data-browser="samsung10">Yes</td>
@@ -12921,7 +12818,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="118">2019 features</td>
+<tr class="category"><td colspan="117">2019 features</td>
 </tr>
 <tr significance="0.25"><td id="test-Object.fromEntries"><span><a class="anchor" href="#test-Object.fromEntries">&#xA7;</a><a href="https://github.com/tc39/proposal-object-from-entries">Object.fromEntries</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var object = Object.fromEntries(new Map([[&apos;foo&apos;, 42], [&apos;bar&apos;, 23]]));
@@ -12940,9 +12837,9 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes" data-browser="closure20200517">Yes</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12975,13 +12872,12 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -13092,13 +12988,12 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally" data-browser="chrome83" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally" data-browser="edge18" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">4/4</td>
-<td class="tally" data-browser="edge80" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge81" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">4/4</td>
+<td class="tally" data-browser="edge83" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">4/4</td>
@@ -13212,13 +13107,12 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -13332,13 +13226,12 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -13452,13 +13345,12 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -13572,13 +13464,12 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -13641,7 +13532,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="supertest" significance="0.5"><td id="test-Array.prototype.{flat,_flatMap}"><span><a class="anchor" href="#test-Array.prototype.{flat,_flatMap}">&#xA7;</a><a href="https://tc39.github.io/proposal-flatMap/">Array.prototype.{flat, flatMap}</a><a href="#flatten-compat-issue-note"><sup>[27]</sup></a></span></td>
+<tr class="supertest" significance="0.5"><td id="test-Array.prototype.{flat,_flatMap}"><span><a class="anchor" href="#test-Array.prototype.{flat,_flatMap}">&#xA7;</a><a href="https://tc39.github.io/proposal-flatMap/">Array.prototype.{flat, flatMap}</a><a href="#flatten-compat-issue-note"><sup>[26]</sup></a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -13689,13 +13580,12 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="chrome83" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">3/3</td>
-<td class="tally" data-browser="edge80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge81" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge83" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -13774,9 +13664,9 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes" data-browser="closure20200517">Yes</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13785,7 +13675,7 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes" data-browser="typescript3_9corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="unknown" data-browser="es7shim">?</td>
 <td class="no" data-browser="ie11">No</td>
-<td class="no obsolete" data-browser="firefox60">No<a href="#ffox-flatten-note"><sup>[28]</sup></a></td>
+<td class="no obsolete" data-browser="firefox60">No<a href="#ffox-flatten-note"><sup>[27]</sup></a></td>
 <td class="yes" data-browser="firefox68">Yes</td>
 <td class="yes obsolete" data-browser="firefox69">Yes</td>
 <td class="yes obsolete" data-browser="firefox70">Yes</td>
@@ -13809,13 +13699,12 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -13931,13 +13820,12 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -14017,9 +13905,9 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown" data-browser="closure20200517">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -14052,13 +13940,12 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -14121,7 +14008,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="118">2019 misc</td>
+<tr class="category"><td colspan="117">2019 misc</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://github.com/tc39/proposal-optional-catch-binding">optional catch binding</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
@@ -14171,13 +14058,12 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally" data-browser="chrome83" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">3/3</td>
-<td class="tally" data-browser="edge80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge81" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge83" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">3/3</td>
@@ -14297,13 +14183,12 @@ return false;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -14424,13 +14309,12 @@ return false;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -14555,13 +14439,12 @@ return it.throw().value;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -14672,13 +14555,12 @@ return it.throw().value;
 <td class="tally" data-browser="chrome83" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">3/3</td>
-<td class="tally" data-browser="edge80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge81" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge83" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">3/3</td>
@@ -14757,9 +14639,9 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes" data-browser="closure20200517">Yes</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -14792,13 +14674,12 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -14877,9 +14758,9 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes" data-browser="closure20200517">Yes</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -14912,13 +14793,12 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -14998,9 +14878,9 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown" data-browser="closure20200517">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -15033,13 +14913,12 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -15150,13 +15029,12 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="tally" data-browser="chrome83" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="edge18" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">7/7</td>
-<td class="tally" data-browser="edge80" data-tally="1">7/7</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">7/7</td>
 <td class="tally" data-browser="edge81" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">7/7</td>
+<td class="tally" data-browser="edge83" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
@@ -15272,13 +15150,12 @@ return fn + &apos;&apos; === str;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -15301,9 +15178,9 @@ return fn + &apos;&apos; === str;
 <td class="unknown obsolete" data-browser="node7">?</td>
 <td class="unknown obsolete" data-browser="node7_6">?</td>
 <td class="unknown obsolete" data-browser="node8">?</td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
 <td class="yes" data-browser="node10_9">Yes</td>
@@ -15329,8 +15206,8 @@ return fn + &apos;&apos; === str;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
@@ -15393,13 +15270,12 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -15514,13 +15390,12 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -15635,13 +15510,12 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -15756,13 +15630,12 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -15877,13 +15750,12 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -15906,9 +15778,9 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown obsolete" data-browser="node7">?</td>
 <td class="unknown obsolete" data-browser="node7_6">?</td>
 <td class="unknown obsolete" data-browser="node8">?</td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
 <td class="yes" data-browser="node10_9">Yes</td>
@@ -15934,8 +15806,8 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
@@ -15998,13 +15870,12 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -16027,9 +15898,9 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="unknown obsolete" data-browser="node7">?</td>
 <td class="unknown obsolete" data-browser="node7_6">?</td>
 <td class="unknown obsolete" data-browser="node8">?</td>
-<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_3">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node8_7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged" data-browser="node8_10">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="node10_0">Yes</td>
 <td class="yes obsolete" data-browser="node10_4">Yes</td>
 <td class="yes" data-browser="node10_9">Yes</td>
@@ -16055,8 +15926,8 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
-<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
 <td class="yes" data-browser="samsung10">Yes</td>
 <td class="yes" data-browser="samsung11">Yes</td>
@@ -16115,13 +15986,12 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally" data-browser="chrome83" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">2/2</td>
-<td class="tally" data-browser="edge80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge81" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge83" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">2/2</td>
@@ -16235,13 +16105,12 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -16355,13 +16224,12 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -16441,9 +16309,9 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown" data-browser="closure20200517">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -16476,13 +16344,12 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -16545,7 +16412,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="118">2020 features</td>
+<tr class="category"><td colspan="117">2020 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-String.prototype.matchAll"><span><a class="anchor" href="#test-String.prototype.matchAll">&#xA7;</a><a href="https://github.com/tc39/String.prototype.matchAll">String.prototype.matchAll</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -16595,13 +16462,12 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally" data-browser="chrome83" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
-<td class="tally" data-browser="edge80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge81" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge83" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/2</td>
@@ -16725,13 +16591,12 @@ return a === &apos;1a2b&apos;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -16759,8 +16624,8 @@ return a === &apos;1a2b&apos;
 <td class="unknown" data-browser="node8_10">?</td>
 <td class="unknown obsolete" data-browser="node10_0">?</td>
 <td class="no obsolete" data-browser="node10_4">No</td>
-<td class="no flagged" data-browser="node10_9">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
-<td class="no flagged obsolete" data-browser="node11_0">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged" data-browser="node10_9">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node11_0">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="node12_0">Yes</td>
 <td class="yes obsolete" data-browser="node12_5">Yes</td>
 <td class="yes obsolete" data-browser="node12_9">Yes</td>
@@ -16773,7 +16638,7 @@ return a === &apos;1a2b&apos;
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
 <td class="yes" data-browser="graalvm19">Yes</td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[29]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[28]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -16785,10 +16650,10 @@ return a === &apos;1a2b&apos;
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
-<td class="no flagged" data-browser="samsung10">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged" data-browser="samsung10">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes" data-browser="samsung11">Yes</td>
 <td class="yes unstable" data-browser="samsung12">Yes</td>
-<td class="no flagged obsolete" data-browser="opera_mobile51">Flag<a href="#chrome-harmony-note"><sup>[23]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera_mobile51">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="opera_mobile52">Yes</td>
 <td class="yes obsolete" data-browser="opera_mobile53">Yes</td>
 <td class="yes" data-browser="opera_mobile54">Yes</td>
@@ -16815,9 +16680,9 @@ try {
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes" data-browser="closure20200517">Yes</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -16850,13 +16715,12 @@ try {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -16898,7 +16762,7 @@ try {
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
 <td class="no" data-browser="graalvm19">No</td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[29]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[28]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -16967,13 +16831,12 @@ try {
 <td class="tally" data-browser="chrome83" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/8</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">8/8</td>
-<td class="tally" data-browser="edge80" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">8/8</td>
 <td class="tally" data-browser="edge81" data-tally="1">8/8</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">8/8</td>
+<td class="tally" data-browser="edge83" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/8</td>
@@ -17087,13 +16950,12 @@ return (1n + 2n) === 3n;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -17207,13 +17069,12 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -17327,13 +17188,12 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -17447,13 +17307,12 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -17570,13 +17429,12 @@ return view[0] === -0x8000000000000000n;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -17693,13 +17551,12 @@ return view[0] === 0n;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -17816,13 +17673,12 @@ return view.getBigInt64(0) === 1n;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -17939,13 +17795,12 @@ return view.getBigUint64(0) === 1n;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -18035,9 +17890,9 @@ Promise.allSettled([
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes" data-browser="closure20200517">Yes</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -18070,13 +17925,12 @@ Promise.allSettled([
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -18118,7 +17972,7 @@ Promise.allSettled([
 <td class="unknown obsolete" data-browser="duktape2_2">?</td>
 <td class="unknown" data-browser="duktape2_3">?</td>
 <td class="no" data-browser="graalvm19">No</td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[29]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[28]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -18187,13 +18041,12 @@ Promise.allSettled([
 <td class="tally" data-browser="chrome83" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">2/2</td>
-<td class="tally" data-browser="edge80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge81" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge83" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">2/2</td>
@@ -18274,9 +18127,9 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes" data-browser="closure20200517">Yes</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -18309,13 +18162,12 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -18400,9 +18252,9 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes" data-browser="closure20200517">Yes</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -18435,13 +18287,12 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -18552,13 +18403,12 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="chrome83" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally" data-browser="edge80" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">4/4</td>
 <td class="tally" data-browser="edge81" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">4/4</td>
+<td class="tally" data-browser="edge83" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/4</td>
@@ -18667,20 +18517,19 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="unknown obsolete" data-browser="chrome75">?</td>
 <td class="unknown obsolete" data-browser="chrome76">?</td>
 <td class="no obsolete" data-browser="chrome77">No</td>
-<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome80">Yes</td>
 <td class="yes" data-browser="chrome81">Yes</td>
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
-<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -18692,8 +18541,8 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="unknown obsolete" data-browser="opera62">?</td>
 <td class="unknown obsolete" data-browser="opera63">?</td>
 <td class="no obsolete" data-browser="opera64">No</td>
-<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="yes" data-browser="opera67">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -18714,8 +18563,8 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="unknown obsolete" data-browser="node12_5">?</td>
 <td class="unknown obsolete" data-browser="node12_9">?</td>
 <td class="no" data-browser="node12_11">No</td>
-<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="yes" data-browser="node14_0">Yes</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
@@ -18736,7 +18585,7 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="unknown obsolete" data-browser="samsung9">?</td>
 <td class="unknown" data-browser="samsung10">?</td>
 <td class="unknown" data-browser="samsung11">?</td>
-<td class="no flagged unstable" data-browser="samsung12">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged unstable" data-browser="samsung12">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera_mobile51">?</td>
 <td class="unknown obsolete" data-browser="opera_mobile52">?</td>
 <td class="unknown obsolete" data-browser="opera_mobile53">?</td>
@@ -18789,20 +18638,19 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="unknown obsolete" data-browser="chrome75">?</td>
 <td class="unknown obsolete" data-browser="chrome76">?</td>
 <td class="no obsolete" data-browser="chrome77">No</td>
-<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome80">Yes</td>
 <td class="yes" data-browser="chrome81">Yes</td>
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
-<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -18814,8 +18662,8 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="unknown obsolete" data-browser="opera62">?</td>
 <td class="unknown obsolete" data-browser="opera63">?</td>
 <td class="no obsolete" data-browser="opera64">No</td>
-<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="yes" data-browser="opera67">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -18836,8 +18684,8 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="unknown obsolete" data-browser="node12_5">?</td>
 <td class="unknown obsolete" data-browser="node12_9">?</td>
 <td class="no" data-browser="node12_11">No</td>
-<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="yes" data-browser="node14_0">Yes</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
@@ -18858,7 +18706,7 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="unknown obsolete" data-browser="samsung9">?</td>
 <td class="unknown" data-browser="samsung10">?</td>
 <td class="unknown" data-browser="samsung11">?</td>
-<td class="no flagged unstable" data-browser="samsung12">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged unstable" data-browser="samsung12">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera_mobile51">?</td>
 <td class="unknown obsolete" data-browser="opera_mobile52">?</td>
 <td class="unknown obsolete" data-browser="opera_mobile53">?</td>
@@ -18911,20 +18759,19 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="unknown obsolete" data-browser="chrome75">?</td>
 <td class="unknown obsolete" data-browser="chrome76">?</td>
 <td class="no obsolete" data-browser="chrome77">No</td>
-<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome80">Yes</td>
 <td class="yes" data-browser="chrome81">Yes</td>
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
-<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -18936,8 +18783,8 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="unknown obsolete" data-browser="opera62">?</td>
 <td class="unknown obsolete" data-browser="opera63">?</td>
 <td class="no obsolete" data-browser="opera64">No</td>
-<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="yes" data-browser="opera67">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -18958,8 +18805,8 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="unknown obsolete" data-browser="node12_5">?</td>
 <td class="unknown obsolete" data-browser="node12_9">?</td>
 <td class="no" data-browser="node12_11">No</td>
-<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="yes" data-browser="node14_0">Yes</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
@@ -18980,7 +18827,7 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="unknown obsolete" data-browser="samsung9">?</td>
 <td class="unknown" data-browser="samsung10">?</td>
 <td class="unknown" data-browser="samsung11">?</td>
-<td class="no flagged unstable" data-browser="samsung12">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged unstable" data-browser="samsung12">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera_mobile51">?</td>
 <td class="unknown obsolete" data-browser="opera_mobile52">?</td>
 <td class="unknown obsolete" data-browser="opera_mobile53">?</td>
@@ -19035,20 +18882,19 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="unknown obsolete" data-browser="chrome75">?</td>
 <td class="unknown obsolete" data-browser="chrome76">?</td>
 <td class="no obsolete" data-browser="chrome77">No</td>
-<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome80">Yes</td>
 <td class="yes" data-browser="chrome81">Yes</td>
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
-<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -19060,8 +18906,8 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="unknown obsolete" data-browser="opera62">?</td>
 <td class="unknown obsolete" data-browser="opera63">?</td>
 <td class="no obsolete" data-browser="opera64">No</td>
-<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="yes" data-browser="opera67">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -19082,8 +18928,8 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="unknown obsolete" data-browser="node12_5">?</td>
 <td class="unknown obsolete" data-browser="node12_9">?</td>
 <td class="no" data-browser="node12_11">No</td>
-<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
-<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
+<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="yes" data-browser="node14_0">Yes</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
@@ -19104,7 +18950,7 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="unknown obsolete" data-browser="samsung9">?</td>
 <td class="unknown" data-browser="samsung10">?</td>
 <td class="unknown" data-browser="samsung11">?</td>
-<td class="no flagged unstable" data-browser="samsung12">Flag<a href="#chrome-optional-chaining-note"><sup>[30]</sup></a></td>
+<td class="no flagged unstable" data-browser="samsung12">Flag<a href="#chrome-optional-chaining-note"><sup>[29]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera_mobile51">?</td>
 <td class="unknown obsolete" data-browser="opera_mobile52">?</td>
 <td class="unknown obsolete" data-browser="opera_mobile53">?</td>
@@ -19160,20 +19006,19 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="unknown obsolete" data-browser="chrome75">?</td>
 <td class="unknown obsolete" data-browser="chrome76">?</td>
 <td class="no obsolete" data-browser="chrome77">No</td>
-<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-nullish-note"><sup>[31]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-nullish-note"><sup>[31]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome78">Flag<a href="#chrome-nullish-note"><sup>[30]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome79">Flag<a href="#chrome-nullish-note"><sup>[30]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome80">Yes</td>
 <td class="yes" data-browser="chrome81">Yes</td>
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
-<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-nullish-note"><sup>[31]</sup></a></td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-nullish-note"><sup>[30]</sup></a></td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -19185,8 +19030,8 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="unknown obsolete" data-browser="opera62">?</td>
 <td class="unknown obsolete" data-browser="opera63">?</td>
 <td class="no obsolete" data-browser="opera64">No</td>
-<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-nullish-note"><sup>[31]</sup></a></td>
-<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-nullish-note"><sup>[31]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera65">Flag<a href="#chrome-nullish-note"><sup>[30]</sup></a></td>
+<td class="no flagged" data-browser="opera66">Flag<a href="#chrome-nullish-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="opera67">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -19207,15 +19052,15 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="unknown obsolete" data-browser="node12_5">?</td>
 <td class="unknown obsolete" data-browser="node12_9">?</td>
 <td class="no" data-browser="node12_11">No</td>
-<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-nullish-note"><sup>[31]</sup></a></td>
-<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-nullish-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="node13_0">Flag<a href="#chrome-nullish-note"><sup>[30]</sup></a></td>
+<td class="no flagged" data-browser="node13_2">Flag<a href="#chrome-nullish-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="node14_0">Yes</td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
 <td class="unknown obsolete" data-browser="duktape2_2">?</td>
 <td class="unknown" data-browser="duktape2_3">?</td>
 <td class="no" data-browser="graalvm19">No</td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[29]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[28]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -19229,14 +19074,14 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="unknown obsolete" data-browser="samsung9">?</td>
 <td class="unknown" data-browser="samsung10">?</td>
 <td class="unknown" data-browser="samsung11">?</td>
-<td class="no flagged unstable" data-browser="samsung12">Flag<a href="#chrome-nullish-note"><sup>[31]</sup></a></td>
+<td class="no flagged unstable" data-browser="samsung12">Flag<a href="#chrome-nullish-note"><sup>[30]</sup></a></td>
 <td class="unknown obsolete" data-browser="opera_mobile51">?</td>
 <td class="unknown obsolete" data-browser="opera_mobile52">?</td>
 <td class="unknown obsolete" data-browser="opera_mobile53">?</td>
 <td class="unknown" data-browser="opera_mobile54">?</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr class="category"><td colspan="118">Finished (stage 4)</td>
+<tr class="category"><td colspan="117">Finished (stage 4)</td>
 </tr>
 <tr significance="0.25"><td id="test-String.prototype.replaceAll"><span><a class="anchor" href="#test-String.prototype.replaceAll">&#xA7;</a><a href="https://github.com/tc39/proposal-string-replace-all">String.prototype.replaceAll</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &apos;) === &apos;q=query string parameters&apos;;
@@ -19254,9 +19099,9 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown" data-browser="closure20200517">?</td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
-<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[26]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
+<td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_4corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_5corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_6corejs3">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -19284,18 +19129,17 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="chrome77">No</td>
 <td class="no obsolete" data-browser="chrome78">No</td>
 <td class="no obsolete" data-browser="chrome79">No</td>
-<td class="no flagged obsolete" data-browser="chrome80">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[32]</sup></a></td>
-<td class="no flagged" data-browser="chrome81">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[32]</sup></a></td>
-<td class="no flagged" data-browser="chrome83">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[32]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome84">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[32]</sup></a></td>
-<td class="no flagged unstable" data-browser="chrome85">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[32]</sup></a></td>
-<td class="no obsolete" data-browser="edge15">No</td>
+<td class="no flagged obsolete" data-browser="chrome80">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="chrome81">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="chrome83">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[31]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome84">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[31]</sup></a></td>
+<td class="no flagged unstable" data-browser="chrome85">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[31]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no flagged" data-browser="edge80">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[32]</sup></a></td>
-<td class="no flagged" data-browser="edge81">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[32]</sup></a></td>
-<td class="no flagged unstable" data-browser="edge83">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[32]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge80">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="edge81">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[31]</sup></a></td>
+<td class="no flagged" data-browser="edge83">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[31]</sup></a></td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -19309,7 +19153,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="opera64">No</td>
 <td class="no obsolete" data-browser="opera65">No</td>
 <td class="no" data-browser="opera66">No</td>
-<td class="no flagged" data-browser="opera67">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[32]</sup></a></td>
+<td class="no flagged" data-browser="opera67">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[31]</sup></a></td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -19331,13 +19175,13 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no" data-browser="node12_11">No</td>
 <td class="no" data-browser="node13_0">No</td>
 <td class="no" data-browser="node13_2">No</td>
-<td class="no flagged" data-browser="node14_0">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[32]</sup></a></td>
+<td class="no flagged" data-browser="node14_0">Flag<a href="#chrome-string-prototype-replace-all-note"><sup>[31]</sup></a></td>
 <td class="unknown obsolete" data-browser="duktape2_0">?</td>
 <td class="unknown obsolete" data-browser="duktape2_1">?</td>
 <td class="unknown obsolete" data-browser="duktape2_2">?</td>
 <td class="unknown" data-browser="duktape2_3">?</td>
 <td class="no" data-browser="graalvm19">No</td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[29]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-es2020-note"><sup>[28]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -19362,7 +19206,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="chrome-experimental-note">  <sup>[4]</sup> The feature have to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="babel-core-js-note">  <sup>[5]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="typescript-downlevel-iteration-note">  <sup>[9]</sup> Requires the <code>downlevelIteration</code> compile option.</p><p id="strict-fn-non-strict-params-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[12]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[13]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="babel-regenerator-note">  <sup>[14]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="fx-shared-memory-spectre-note">  <sup>[15]</sup> The feature was <a href="https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.  It can be enabled via <code>javascript.options.shared_memory</code> setting under <code>about:config</code></p><p id="firefox-nightly-note">  <sup>[16]</sup> The feature is available only in Firefox Nightly builds.</p><p id="firefox-beta-note">  <sup>[17]</sup> The feature is available only in Firefox Beta, Firefox Developer Edition and Firefox Nightly builds.</p><p id="edge-experimental-flag-note">  <sup>[18]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="edg-shared-memory-spectre-note">  <sup>[19]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="sf-shared-memory-spectre-note">  <sup>[20]</sup> The feature was <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-sharedmem-note">  <sup>[21]</sup> The feature have to be enabled via &quot;Experimental enabled SharedArrayBuffer support in JavaScript.&quot; setting under <code>about:flags</code></p><p id="chr-shared-memory-spectre-note">  <sup>[22]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-harmony-note">  <sup>[23]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="closure-object-assign-note">  <sup>[24]</sup> Requires native support for <code>Object.assign</code></p><p id="chrome-promise-note">  <sup>[25]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-promise-finally&quot;</code> flag</p><p id="typescript-es6-note">  <sup>[26]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="flatten-compat-issue-note">  <sup>[27]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="ffox-flatten-note">  <sup>[28]</sup> Older Firefox Nightly builds support only the obsolete draft function name <code>Array.prototype.flatten()</code>.</p><p id="graalvm-es2020-note">  <sup>[29]</sup> The feature have to be enabled via <code>--js.ecmascript-version=2020</code> flag</p><p id="chrome-optional-chaining-note">  <sup>[30]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony-optional-chaining&quot;</code> flag</p><p id="chrome-nullish-note">  <sup>[31]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony-nullish&quot;</code> flag</p><p id="chrome-string-prototype-replace-all-note">  <sup>[32]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-string-replaceall&quot;</code> flag</p></div>
+    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="chrome-experimental-note">  <sup>[4]</sup> The feature have to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="babel-core-js-note">  <sup>[5]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="typescript-downlevel-iteration-note">  <sup>[9]</sup> Requires the <code>downlevelIteration</code> compile option.</p><p id="strict-fn-non-strict-params-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[12]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[13]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="babel-regenerator-note">  <sup>[14]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="fx-shared-memory-spectre-note">  <sup>[15]</sup> The feature was <a href="https://blog.mozilla.org/security/2018/01/03/mitigations-landing-new-class-timing-attack/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.  It can be enabled via <code>javascript.options.shared_memory</code> setting under <code>about:config</code></p><p id="firefox-nightly-note">  <sup>[16]</sup> The feature is available only in Firefox Nightly builds.</p><p id="firefox-beta-note">  <sup>[17]</sup> The feature is available only in Firefox Beta, Firefox Developer Edition and Firefox Nightly builds.</p><p id="edg-shared-memory-spectre-note">  <sup>[18]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="sf-shared-memory-spectre-note">  <sup>[19]</sup> The feature was <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-sharedmem-note">  <sup>[20]</sup> The feature have to be enabled via &quot;Experimental enabled SharedArrayBuffer support in JavaScript.&quot; setting under <code>about:flags</code></p><p id="chr-shared-memory-spectre-note">  <sup>[21]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-harmony-note">  <sup>[22]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="closure-object-assign-note">  <sup>[23]</sup> Requires native support for <code>Object.assign</code></p><p id="chrome-promise-note">  <sup>[24]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-promise-finally&quot;</code> flag</p><p id="typescript-es6-note">  <sup>[25]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="flatten-compat-issue-note">  <sup>[26]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="ffox-flatten-note">  <sup>[27]</sup> Older Firefox Nightly builds support only the obsolete draft function name <code>Array.prototype.flatten()</code>.</p><p id="graalvm-es2020-note">  <sup>[28]</sup> The feature have to be enabled via <code>--js.ecmascript-version=2020</code> flag</p><p id="chrome-optional-chaining-note">  <sup>[29]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony-optional-chaining&quot;</code> flag</p><p id="chrome-nullish-note">  <sup>[30]</sup> The feature have to be enabled via <code>--js-flags=&quot;--harmony-nullish&quot;</code> flag</p><p id="chrome-string-prototype-replace-all-note">  <sup>[31]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-string-replaceall&quot;</code> flag</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
 </body>

--- a/es5/index.html
+++ b/es5/index.html
@@ -157,13 +157,12 @@
 <th class="platform chrome83 desktop" data-browser="chrome83"><a href="#chrome83" class="browser-name"><abbr title="Chrome 83">CH 83</abbr></a></th>
 <th class="platform chrome84 desktop unstable" data-browser="chrome84"><a href="#chrome84" class="browser-name"><abbr title="Chrome 84 Beta">CH 84</abbr></a></th>
 <th class="platform chrome85 desktop unstable" data-browser="chrome85"><a href="#chrome85" class="browser-name"><abbr title="Chrome 85 Canary">CH 85</abbr></a></th>
-<th class="platform edge15 desktop obsolete" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge 15">Edge 15</abbr></a></th>
 <th class="platform edge17 desktop obsolete" data-browser="edge17"><a href="#edge17" class="browser-name"><abbr title="Microsoft Edge 17">Edge 17</abbr></a></th>
 <th class="platform edge18 desktop" data-browser="edge18"><a href="#edge18" class="browser-name"><abbr title="Microsoft Edge 18">Edge 18</abbr></a></th>
 <th class="platform edge79 desktop obsolete" data-browser="edge79"><a href="#edge79" class="browser-name"><abbr title="Microsoft Edge 79">Edge 79</abbr></a></th>
-<th class="platform edge80 desktop" data-browser="edge80"><a href="#edge80" class="browser-name"><abbr title="Microsoft Edge 80">Edge 80</abbr></a></th>
+<th class="platform edge80 desktop obsolete" data-browser="edge80"><a href="#edge80" class="browser-name"><abbr title="Microsoft Edge 80">Edge 80</abbr></a></th>
 <th class="platform edge81 desktop" data-browser="edge81"><a href="#edge81" class="browser-name"><abbr title="Microsoft Edge 81">Edge 81</abbr></a></th>
-<th class="platform edge83 desktop unstable" data-browser="edge83"><a href="#edge83" class="browser-name"><abbr title="Microsoft Edge 83 Beta">Edge 83 Beta</abbr></a></th>
+<th class="platform edge83 desktop" data-browser="edge83"><a href="#edge83" class="browser-name"><abbr title="Microsoft Edge 83">Edge 83</abbr></a></th>
 <th class="platform safari11_1 desktop obsolete" data-browser="safari11_1"><a href="#safari11_1" class="browser-name"><abbr title="Safari 11.1">SF 11.1</abbr></a></th>
 <th class="platform safari12 desktop obsolete" data-browser="safari12"><a href="#safari12" class="browser-name"><abbr title="Safari 12">SF 12</abbr></a></th>
 <th class="platform safari12_1 desktop obsolete" data-browser="safari12_1"><a href="#safari12_1" class="browser-name"><abbr title="Safari 12.1">SF&#xA0;12.1</abbr></a></th>
@@ -276,13 +275,12 @@
 <td class="tally" data-browser="chrome83" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge18" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">5/5</td>
-<td class="tally" data-browser="edge80" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">5/5</td>
 <td class="tally" data-browser="edge81" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">5/5</td>
+<td class="tally" data-browser="edge83" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">5/5</td>
@@ -394,13 +392,12 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -514,13 +511,12 @@ return value === 1;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -632,13 +628,12 @@ return { a: true, }.a === true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -750,13 +745,12 @@ return [1,].length === 1;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -868,13 +862,12 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -951,7 +944,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr><th colspan="116" class="separator"></th>
+<tr><th colspan="115" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
@@ -985,13 +978,12 @@ return ({ if: 1 }).if === 1;
 <td class="tally" data-browser="chrome83" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">13/13</td>
 <td class="tally" data-browser="edge18" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">13/13</td>
-<td class="tally" data-browser="edge80" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">13/13</td>
 <td class="tally" data-browser="edge81" data-tally="1">13/13</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">13/13</td>
+<td class="tally" data-browser="edge83" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">13/13</td>
@@ -1105,13 +1097,12 @@ return typeof Object.create === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1225,13 +1216,12 @@ return typeof Object.defineProperty === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1345,13 +1335,12 @@ return typeof Object.defineProperties === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1465,13 +1454,12 @@ return typeof Object.getPrototypeOf === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1585,13 +1573,12 @@ return typeof Object.keys === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1705,13 +1692,12 @@ return typeof Object.seal === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1825,13 +1811,12 @@ return typeof Object.freeze === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1945,13 +1930,12 @@ return typeof Object.preventExtensions === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2065,13 +2049,12 @@ return typeof Object.isSealed === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2185,13 +2168,12 @@ return typeof Object.isFrozen === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2305,13 +2287,12 @@ return typeof Object.isExtensible === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2425,13 +2406,12 @@ return typeof Object.getOwnPropertyDescriptor === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2545,13 +2525,12 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2660,13 +2639,12 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="tally" data-browser="chrome83" data-tally="1">12/12</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">12/12</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">12/12</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">12/12</td>
 <td class="tally" data-browser="edge18" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">12/12</td>
-<td class="tally" data-browser="edge80" data-tally="1">12/12</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">12/12</td>
 <td class="tally" data-browser="edge81" data-tally="1">12/12</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">12/12</td>
+<td class="tally" data-browser="edge83" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">12/12</td>
@@ -2780,13 +2758,12 @@ return typeof Array.isArray === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2900,13 +2877,12 @@ return typeof Array.prototype.indexOf === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3020,13 +2996,12 @@ return typeof Array.prototype.lastIndexOf === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3140,13 +3115,12 @@ return typeof Array.prototype.every === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3260,13 +3234,12 @@ return typeof Array.prototype.some === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3380,13 +3353,12 @@ return typeof Array.prototype.forEach === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3500,13 +3472,12 @@ return typeof Array.prototype.map === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3620,13 +3591,12 @@ return typeof Array.prototype.filter === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3740,13 +3710,12 @@ return typeof Array.prototype.reduce === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3860,13 +3829,12 @@ return typeof Array.prototype.reduceRight === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4020,13 +3988,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4150,13 +4117,12 @@ try {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4265,13 +4231,12 @@ try {
 <td class="tally" data-browser="chrome83" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge18" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">2/2</td>
-<td class="tally" data-browser="edge80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge81" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge83" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">2/2</td>
@@ -4385,13 +4350,12 @@ return "foobar"[3] === "b";
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4505,13 +4469,12 @@ return typeof String.prototype.trim === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4620,13 +4583,12 @@ return typeof String.prototype.trim === 'function';
 <td class="tally" data-browser="chrome83" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge18" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">3/3</td>
-<td class="tally" data-browser="edge80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge81" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge83" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">3/3</td>
@@ -4740,13 +4702,12 @@ return typeof Date.prototype.toISOString === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4860,13 +4821,12 @@ return typeof Date.now === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4988,13 +4948,12 @@ try {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -5108,13 +5067,12 @@ return typeof Function.prototype.bind === 'function';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -5228,13 +5186,12 @@ return typeof JSON === 'object';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -5311,7 +5268,7 @@ return typeof JSON === 'object';
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr><th colspan="116" class="separator"></th>
+<tr><th colspan="115" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -5345,13 +5302,12 @@ return typeof JSON === 'object';
 <td class="tally" data-browser="chrome83" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge18" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">3/3</td>
-<td class="tally" data-browser="edge80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge81" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge83" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">3/3</td>
@@ -5466,13 +5422,12 @@ return result;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -5587,13 +5542,12 @@ return result;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -5708,13 +5662,12 @@ return result;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -5823,13 +5776,12 @@ return result;
 <td class="tally" data-browser="chrome83" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">8/8</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">8/8</td>
 <td class="tally" data-browser="edge18" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">8/8</td>
-<td class="tally" data-browser="edge80" data-tally="1">8/8</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">8/8</td>
 <td class="tally" data-browser="edge81" data-tally="1">8/8</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">8/8</td>
+<td class="tally" data-browser="edge83" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
@@ -5951,13 +5903,12 @@ try {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -6071,13 +6022,12 @@ return parseInt('010') === 10;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -6189,13 +6139,12 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -6307,13 +6256,12 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -6426,13 +6374,12 @@ return _\u200c\u200d;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -6546,13 +6493,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -6672,13 +6618,12 @@ return result;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -6796,13 +6741,12 @@ catch(e) {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -6911,13 +6855,12 @@ catch(e) {
 <td class="tally" data-browser="chrome83" data-tally="1">19/19</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">19/19</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">19/19</td>
 <td class="tally" data-browser="edge18" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">19/19</td>
-<td class="tally" data-browser="edge80" data-tally="1">19/19</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">19/19</td>
 <td class="tally" data-browser="edge81" data-tally="1">19/19</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">19/19</td>
+<td class="tally" data-browser="edge83" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">19/19</td>
@@ -7034,13 +6977,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -7153,13 +7095,12 @@ return this === void undefined &amp;&amp; (function(){ return this === void unde
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="edge17">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
 <td class="yes" data-browser="edge18">Yes<a href="#strict-mode-ie10-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -7274,13 +7215,12 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -7409,13 +7349,12 @@ return test(String, &apos;&apos;)
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -7530,13 +7469,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -7649,13 +7587,12 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -7772,13 +7709,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -7895,13 +7831,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8020,13 +7955,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8142,13 +8076,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8262,13 +8195,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8383,13 +8315,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8508,13 +8439,12 @@ return (function(x){
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8627,13 +8557,12 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8746,13 +8675,12 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8865,13 +8793,12 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -8984,13 +8911,12 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -9103,13 +9029,12 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -9222,13 +9147,12 @@ return typeof foo === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -161,13 +161,12 @@
 <th class="platform chrome83 desktop" data-browser="chrome83"><a href="#chrome83" class="browser-name"><abbr title="Chrome 83">CH 83</abbr></a></th>
 <th class="platform chrome84 desktop unstable" data-browser="chrome84"><a href="#chrome84" class="browser-name"><abbr title="Chrome 84 Beta">CH 84</abbr></a></th>
 <th class="platform chrome85 desktop unstable" data-browser="chrome85"><a href="#chrome85" class="browser-name"><abbr title="Chrome 85 Canary">CH 85</abbr></a></th>
-<th class="platform edge15 desktop obsolete" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge 15">Edge 15</abbr></a></th>
 <th class="platform edge17 desktop obsolete" data-browser="edge17"><a href="#edge17" class="browser-name"><abbr title="Microsoft Edge 17">Edge 17</abbr></a></th>
 <th class="platform edge18 desktop" data-browser="edge18"><a href="#edge18" class="browser-name"><abbr title="Microsoft Edge 18">Edge 18</abbr></a></th>
 <th class="platform edge79 desktop obsolete" data-browser="edge79"><a href="#edge79" class="browser-name"><abbr title="Microsoft Edge 79">Edge 79</abbr></a></th>
-<th class="platform edge80 desktop" data-browser="edge80"><a href="#edge80" class="browser-name"><abbr title="Microsoft Edge 80">Edge 80</abbr></a></th>
+<th class="platform edge80 desktop obsolete" data-browser="edge80"><a href="#edge80" class="browser-name"><abbr title="Microsoft Edge 80">Edge 80</abbr></a></th>
 <th class="platform edge81 desktop" data-browser="edge81"><a href="#edge81" class="browser-name"><abbr title="Microsoft Edge 81">Edge 81</abbr></a></th>
-<th class="platform edge83 desktop unstable" data-browser="edge83"><a href="#edge83" class="browser-name"><abbr title="Microsoft Edge 83 Beta">Edge 83 Beta</abbr></a></th>
+<th class="platform edge83 desktop" data-browser="edge83"><a href="#edge83" class="browser-name"><abbr title="Microsoft Edge 83">Edge 83</abbr></a></th>
 <th class="platform safari11_1 desktop obsolete" data-browser="safari11_1"><a href="#safari11_1" class="browser-name"><abbr title="Safari 11.1">SF 11.1</abbr></a></th>
 <th class="platform safari12 desktop obsolete" data-browser="safari12"><a href="#safari12" class="browser-name"><abbr title="Safari 12">SF 12</abbr></a></th>
 <th class="platform safari12_1 desktop obsolete" data-browser="safari12_1"><a href="#safari12_1" class="browser-name"><abbr title="Safari 12.1">SF&#xA0;12.1</abbr></a></th>
@@ -263,13 +262,12 @@
 <td class="tally" data-browser="chrome83" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge18" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">2/2</td>
-<td class="tally" data-browser="edge80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge81" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge83" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">2/2</td>
@@ -364,13 +362,12 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -465,13 +462,12 @@ return Intl.constructor === Object;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -563,13 +559,12 @@ return Intl.constructor === Object;
 <td class="tally" data-browser="chrome83" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="edge18" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally" data-browser="edge80" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="edge81" data-tally="1">5/5</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">5/5</td>
+<td class="tally" data-browser="edge83" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
@@ -664,13 +659,12 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -765,13 +759,12 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -866,13 +859,12 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -989,13 +981,12 @@ try {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1106,13 +1097,12 @@ try {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="unknown obsolete" data-browser="edge15">?</td>
 <td class="unknown obsolete" data-browser="edge17">?</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="unknown obsolete" data-browser="edge79">?</td>
-<td class="unknown" data-browser="edge80">?</td>
+<td class="unknown obsolete" data-browser="edge80">?</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1204,13 +1194,12 @@ try {
 <td class="tally" data-browser="chrome83" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">1/1</td>
-<td class="tally" data-browser="edge80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge81" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge83" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">1/1</td>
@@ -1305,13 +1294,12 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1403,13 +1391,12 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally" data-browser="chrome83" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">1/1</td>
-<td class="tally" data-browser="edge80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge81" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge83" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">1/1</td>
@@ -1504,13 +1491,12 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1602,13 +1588,12 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally" data-browser="chrome83" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally" data-browser="edge18" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally" data-browser="edge80" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally" data-browser="edge81" data-tally="1">6/6</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">6/6</td>
+<td class="tally" data-browser="edge83" data-tally="1">6/6</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
@@ -1703,13 +1688,12 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1804,13 +1788,12 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -1905,13 +1888,12 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2006,13 +1988,12 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2129,13 +2110,12 @@ try {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2246,13 +2226,12 @@ try {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="unknown obsolete" data-browser="edge15">?</td>
 <td class="unknown obsolete" data-browser="edge17">?</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="unknown obsolete" data-browser="edge79">?</td>
-<td class="unknown" data-browser="edge80">?</td>
+<td class="unknown obsolete" data-browser="edge80">?</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2344,13 +2323,12 @@ try {
 <td class="tally" data-browser="chrome83" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">7/7</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally" data-browser="edge18" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
-<td class="tally" data-browser="edge80" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally" data-browser="edge81" data-tally="1">7/7</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">7/7</td>
+<td class="tally" data-browser="edge83" data-tally="1">7/7</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
@@ -2445,13 +2423,12 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2546,13 +2523,12 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2647,13 +2623,12 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2770,13 +2745,12 @@ try {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -2887,13 +2861,12 @@ try {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="unknown obsolete" data-browser="edge15">?</td>
 <td class="unknown obsolete" data-browser="edge17">?</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="unknown obsolete" data-browser="edge79">?</td>
-<td class="unknown" data-browser="edge80">?</td>
+<td class="unknown obsolete" data-browser="edge80">?</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2989,13 +2962,12 @@ return tz !== void undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3098,13 +3070,12 @@ try {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3196,13 +3167,12 @@ try {
 <td class="tally" data-browser="chrome83" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">1/1</td>
-<td class="tally" data-browser="edge80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge81" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge83" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">1/1</td>
@@ -3297,13 +3267,12 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3395,13 +3364,12 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally" data-browser="chrome83" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">1/1</td>
-<td class="tally" data-browser="edge80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge81" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge83" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">1/1</td>
@@ -3496,13 +3464,12 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3594,13 +3561,12 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="chrome83" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">1/1</td>
-<td class="tally" data-browser="edge80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge81" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge83" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">1/1</td>
@@ -3695,13 +3661,12 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3793,13 +3758,12 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="chrome83" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">1/1</td>
-<td class="tally" data-browser="edge80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge81" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge83" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">1/1</td>
@@ -3894,13 +3858,12 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3992,13 +3955,12 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="chrome83" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">1/1</td>
-<td class="tally" data-browser="edge80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge81" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge83" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">1/1</td>
@@ -4093,13 +4055,12 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4191,13 +4152,12 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="chrome83" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">1/1</td>
-<td class="tally" data-browser="edge80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge81" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge83" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">1/1</td>
@@ -4292,13 +4252,12 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -4390,13 +4349,12 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally" data-browser="chrome83" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">1/1</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge18" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">1/1</td>
-<td class="tally" data-browser="edge80" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">1/1</td>
 <td class="tally" data-browser="edge81" data-tally="1">1/1</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">1/1</td>
+<td class="tally" data-browser="edge83" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">1/1</td>
@@ -4491,13 +4449,12 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -175,13 +175,12 @@
 <th class="platform chrome83 desktop" data-browser="chrome83"><a href="#chrome83" class="browser-name"><abbr title="Chrome 83">CH 83</abbr></a></th>
 <th class="platform chrome84 desktop unstable" data-browser="chrome84"><a href="#chrome84" class="browser-name"><abbr title="Chrome 84 Beta">CH 84</abbr></a></th>
 <th class="platform chrome85 desktop unstable" data-browser="chrome85"><a href="#chrome85" class="browser-name"><abbr title="Chrome 85 Canary">CH 85</abbr></a></th>
-<th class="platform edge15 desktop obsolete" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge 15">Edge 15</abbr></a></th>
 <th class="platform edge17 desktop obsolete" data-browser="edge17"><a href="#edge17" class="browser-name"><abbr title="Microsoft Edge 17">Edge 17</abbr></a></th>
 <th class="platform edge18 desktop" data-browser="edge18"><a href="#edge18" class="browser-name"><abbr title="Microsoft Edge 18">Edge 18</abbr></a></th>
 <th class="platform edge79 desktop obsolete" data-browser="edge79"><a href="#edge79" class="browser-name"><abbr title="Microsoft Edge 79">Edge 79</abbr></a></th>
-<th class="platform edge80 desktop" data-browser="edge80"><a href="#edge80" class="browser-name"><abbr title="Microsoft Edge 80">Edge 80</abbr></a></th>
+<th class="platform edge80 desktop obsolete" data-browser="edge80"><a href="#edge80" class="browser-name"><abbr title="Microsoft Edge 80">Edge 80</abbr></a></th>
 <th class="platform edge81 desktop" data-browser="edge81"><a href="#edge81" class="browser-name"><abbr title="Microsoft Edge 81">Edge 81</abbr></a></th>
-<th class="platform edge83 desktop unstable" data-browser="edge83"><a href="#edge83" class="browser-name"><abbr title="Microsoft Edge 83 Beta">Edge 83 Beta</abbr></a></th>
+<th class="platform edge83 desktop" data-browser="edge83"><a href="#edge83" class="browser-name"><abbr title="Microsoft Edge 83">Edge 83</abbr></a></th>
 <th class="platform safari11_1 desktop obsolete" data-browser="safari11_1"><a href="#safari11_1" class="browser-name"><abbr title="Safari 11.1">SF 11.1</abbr></a></th>
 <th class="platform safari12 desktop obsolete" data-browser="safari12"><a href="#safari12" class="browser-name"><abbr title="Safari 12">SF 12</abbr></a></th>
 <th class="platform safari12_1 desktop obsolete" data-browser="safari12_1"><a href="#safari12_1" class="browser-name"><abbr title="Safari 12.1">SF&#xA0;12.1</abbr></a></th>
@@ -248,7 +247,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="116">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="115">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-WeakReferences"><span><a class="anchor" href="#test-WeakReferences">&#xA7;</a><a href="https://github.com/tc39/proposal-weakrefs">WeakReferences</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -296,13 +295,12 @@
 <td class="tally" data-browser="chrome83" data-tally="0" data-flagged-tally="0.5">0/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="0" data-flagged-tally="0.5">0/2</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0" data-flagged-tally="0.5">0/2</td>
-<td class="tally" data-browser="edge80" data-tally="0" data-flagged-tally="0.5">0/2</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0" data-flagged-tally="0.5">0/2</td>
 <td class="tally" data-browser="edge81" data-tally="0" data-flagged-tally="0.5">0/2</td>
-<td class="tally unstable" data-browser="edge83" data-tally="0" data-flagged-tally="0.5">0/2</td>
+<td class="tally" data-browser="edge83" data-tally="0" data-flagged-tally="0.5">0/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/2</td>
@@ -416,13 +414,12 @@ return weakref.deref() === O;
 <td class="no flagged" data-browser="chrome83">Flag<a href="#chrome-weakrefs-note"><sup>[5]</sup></a></td>
 <td class="no flagged unstable" data-browser="chrome84">Flag<a href="#chrome-weakrefs-note"><sup>[5]</sup></a></td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-weakrefs-note"><sup>[5]</sup></a></td>
-<td class="no flagged" data-browser="edge80">Flag<a href="#chrome-weakrefs-note"><sup>[5]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge80">Flag<a href="#chrome-weakrefs-note"><sup>[5]</sup></a></td>
 <td class="no flagged" data-browser="edge81">Flag<a href="#chrome-weakrefs-note"><sup>[5]</sup></a></td>
-<td class="no flagged unstable" data-browser="edge83">Flag<a href="#chrome-weakrefs-note"><sup>[5]</sup></a></td>
+<td class="no flagged" data-browser="edge83">Flag<a href="#chrome-weakrefs-note"><sup>[5]</sup></a></td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -535,13 +532,12 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -650,13 +646,12 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally" data-browser="chrome83" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">6/6</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/6</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)" data-flagged-tally="0.8333333333333334">4/6</td>
-<td class="tally" data-browser="edge80" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally" data-browser="edge81" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
-<td class="tally unstable" data-browser="edge83" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td class="tally" data-browser="edge83" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/6</td>
@@ -771,13 +766,12 @@ return new C().x === &apos;x&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -898,13 +892,12 @@ return new C(42).x() === 42;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1022,13 +1015,12 @@ return new C().x() === 42;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1146,13 +1138,12 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="no" data-browser="chrome83">No</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -1270,13 +1261,12 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-optional-chaining-note"><sup>[10]</sup></a></td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -1391,13 +1381,12 @@ return new C().x === 42;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1506,13 +1495,12 @@ return new C().x === 42;
 <td class="tally" data-browser="chrome83" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/3</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">3/3</td>
-<td class="tally" data-browser="edge80" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">3/3</td>
 <td class="tally" data-browser="edge81" data-tally="1">3/3</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">3/3</td>
+<td class="tally" data-browser="edge83" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/3</td>
@@ -1627,13 +1615,12 @@ return C.x === &apos;x&apos;;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1751,13 +1738,12 @@ return new C().x() === 42;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1872,13 +1858,12 @@ return C.x === 42;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1987,13 +1972,12 @@ return C.x === 42;
 <td class="tally" data-browser="chrome83" data-tally="0" data-flagged-tally="1">0/4</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">4/4</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally" data-browser="edge80" data-tally="0" data-flagged-tally="1">0/4</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0" data-flagged-tally="1">0/4</td>
 <td class="tally" data-browser="edge81" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally unstable" data-browser="edge83" data-tally="0" data-flagged-tally="1">0/4</td>
+<td class="tally" data-browser="edge83" data-tally="0" data-flagged-tally="1">0/4</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/4</td>
@@ -2111,13 +2095,12 @@ return new C().x() === 42;
 <td class="no flagged" data-browser="chrome83">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="edge80">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge80">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
 <td class="no flagged" data-browser="edge81">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged unstable" data-browser="edge83">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="edge83">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2235,13 +2218,12 @@ return new C().x() === 42;
 <td class="no flagged" data-browser="chrome83">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="edge80">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge80">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
 <td class="no flagged" data-browser="edge81">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged unstable" data-browser="edge83">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="edge83">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2362,13 +2344,12 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="no flagged" data-browser="chrome83">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="edge80">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge80">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
 <td class="no flagged" data-browser="edge81">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged unstable" data-browser="edge83">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="edge83">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2489,13 +2470,12 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="no flagged" data-browser="chrome83">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no flagged obsolete" data-browser="edge79">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="edge80">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge80">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
 <td class="no flagged" data-browser="edge81">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
-<td class="no flagged unstable" data-browser="edge83">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="edge83">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2608,13 +2588,12 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2732,13 +2711,12 @@ Promise.any([
 <td class="no" data-browser="chrome83">No</td>
 <td class="no flagged unstable" data-browser="chrome84">Flag<a href="#chrome-promise-any-note"><sup>[16]</sup></a></td>
 <td class="no flagged unstable" data-browser="chrome85">Flag<a href="#chrome-promise-any-note"><sup>[16]</sup></a></td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2847,13 +2825,12 @@ Promise.any([
 <td class="tally" data-browser="chrome83" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="1">2/2</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge18" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="1">2/2</td>
-<td class="tally" data-browser="edge80" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="1">2/2</td>
 <td class="tally" data-browser="edge81" data-tally="1">2/2</td>
-<td class="tally unstable" data-browser="edge83" data-tally="1">2/2</td>
+<td class="tally" data-browser="edge83" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="1">2/2</td>
@@ -2971,13 +2948,12 @@ return RegExp.lastMatch === 'x';
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3097,13 +3073,12 @@ return true;
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -3212,13 +3187,12 @@ return true;
 <td class="tally" data-browser="chrome83" data-tally="0">0/9</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="0" data-flagged-tally="1">0/9</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/9</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0">0/9</td>
-<td class="tally" data-browser="edge80" data-tally="0">0/9</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0">0/9</td>
 <td class="tally" data-browser="edge81" data-tally="0">0/9</td>
-<td class="tally unstable" data-browser="edge83" data-tally="0">0/9</td>
+<td class="tally" data-browser="edge83" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/9</td>
@@ -3336,13 +3310,12 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no flagged unstable" data-browser="chrome84">Flag<a href="#chrome-logical-assignment-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="unknown obsolete" data-browser="edge79">?</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -3457,13 +3430,12 @@ return a === 1 &amp;&amp; i === 1;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no flagged unstable" data-browser="chrome84">Flag<a href="#chrome-logical-assignment-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="unknown obsolete" data-browser="edge79">?</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -3578,13 +3550,12 @@ return i === 1;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no flagged unstable" data-browser="chrome84">Flag<a href="#chrome-logical-assignment-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="unknown obsolete" data-browser="edge79">?</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -3702,13 +3673,12 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no flagged unstable" data-browser="chrome84">Flag<a href="#chrome-logical-assignment-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="unknown obsolete" data-browser="edge79">?</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -3823,13 +3793,12 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no flagged unstable" data-browser="chrome84">Flag<a href="#chrome-logical-assignment-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="unknown obsolete" data-browser="edge79">?</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -3944,13 +3913,12 @@ return i === 1;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no flagged unstable" data-browser="chrome84">Flag<a href="#chrome-logical-assignment-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="unknown obsolete" data-browser="edge79">?</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4068,13 +4036,12 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no flagged unstable" data-browser="chrome84">Flag<a href="#chrome-logical-assignment-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="unknown obsolete" data-browser="edge79">?</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4189,13 +4156,12 @@ return a === 1 &amp;&amp; i === 1;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no flagged unstable" data-browser="chrome84">Flag<a href="#chrome-logical-assignment-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="unknown obsolete" data-browser="edge79">?</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4310,13 +4276,12 @@ return i === 1;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no flagged unstable" data-browser="chrome84">Flag<a href="#chrome-logical-assignment-note"><sup>[17]</sup></a></td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="unknown obsolete" data-browser="edge79">?</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4432,13 +4397,12 @@ try {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -4501,7 +4465,7 @@ try {
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="116">Draft (stage 2)</td>
+<tr class="category"><td colspan="115">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/tc39/proposal-function.sent">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -4558,13 +4522,12 @@ return result === &apos;tromple&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4673,13 +4636,12 @@ return result === &apos;tromple&apos;;
 <td class="tally" data-browser="chrome83" data-tally="0">0/1</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="0">0/1</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/1</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0">0/1</td>
-<td class="tally" data-browser="edge80" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0">0/1</td>
 <td class="tally" data-browser="edge81" data-tally="0">0/1</td>
-<td class="tally unstable" data-browser="edge83" data-tally="0">0/1</td>
+<td class="tally" data-browser="edge83" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/1</td>
@@ -4799,13 +4761,12 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4920,13 +4881,12 @@ return typeof Realm === &quot;function&quot;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5035,13 +4995,12 @@ return typeof Realm === &quot;function&quot;
 <td class="tally" data-browser="chrome83" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0">0/4</td>
-<td class="tally" data-browser="edge80" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge81" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="edge83" data-tally="0">0/4</td>
+<td class="tally" data-browser="edge83" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/4</td>
@@ -5159,13 +5118,12 @@ try {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5287,13 +5245,12 @@ try {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5410,13 +5367,12 @@ try {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5533,13 +5489,12 @@ try {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5648,13 +5603,12 @@ try {
 <td class="tally" data-browser="chrome83" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="0">0/7</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/7</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0">0/7</td>
-<td class="tally" data-browser="edge80" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0">0/7</td>
 <td class="tally" data-browser="edge81" data-tally="0">0/7</td>
-<td class="tally unstable" data-browser="edge83" data-tally="0">0/7</td>
+<td class="tally" data-browser="edge83" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/7</td>
@@ -5769,13 +5723,12 @@ return set.size === 2
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5891,13 +5844,12 @@ return set.size === 3
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -6012,13 +5964,12 @@ return set.size === 2
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -6133,13 +6084,12 @@ return set.size === 2
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -6251,13 +6201,12 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -6369,13 +6318,12 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -6487,13 +6435,12 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -6602,13 +6549,12 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally" data-browser="chrome83" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge80" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge81" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="edge83" data-tally="0">0/2</td>
+<td class="tally" data-browser="edge83" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/2</td>
@@ -6723,13 +6669,12 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -6844,13 +6789,12 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -6959,13 +6903,12 @@ return buffer1.byteLength === 0
 <td class="tally" data-browser="chrome83" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge80" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge81" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="edge83" data-tally="0">0/2</td>
+<td class="tally" data-browser="edge83" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/2</td>
@@ -7080,13 +7023,12 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -7202,13 +7144,12 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -7321,13 +7262,12 @@ return !Array.isTemplateObject([])
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -7436,13 +7376,12 @@ return !Array.isTemplateObject([])
 <td class="tally" data-browser="chrome83" data-tally="0">0/35</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="0">0/35</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="0">0/35</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/35</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0">0/35</td>
-<td class="tally" data-browser="edge80" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0">0/35</td>
 <td class="tally" data-browser="edge81" data-tally="0">0/35</td>
-<td class="tally unstable" data-browser="edge83" data-tally="0">0/35</td>
+<td class="tally" data-browser="edge83" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/35</td>
@@ -7554,13 +7493,12 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -7674,13 +7612,12 @@ return instance[Symbol.iterator]() === instance;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -7795,13 +7732,12 @@ return &apos;next&apos; in iterator
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -7921,13 +7857,12 @@ return &apos;next&apos; in iterator
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -8039,13 +7974,12 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -8157,13 +8091,12 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -8275,13 +8208,12 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -8393,13 +8325,12 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -8511,13 +8442,12 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -8629,13 +8559,12 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -8749,13 +8678,12 @@ return result === &apos;123&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -8867,13 +8795,12 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -8985,13 +8912,12 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -9103,13 +9029,12 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -9221,13 +9146,12 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -9340,13 +9264,12 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -9458,13 +9381,12 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -9576,13 +9498,12 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -9696,13 +9617,12 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -9826,13 +9746,12 @@ toArray(iterator).then(it =&gt; {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -9956,13 +9875,12 @@ toArray(iterator).then(it =&gt; {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -10086,13 +10004,12 @@ toArray(iterator).then(it =&gt; {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -10212,13 +10129,12 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -10338,13 +10254,12 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -10458,13 +10373,12 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -10584,13 +10498,12 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -10704,13 +10617,12 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -10830,13 +10742,12 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -10951,13 +10862,12 @@ let result = &apos;&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -11077,13 +10987,12 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -11197,13 +11106,12 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -11317,13 +11225,12 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -11443,13 +11350,12 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -11563,13 +11469,12 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -11681,13 +11586,12 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -11750,7 +11654,7 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="unknown" data-browser="opera_mobile54">?</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr class="category"><td colspan="116">Proposal (stage 1)</td>
+<tr class="category"><td colspan="115">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25" class="optional-feature"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="https://github.com/tc39/proposal-do-expressions">do expressions</a></span><script data-source="
 return do {
@@ -11804,13 +11708,12 @@ return do {
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -11919,13 +11822,12 @@ return do {
 <td class="tally not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -12037,13 +11939,12 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12155,13 +12056,12 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12273,13 +12173,12 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12401,13 +12300,12 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12520,13 +12418,12 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12638,13 +12535,12 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12756,13 +12652,12 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12875,13 +12770,12 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12997,13 +12891,12 @@ return Math.signbit(NaN) === false
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13112,13 +13005,12 @@ return Math.signbit(NaN) === false
 <td class="tally not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -13232,13 +13124,12 @@ return Math.clamp(2, 4, 6) === 4
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13350,13 +13241,12 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13469,13 +13359,12 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13587,13 +13476,12 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13705,13 +13593,12 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13824,13 +13711,12 @@ return Math.radians(90) === Math.PI / 2
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13942,13 +13828,12 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14057,13 +13942,12 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -14175,13 +14059,12 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14293,13 +14176,12 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14413,13 +14295,12 @@ return score === 1;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14538,13 +14419,12 @@ Promise.try(function() {
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14663,13 +14543,12 @@ Promise.try(function() {
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14788,13 +14667,12 @@ Promise.try(function() {
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14913,13 +14791,12 @@ Promise.try(function() {
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15028,13 +14905,12 @@ Promise.try(function() {
 <td class="tally not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
-<td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
-<td class="tally not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
+<td class="tally obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
-<td class="tally unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
+<td class="tally not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
@@ -15149,13 +15025,12 @@ return C.get(A) + C.get(B) === 3;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15272,13 +15147,12 @@ return C.get(A) + C.get(B) === 5;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15393,13 +15267,12 @@ return C.has(A) + C.has(B);
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15514,13 +15387,12 @@ return C.has(3) + C.has(4);
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15635,13 +15507,12 @@ return C.get(A) + C.get(B) === 3;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15758,13 +15629,12 @@ return C.get(A) + C.get(B) === 5;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15879,13 +15749,12 @@ return C.has(A) + C.has(B);
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16000,13 +15869,12 @@ return C.has(A) + C.has(B);
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16130,13 +15998,12 @@ return result === &apos;Hello, hello!&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16252,13 +16119,12 @@ return 123i === &apos;string123number123&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16367,13 +16233,12 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
 <td class="tally unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
 <td class="tally unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
-<td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
 <td class="tally obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
 <td class="tally not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
 <td class="tally obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
-<td class="tally not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
+<td class="tally obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
 <td class="tally not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
-<td class="tally unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
+<td class="tally not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
 <td class="tally obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
 <td class="tally obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
 <td class="tally obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
@@ -16489,13 +16354,12 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16611,13 +16475,12 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16733,13 +16596,12 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16855,13 +16717,12 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16977,13 +16838,12 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17099,13 +16959,12 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17221,13 +17080,12 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17346,13 +17204,12 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17469,13 +17326,12 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17591,13 +17447,12 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17713,13 +17568,12 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="unknown not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17835,13 +17689,12 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17950,13 +17803,12 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
-<td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
-<td class="tally not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
+<td class="tally obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
-<td class="tally unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
+<td class="tally not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
@@ -18068,13 +17920,12 @@ return Object.isFrozen({# foo: 42 #});
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -18186,13 +18037,12 @@ return Object.isFrozen([# 42 #]);
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -18304,13 +18154,12 @@ return Object.isSealed({| foo: 42 |});
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -18422,13 +18271,12 @@ return Object.isSealed([| 42 |]);
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -18548,13 +18396,12 @@ try {
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -18675,13 +18522,12 @@ try {
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -18801,13 +18647,12 @@ try {
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -18928,13 +18773,12 @@ try {
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -19051,13 +18895,12 @@ return results.length === 3
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -19166,13 +19009,12 @@ return results.length === 3
 <td class="tally not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -19284,13 +19126,12 @@ return [1, 2, 3].lastItem === 3;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -19402,13 +19243,12 @@ return [1, 2, 3].lastIndex === 2;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -19517,13 +19357,12 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
 <td class="tally unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
 <td class="tally unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
-<td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
 <td class="tally obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
 <td class="tally not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
 <td class="tally obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
-<td class="tally not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
+<td class="tally obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
 <td class="tally not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
-<td class="tally unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
+<td class="tally not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
 <td class="tally obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
 <td class="tally obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
 <td class="tally obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
@@ -19640,13 +19479,12 @@ return map.size === 2
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -19761,13 +19599,12 @@ return map.size === 2
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -19883,13 +19720,12 @@ return map.size === 2
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20001,13 +19837,12 @@ return new Map([[1, 4], [2, 5], [3, 6]]).every(it =&gt; typeof it === &apos;numb
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20122,13 +19957,12 @@ return map.size === 2
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20240,13 +20074,12 @@ return new Map([[1, 2], [2, 3], [3, 4]]).find(it =&gt; it % 2) === 3;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20358,13 +20191,12 @@ return new Map([[1, 2], [2, 3], [3, 4]]).findKey(it =&gt; it % 2) === 2;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20477,13 +20309,12 @@ return new Map([[1, 2], [2, NaN]]).includes(2)
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20596,13 +20427,12 @@ return new Map([[1, 2], [2, NaN]]).keyOf(2) === 1
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20718,13 +20548,12 @@ return map.size === 3
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20840,13 +20669,12 @@ return map.size === 3
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20962,13 +20790,12 @@ return map.size === 3
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21080,13 +20907,12 @@ return new Map([[&apos;a&apos;, 1], [&apos;b&apos;, 2], [&apos;c&apos;, 3], ]).r
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21198,13 +21024,12 @@ return new Map([[1, 4], [2, 5], [3, 6]]).some(it =&gt; it % 2);
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21320,13 +21145,12 @@ return set.size === 3
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21442,13 +21266,12 @@ return set.deleteAll(2, 3) === true
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21560,13 +21383,12 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21681,13 +21503,12 @@ return set.size === 2
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21799,13 +21620,12 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21917,13 +21737,12 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22039,13 +21858,12 @@ return set.size === 3
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22157,13 +21975,12 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22275,13 +22092,12 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22402,13 +22218,12 @@ return !map.has(a)
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22529,13 +22344,12 @@ return set.has(a)
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22656,13 +22470,12 @@ return !set.has(a)
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22782,13 +22595,12 @@ return second === gen2.next().value;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22897,13 +22709,12 @@ return second === gen2.next().value;
 <td class="tally not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -23015,13 +22826,12 @@ return Number.fromString(&apos;42&apos;) === 42;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -23133,13 +22943,12 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -23248,13 +23057,12 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="tally not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
-<td class="tally unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -23370,13 +23178,12 @@ return [...iterator].join() === &apos;a,c&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -23492,13 +23299,12 @@ return [...iterator].join() === &apos;1,3&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -23614,13 +23420,12 @@ return [...iterator].join() === &apos;a,1,c,3&apos;;
 <td class="no not-applicable" data-browser="chrome83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome84" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no unstable not-applicable" data-browser="chrome85" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="edge15" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge17" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge18" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no obsolete not-applicable" data-browser="edge79" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="edge80" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="edge81" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no unstable not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no not-applicable" data-browser="edge83" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="safari11_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="safari12_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -146,13 +146,12 @@
 <th class="platform chrome83 desktop" data-browser="chrome83"><a href="#chrome83" class="browser-name"><abbr title="Chrome 83">CH 83</abbr></a></th>
 <th class="platform chrome84 desktop unstable" data-browser="chrome84"><a href="#chrome84" class="browser-name"><abbr title="Chrome 84 Beta">CH 84</abbr></a></th>
 <th class="platform chrome85 desktop unstable" data-browser="chrome85"><a href="#chrome85" class="browser-name"><abbr title="Chrome 85 Canary">CH 85</abbr></a></th>
-<th class="platform edge15 desktop obsolete" data-browser="edge15"><a href="#edge15" class="browser-name"><abbr title="Microsoft Edge 15">Edge 15</abbr></a></th>
 <th class="platform edge17 desktop obsolete" data-browser="edge17"><a href="#edge17" class="browser-name"><abbr title="Microsoft Edge 17">Edge 17</abbr></a></th>
 <th class="platform edge18 desktop" data-browser="edge18"><a href="#edge18" class="browser-name"><abbr title="Microsoft Edge 18">Edge 18</abbr></a></th>
 <th class="platform edge79 desktop obsolete" data-browser="edge79"><a href="#edge79" class="browser-name"><abbr title="Microsoft Edge 79">Edge 79</abbr></a></th>
-<th class="platform edge80 desktop" data-browser="edge80"><a href="#edge80" class="browser-name"><abbr title="Microsoft Edge 80">Edge 80</abbr></a></th>
+<th class="platform edge80 desktop obsolete" data-browser="edge80"><a href="#edge80" class="browser-name"><abbr title="Microsoft Edge 80">Edge 80</abbr></a></th>
 <th class="platform edge81 desktop" data-browser="edge81"><a href="#edge81" class="browser-name"><abbr title="Microsoft Edge 81">Edge 81</abbr></a></th>
-<th class="platform edge83 desktop unstable" data-browser="edge83"><a href="#edge83" class="browser-name"><abbr title="Microsoft Edge 83 Beta">Edge 83 Beta</abbr></a></th>
+<th class="platform edge83 desktop" data-browser="edge83"><a href="#edge83" class="browser-name"><abbr title="Microsoft Edge 83">Edge 83</abbr></a></th>
 <th class="platform safari11_1 desktop obsolete" data-browser="safari11_1"><a href="#safari11_1" class="browser-name"><abbr title="Safari 11.1">SF 11.1</abbr></a></th>
 <th class="platform safari12 desktop obsolete" data-browser="safari12"><a href="#safari12" class="browser-name"><abbr title="Safari 12">SF 12</abbr></a></th>
 <th class="platform safari12_1 desktop obsolete" data-browser="safari12_1"><a href="#safari12_1" class="browser-name"><abbr title="Safari 12.1">SF&#xA0;12.1</abbr></a></th>
@@ -252,13 +251,12 @@
 <td class="tally" data-browser="chrome83" data-tally="0">0/57</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="0">0/57</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0" data-flagged-tally="0.9649122807017544">0/57</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/57</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0">0/57</td>
-<td class="tally" data-browser="edge80" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0">0/57</td>
 <td class="tally" data-browser="edge81" data-tally="0">0/57</td>
-<td class="tally unstable" data-browser="edge83" data-tally="0">0/57</td>
+<td class="tally" data-browser="edge83" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/57</td>
@@ -365,13 +363,12 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -391,10 +388,10 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -414,8 +411,8 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -470,13 +467,12 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -496,10 +492,10 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -519,8 +515,8 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -575,13 +571,12 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -601,10 +596,10 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -624,8 +619,8 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -680,13 +675,12 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -706,10 +700,10 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -729,8 +723,8 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -785,13 +779,12 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -811,10 +804,10 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -834,8 +827,8 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -890,13 +883,12 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -916,10 +908,10 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -939,8 +931,8 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -995,13 +987,12 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1021,10 +1012,10 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -1044,8 +1035,8 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1100,13 +1091,12 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1126,10 +1116,10 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -1149,8 +1139,8 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1205,13 +1195,12 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1231,10 +1220,10 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -1254,8 +1243,8 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1310,13 +1299,12 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1336,10 +1324,10 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -1359,8 +1347,8 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1415,13 +1403,12 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1441,10 +1428,10 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -1464,8 +1451,8 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1522,13 +1509,12 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1548,10 +1534,10 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -1571,8 +1557,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1629,13 +1615,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1655,10 +1640,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -1678,8 +1663,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1736,13 +1721,12 @@ return simdSmallIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1762,10 +1746,10 @@ return simdSmallIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -1785,8 +1769,8 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1843,13 +1827,12 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1869,10 +1852,10 @@ return simdBoolIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -1892,8 +1875,8 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1950,13 +1933,12 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -1976,10 +1958,10 @@ return simdBoolTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -1999,8 +1981,8 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2057,13 +2039,12 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2083,10 +2064,10 @@ return simdBoolTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -2106,8 +2087,8 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2164,13 +2145,12 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2190,10 +2170,10 @@ return simdAllTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -2213,8 +2193,8 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2271,13 +2251,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2297,10 +2276,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -2320,8 +2299,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2378,13 +2357,12 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2404,10 +2382,10 @@ return simdAllTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -2427,8 +2405,8 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2485,13 +2463,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2511,10 +2488,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -2534,8 +2511,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2592,13 +2569,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2618,10 +2594,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -2641,8 +2617,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2699,13 +2675,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2725,10 +2700,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -2748,8 +2723,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2806,13 +2781,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2832,10 +2806,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -2855,8 +2829,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2913,13 +2887,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -2939,10 +2912,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -2962,8 +2935,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3020,13 +2993,12 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -3046,10 +3018,10 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -3069,8 +3041,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3127,13 +3099,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -3153,10 +3124,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -3176,8 +3147,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3234,13 +3205,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -3260,10 +3230,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -3283,8 +3253,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3341,13 +3311,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -3367,10 +3336,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -3390,8 +3359,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3448,13 +3417,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -3474,10 +3442,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -3497,8 +3465,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3555,13 +3523,12 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -3581,10 +3548,10 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -3604,8 +3571,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3662,13 +3629,12 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -3688,10 +3654,10 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -3711,8 +3677,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3769,13 +3735,12 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -3795,10 +3760,10 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -3818,8 +3783,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3876,13 +3841,12 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -3902,10 +3866,10 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -3925,8 +3889,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3983,13 +3947,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4009,10 +3972,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -4032,8 +3995,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4090,13 +4053,12 @@ return simdBoolTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4116,10 +4078,10 @@ return simdBoolTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -4139,8 +4101,8 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4197,13 +4159,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4223,10 +4184,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -4246,8 +4207,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4304,13 +4265,12 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4330,10 +4290,10 @@ return simdBoolIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -4353,8 +4313,8 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4411,13 +4371,12 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4437,10 +4396,10 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -4460,8 +4419,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4518,13 +4477,12 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4544,10 +4502,10 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -4567,8 +4525,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4625,13 +4583,12 @@ return simdAllTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4651,10 +4608,10 @@ return simdAllTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -4674,8 +4631,8 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4732,13 +4689,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4758,10 +4714,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -4781,8 +4737,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4839,13 +4795,12 @@ return simdIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4865,10 +4820,10 @@ return simdIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -4888,8 +4843,8 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4946,13 +4901,12 @@ return simdIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -4972,10 +4926,10 @@ return simdIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -4995,8 +4949,8 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5053,13 +5007,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5079,10 +5032,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -5102,8 +5055,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5160,13 +5113,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5186,10 +5138,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -5209,8 +5161,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5267,13 +5219,12 @@ return simdFloatTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5293,10 +5244,10 @@ return simdFloatTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -5316,8 +5267,8 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5374,13 +5325,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5400,10 +5350,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -5423,8 +5373,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5481,13 +5431,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5507,10 +5456,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -5530,8 +5479,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5588,13 +5537,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5614,10 +5562,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -5637,8 +5585,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5695,13 +5643,12 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5721,10 +5668,10 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -5744,8 +5691,8 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5802,13 +5749,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5828,10 +5774,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -5851,8 +5797,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5909,13 +5855,12 @@ return simdSmallIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -5935,10 +5880,10 @@ return simdSmallIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -5958,8 +5903,8 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6016,13 +5961,12 @@ return simdFloatIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -6042,10 +5986,10 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -6065,8 +6009,8 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6123,13 +6067,12 @@ return simdBoolIntTypes.every(function(type){
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -6149,10 +6092,10 @@ return simdBoolIntTypes.every(function(type){
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -6172,8 +6115,8 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6230,13 +6173,12 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -6256,10 +6198,10 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -6279,8 +6221,8 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6335,13 +6277,12 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no flagged obsolete" data-browser="edge15">Flag<a href="#edge-experimental-flag-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -6361,10 +6302,10 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
-<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
-<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[7]</sup></a></td>
+<td class="no obsolete" data-browser="node4">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node6_5">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
+<td class="no obsolete" data-browser="node7_6">No<a href="#chrome-simd-note"><sup>[6]</sup></a></td>
 <td class="no obsolete" data-browser="node8">No</td>
 <td class="no obsolete" data-browser="node8_3">No</td>
 <td class="no obsolete" data-browser="node8_7">No</td>
@@ -6384,8 +6325,8 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-simdjs-note"><sup>[7]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6406,7 +6347,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no" data-browser="opera_mobile54">No</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="103" class="separator"></th>
+<tr><th colspan="102" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-decompilation"><span><a class="anchor" href="#test-decompilation">&#xA7;</a>decompilation</span></td>
 <td class="tally obsolete" data-browser="konq4_13" data-tally="0">0/4</td>
@@ -6439,13 +6380,12 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally" data-browser="chrome83" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="0">0/4</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0">0/4</td>
-<td class="tally" data-browser="edge80" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0">0/4</td>
 <td class="tally" data-browser="edge81" data-tally="0">0/4</td>
-<td class="tally unstable" data-browser="edge83" data-tally="0">0/4</td>
+<td class="tally" data-browser="edge83" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/4</td>
@@ -6544,13 +6484,12 @@ return typeof uneval === &apos;function&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -6657,13 +6596,12 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -6762,13 +6700,12 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -6953,13 +6890,12 @@ return true;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -7059,13 +6995,12 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -7130,7 +7065,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="unknown" data-browser="opera_mobile54">?</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="103" class="separator"></th>
+<tr><th colspan="102" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#test-function_caller_property">&#xA7;</a>function &quot;caller&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;caller&apos; in function(){};
@@ -7168,13 +7103,12 @@ return 'caller' in function(){};
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -7279,13 +7213,12 @@ return (function () {}).arity === 0 &&
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -7392,13 +7325,12 @@ return f(1, 'boo');
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -7499,13 +7431,12 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -7570,7 +7501,7 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no" data-browser="opera_mobile54">No</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="103" class="separator"></th>
+<tr><th colspan="102" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-class_extends_null"><span><a class="anchor" href="#test-class_extends_null">&#xA7;</a><a href="https://github.com/tc39/ecma262/issues/543">class extends null</a></span><script data-source="
 class C extends null {}
@@ -7607,13 +7538,12 @@ return new C instanceof C;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -7716,13 +7646,12 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -7823,13 +7752,12 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -7940,13 +7868,12 @@ return executed;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -7989,8 +7916,8 @@ return executed;
 <td class="no obsolete" data-browser="duktape2_1">No</td>
 <td class="no obsolete" data-browser="duktape2_2">No</td>
 <td class="no" data-browser="duktape2_3">No</td>
-<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-nashorn-compat-note"><sup>[9]</sup></a></td>
-<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-nashorn-compat-note"><sup>[9]</sup></a></td>
+<td class="no flagged" data-browser="graalvm19">Flag<a href="#graalvm-nashorn-compat-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20">Flag<a href="#graalvm-nashorn-compat-note"><sup>[8]</sup></a></td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -8026,7 +7953,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="yes obsolete" data-browser="firefox60">Yes</td>
 <td class="yes" data-browser="firefox68">Yes</td>
 <td class="yes obsolete" data-browser="firefox69">Yes</td>
-<td class="yes obsolete" data-browser="firefox70">Yes<a href="#firefox-not-nightly-note"><sup>[10]</sup></a></td>
+<td class="yes obsolete" data-browser="firefox70">Yes<a href="#firefox-not-nightly-note"><sup>[9]</sup></a></td>
 <td class="no obsolete" data-browser="firefox71">No</td>
 <td class="no obsolete" data-browser="firefox72">No</td>
 <td class="no obsolete" data-browser="firefox73">No</td>
@@ -8047,13 +7974,12 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -8154,13 +8080,12 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -8225,7 +8150,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="opera_mobile54">No</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="103" class="separator"></th>
+<tr><th colspan="102" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Array_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (JS 1.8 style)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions#Differences_to_the_older_JS1.7JS1.8_comprehensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -8263,13 +8188,12 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -8368,13 +8292,12 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -8473,13 +8396,12 @@ return (function(x)x)(1) === 1;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -8578,13 +8500,12 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -8687,13 +8608,12 @@ return str === &quot;foobarbaz&quot;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -8793,13 +8713,12 @@ return arr[1] === arr;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -8864,7 +8783,7 @@ return arr[1] === arr;
 <td class="no" data-browser="opera_mobile54">No</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="103" class="separator"></th>
+<tr><th colspan="102" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#test-Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 /* global Iterator */
@@ -8932,13 +8851,12 @@ catch(e) {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -9077,13 +8995,12 @@ catch(e) {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -9221,13 +9138,12 @@ global.test((function () {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -9328,13 +9244,12 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -9440,13 +9355,12 @@ return passed;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -9511,7 +9425,7 @@ return passed;
 <td class="unknown" data-browser="opera_mobile54">?</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="103" class="separator"></th>
+<tr><th colspan="102" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#test-RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
@@ -9563,13 +9477,12 @@ try {
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -9668,13 +9581,12 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -9774,13 +9686,12 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -9845,7 +9756,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no" data-browser="opera_mobile54">No</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="103" class="separator"></th>
+<tr><th colspan="102" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-String.prototype.quote"><span><a class="anchor" href="#test-String.prototype.quote">&#xA7;</a>String.prototype.quote <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/quote" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
@@ -9879,13 +9790,12 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -9982,13 +9892,12 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -10053,7 +9962,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="unknown" data-browser="opera_mobile54">?</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="103" class="separator"></th>
+<tr><th colspan="102" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#test-Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
@@ -10087,13 +9996,12 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -10200,13 +10108,12 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -10271,7 +10178,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="unknown" data-browser="opera_mobile54">?</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="103" class="separator"></th>
+<tr><th colspan="102" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.watch === &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch === 'function' }())</script></td>
@@ -10305,13 +10212,12 @@ function () { return typeof Object.prototype.watch === 'function' }())</script><
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -10408,13 +10314,12 @@ function () { return typeof Object.prototype.unwatch === 'function' }())</script
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -10511,13 +10416,12 @@ function () { return typeof Object.prototype.eval === 'function' }())</script></
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -10616,13 +10520,12 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="unknown obsolete" data-browser="safari11_1">?</td>
 <td class="unknown obsolete" data-browser="safari12">?</td>
 <td class="unknown obsolete" data-browser="safari12_1">?</td>
@@ -10687,7 +10590,7 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no" data-browser="opera_mobile54">No</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="103" class="separator"></th>
+<tr><th colspan="102" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#test-error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 try {
@@ -10733,13 +10636,12 @@ try {
 <td class="yes" data-browser="chrome83">Yes</td>
 <td class="yes unstable" data-browser="chrome84">Yes</td>
 <td class="yes unstable" data-browser="chrome85">Yes</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="yes obsolete" data-browser="edge79">Yes</td>
-<td class="yes" data-browser="edge80">Yes</td>
+<td class="yes obsolete" data-browser="edge80">Yes</td>
 <td class="yes" data-browser="edge81">Yes</td>
-<td class="yes unstable" data-browser="edge83">Yes</td>
+<td class="yes" data-browser="edge83">Yes</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -10840,13 +10742,12 @@ return 'lineNumber' in new Error();
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -10947,13 +10848,12 @@ return 'columnNumber' in new Error();
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -11054,13 +10954,12 @@ return 'fileName' in new Error();
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -11161,13 +11060,12 @@ return 'description' in new Error();
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="yes obsolete" data-browser="edge15">Yes</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -11232,7 +11130,7 @@ return 'description' in new Error();
 <td class="no" data-browser="opera_mobile54">No</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="103" class="separator"></th>
+<tr><th colspan="102" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-global"><span><a class="anchor" href="#test-global">&#xA7;</a>global</span></td>
 <td class="tally obsolete" data-browser="konq4_13" data-tally="0">0/2</td>
@@ -11265,13 +11163,12 @@ return 'description' in new Error();
 <td class="tally" data-browser="chrome83" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="chrome84" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="chrome85" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="edge15" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge17" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge18" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="edge79" data-tally="0">0/2</td>
-<td class="tally" data-browser="edge80" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0">0/2</td>
 <td class="tally" data-browser="edge81" data-tally="0">0/2</td>
-<td class="tally unstable" data-browser="edge83" data-tally="0">0/2</td>
+<td class="tally" data-browser="edge83" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari11_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari12" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/2</td>
@@ -11372,13 +11269,12 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -11484,13 +11380,12 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="no obsolete" data-browser="edge17">No</td>
 <td class="no" data-browser="edge18">No</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="no obsolete" data-browser="safari11_1">No</td>
 <td class="no obsolete" data-browser="safari12">No</td>
 <td class="no obsolete" data-browser="safari12_1">No</td>
@@ -11555,7 +11450,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="unknown" data-browser="opera_mobile54">?</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr significance="1"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets (ES 2017 semantics)</a><a href="#proxy-duplictate-ownkeys-updated-note"><sup>[11]</sup></a></span><script data-source="
+<tr significance="1"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets_(ES_2017_semantics)">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/594">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets (ES 2017 semantics)</a><a href="#proxy-duplictate-ownkeys-updated-note"><sup>[10]</sup></a></span><script data-source="
 var P = new Proxy(Object.preventExtensions(Object.defineProperty({a:1}, &quot;b&quot;, {value:1})), {
 ownKeys: function() {
 return [&apos;a&apos;,&apos;a&apos;,&apos;b&apos;,&apos;b&apos;];
@@ -11594,13 +11489,12 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no" data-browser="chrome83">No</td>
 <td class="no unstable" data-browser="chrome84">No</td>
 <td class="no unstable" data-browser="chrome85">No</td>
-<td class="no obsolete" data-browser="edge15">No</td>
 <td class="yes obsolete" data-browser="edge17">Yes</td>
 <td class="yes" data-browser="edge18">Yes</td>
 <td class="no obsolete" data-browser="edge79">No</td>
-<td class="no" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
 <td class="no" data-browser="edge81">No</td>
-<td class="no unstable" data-browser="edge83">No</td>
+<td class="no" data-browser="edge83">No</td>
 <td class="yes obsolete" data-browser="safari11_1">Yes</td>
 <td class="yes obsolete" data-browser="safari12">Yes</td>
 <td class="yes obsolete" data-browser="safari12_1">Yes</td>
@@ -11669,7 +11563,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
       </table>
       <div id="footnotes">
         <!-- FOOTNOTES -->
-      <p id="khtml-note">  <sup>[1]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-old-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[4]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="firefox-nightly-note">  <sup>[5]</sup> The feature is available only in Firefox Nightly builds.</p><p id="edge-experimental-flag-note">  <sup>[6]</sup> Flagged features have to be enabled via &quot;Enable experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="chrome-simd-note">  <sup>[7]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-simd&quot;</code> flag</p><p id="graalvm-simdjs-note">  <sup>[8]</sup> The feature have to be enabled via <code>--experimental-options --js.simdjs</code> flag</p><p id="graalvm-nashorn-compat-note">  <sup>[9]</sup> The feature has to be enabled via the <code>--nashorn-compat</code> flag.</p><p id="firefox-not-nightly-note">  <sup>[10]</sup> The feature is disabled only in Firefox Nightly builds.</p><p id="proxy-duplictate-ownkeys-updated-note">  <sup>[11]</sup> The behaviour of the Proxy &#x201C;ownKeys&#x201D; handler in presence of duplicate keys has been <a href="https://github.com/tc39/ecma262/issues/833">modified later</a>.</p></div>
+      <p id="khtml-note">  <sup>[1]</sup> Results are only applicable for the KHTML rendering engine.</p><p id="harmony-flag-old-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[3]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[4]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="firefox-nightly-note">  <sup>[5]</sup> The feature is available only in Firefox Nightly builds.</p><p id="chrome-simd-note">  <sup>[6]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-simd&quot;</code> flag</p><p id="graalvm-simdjs-note">  <sup>[7]</sup> The feature have to be enabled via <code>--experimental-options --js.simdjs</code> flag</p><p id="graalvm-nashorn-compat-note">  <sup>[8]</sup> The feature has to be enabled via the <code>--nashorn-compat</code> flag.</p><p id="firefox-not-nightly-note">  <sup>[9]</sup> The feature is disabled only in Firefox Nightly builds.</p><p id="proxy-duplictate-ownkeys-updated-note">  <sup>[10]</sup> The behaviour of the Proxy &#x201C;ownKeys&#x201D; handler in presence of duplicate keys has been <a href="https://github.com/tc39/ecma262/issues/833">modified later</a>.</p></div>
     </div>
     <pre class="info-tooltip" style="display:none"></pre>
   </body>


### PR DESCRIPTION
What is fixed here:
- Edge 15 is very obsolete now (it had `"obsolete": true` while Edge 16 had `"obsolete": "very"`)
- Edge 80 is obsolete (only last two versions are not obsolete)
- Edge 82 retire date was added
- Edge 83 changed to stable