### PR TITLE
Adding MDN links do ES2018 RegEx features

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -2751,6 +2751,7 @@ exports.tests = [
   {
     name: 's (dotAll) flag for regular expressions',
     spec: 'https://tc39.github.io/ecma262/#sec-get-regexp.prototype.dotAll',
+    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll',
     category: '2018 features',
     significance: 'small',
     exec: function(){/*
@@ -2794,6 +2795,7 @@ exports.tests = [
   {
     name: 'RegExp named capture groups',
     spec: 'https://github.com/tc39/proposal-regexp-named-groups',
+    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges',
     category: '2018 features',
     significance: 'small',
     exec: function(){/*
@@ -2825,6 +2827,7 @@ exports.tests = [
   {
     name: 'RegExp Lookbehind Assertions',
     spec: 'https://github.com/tc39/proposal-regexp-lookbehind',
+    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions',
     category: '2018 features',
     significance: 'small',
     exec: function(){/*
@@ -2849,6 +2852,7 @@ exports.tests = [
     category: '2018 features',
     significance: 'small',
     spec: 'https://github.com/tc39/proposal-regexp-unicode-property-escapes',
+    mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes',
     exec: function () {/*
     const regexGreekSymbol = /\p{Script=Greek}/u;
     return regexGreekSymbol.test('π');

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -11697,7 +11697,7 @@ function check() {
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr significance="0.25"><td id="test-s_(dotAll)_flag_for_regular_expressions"><span><a class="anchor" href="#test-s_(dotAll)_flag_for_regular_expressions">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-get-regexp.prototype.dotAll">s (dotAll) flag for regular expressions</a></span><script data-source="
+<tr significance="0.25"><td id="test-s_(dotAll)_flag_for_regular_expressions"><span><a class="anchor" href="#test-s_(dotAll)_flag_for_regular_expressions">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-get-regexp.prototype.dotAll">s (dotAll) flag for regular expressions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 const regex = /foo.bar/s;
 return regex.test(&apos;foo\nbar&apos;);
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("93");try{return Function("asyncTestPassed","\nconst regex = /foo.bar/s;\nreturn regex.test('foo\\nbar');\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("93");return Function("asyncTestPassed","'use strict';"+"\nconst regex = /foo.bar/s;\nreturn regex.test('foo\\nbar');\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
@@ -11817,7 +11817,7 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr significance="0.25"><td id="test-RegExp_named_capture_groups"><span><a class="anchor" href="#test-RegExp_named_capture_groups">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-named-groups">RegExp named capture groups</a></span><script data-source="
+<tr significance="0.25"><td id="test-RegExp_named_capture_groups"><span><a class="anchor" href="#test-RegExp_named_capture_groups">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-named-groups">RegExp named capture groups</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var result = /(?&lt;year&gt;\d{4})-(?&lt;month&gt;\d{2})-(?&lt;day&gt;\d{2})/.exec(&apos;2016-03-11&apos;);
 return result.groups.year === &apos;2016&apos;
   &amp;&amp; result.groups.month === &apos;03&apos;
@@ -11943,7 +11943,7 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr significance="0.25"><td id="test-RegExp_Lookbehind_Assertions"><span><a class="anchor" href="#test-RegExp_Lookbehind_Assertions">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-lookbehind">RegExp Lookbehind Assertions</a></span><script data-source="
+<tr significance="0.25"><td id="test-RegExp_Lookbehind_Assertions"><span><a class="anchor" href="#test-RegExp_Lookbehind_Assertions">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-lookbehind">RegExp Lookbehind Assertions</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&apos;) &amp;&amp;
        !/(?&lt;=a)b/.test(&apos;b&apos;);
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("95");try{return Function("asyncTestPassed","\nreturn /(?<=a)b/.test('ab') && /(?<!a)b/.test('cb') &&\n       !/(?<=a)b/.test('b');\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("95");return Function("asyncTestPassed","'use strict';"+"\nreturn /(?<=a)b/.test('ab') && /(?<!a)b/.test('cb') &&\n       !/(?<=a)b/.test('b');\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
@@ -12063,7 +12063,7 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr significance="0.25"><td id="test-RegExp_Unicode_Property_Escapes"><span><a class="anchor" href="#test-RegExp_Unicode_Property_Escapes">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-unicode-property-escapes">RegExp Unicode Property Escapes</a></span><script data-source="
+<tr significance="0.25"><td id="test-RegExp_Unicode_Property_Escapes"><span><a class="anchor" href="#test-RegExp_Unicode_Property_Escapes">&#xA7;</a><a href="https://github.com/tc39/proposal-regexp-unicode-property-escapes">RegExp Unicode Property Escapes</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 const regexGreekSymbol = /\p{Script=Greek}/u;
 return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
   ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("96");try{return Function("asyncTestPassed","\nconst regexGreekSymbol = /\\p{Script=Greek}/u;\nreturn regexGreekSymbol.test('π');\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("96");return Function("asyncTestPassed","'use strict';"+"\nconst regexGreekSymbol = /\\p{Script=Greek}/u;\nreturn regexGreekSymbol.test('π');\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());


### PR DESCRIPTION
The MDN links for ES2018 RegEx features were missing.