### PR TITLE
Atomics.wake was renamed Atomics.notify in ECMAScript 2019

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -1556,11 +1556,11 @@ exports.tests = [
         }
       },
       {
-        name: 'Atomics.wake',
-        spec: 'https://tc39.github.io/ecma262/#sec-atomics.wake',
-        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wake',
+        name: 'Atomics.notify',
+        spec: 'https://tc39.github.io/ecma262/#sec-atomics.notify',
+        mdn: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify',
         exec: function () {/*
-         return typeof Atomics.wake === 'function';
+         return typeof Atomics.notify === 'function';
          */},
         res: {
           ie11: false,
@@ -1588,8 +1588,8 @@ exports.tests = [
           duktape2_0: false,
           jerryscript2_3_0: false,
           graalvm19: false,
-          graalvm20: false,
-          graalvm20_1: false,
+          graalvm20: true,
+          graalvm20_1: true,
           hermes0_7_0: false,
           rhino1_7_13: false
         }

--- a/data-esnext.js
+++ b/data-esnext.js
@@ -3,7 +3,7 @@ var common = require('./data-common');
 var babel = common.babel;
 var typescript = common.typescript;
 // var firefox = common.firefox;
-// var graalvm = common.graalvm;
+var graalvm = common.graalvm;
 
 exports.name = 'ES Next';
 exports.target_file = 'esnext/index.html';
@@ -325,7 +325,7 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm20: false,
-        graalvm20_1: false,
+        graalvm20_1: graalvm.es2021flag,
         rhino1_7_13: false
       }
     },

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -7560,11 +7560,11 @@ p.then(function(result) {
 <td class="tally" data-browser="jerryscript2_4_0" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="graalvm19" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
 <td class="tally" data-browser="graalvm19_3_6" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
-<td class="tally obsolete" data-browser="graalvm20" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
-<td class="tally obsolete" data-browser="graalvm20_1" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
-<td class="tally obsolete" data-browser="graalvm20_3" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
-<td class="tally" data-browser="graalvm20_3_1" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
-<td class="tally" data-browser="graalvm21" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
+<td class="tally obsolete" data-browser="graalvm20" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="graalvm20_1" data-tally="1">17/17</td>
+<td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">17/17</td>
+<td class="tally" data-browser="graalvm20_3_1" data-tally="1">17/17</td>
+<td class="tally" data-browser="graalvm21" data-tally="1">17/17</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/17</td>
@@ -9169,9 +9169,9 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.wake_Atomics.wake_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wake_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.wake_Atomics.wake_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wake_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.wake">Atomics.wake</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wake" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
-return typeof Atomics.wake === &apos;function&apos;;
-">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("55");try{return Function("asyncTestPassed","\nreturn typeof Atomics.wake === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("55");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.wake === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+<tr class="subtest" data-parent="shared_memory_and_atomics" id="test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.notify_Atomics.notify_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;"><td><span><a class="anchor" href="#test-shared_memory_and_atomics_a_href=_https://tc39.github.io/ecma262/#sec-atomics.notify_Atomics.notify_/a_a_href=_https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify_title=_MDN_documentation_img_src=_../mdn.png_alt=_MDN_(Mozilla_Development_Network)_logo_width=_15_height=_13_/_/a_nbsp;">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-atomics.notify">Atomics.notify</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
+return typeof Atomics.notify === &apos;function&apos;;
+">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("55");try{return Function("asyncTestPassed","\nreturn typeof Atomics.notify === 'function';\n")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("55");return Function("asyncTestPassed","'use strict';"+"\nreturn typeof Atomics.notify === 'function';\n")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -9298,11 +9298,11 @@ return typeof Atomics.wake === &apos;function&apos;;
 <td class="no" data-browser="jerryscript2_4_0">No</td>
 <td class="no obsolete" data-browser="graalvm19">No</td>
 <td class="no" data-browser="graalvm19_3_6">No</td>
-<td class="no obsolete" data-browser="graalvm20">No</td>
-<td class="no obsolete" data-browser="graalvm20_1">No</td>
-<td class="no obsolete" data-browser="graalvm20_3">No</td>
-<td class="no" data-browser="graalvm20_3_1">No</td>
-<td class="no" data-browser="graalvm21">No</td>
+<td class="yes obsolete" data-browser="graalvm20">Yes</td>
+<td class="yes obsolete" data-browser="graalvm20_1">Yes</td>
+<td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
+<td class="yes" data-browser="graalvm20_3_1">Yes</td>
+<td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -2909,10 +2909,10 @@ try {
 <td class="tally obsolete" data-browser="graalvm19" data-tally="0">0/7</td>
 <td class="tally" data-browser="graalvm19_3_6" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="graalvm20" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="graalvm20_1" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/7</td>
-<td class="tally" data-browser="graalvm20_3_1" data-tally="0">0/7</td>
-<td class="tally" data-browser="graalvm21" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="graalvm20_1" data-tally="0" data-flagged-tally="0.14285714285714285">0/7</td>
+<td class="tally obsolete" data-browser="graalvm20_3" data-tally="0" data-flagged-tally="0.14285714285714285">0/7</td>
+<td class="tally" data-browser="graalvm20_3_1" data-tally="0" data-flagged-tally="0.14285714285714285">0/7</td>
+<td class="tally" data-browser="graalvm21" data-tally="0" data-flagged-tally="0.14285714285714285">0/7</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/7</td>
@@ -3687,10 +3687,10 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no obsolete" data-browser="graalvm19">No</td>
 <td class="no" data-browser="graalvm19_3_6">No</td>
 <td class="no obsolete" data-browser="graalvm20">No</td>
-<td class="no obsolete" data-browser="graalvm20_1">No</td>
-<td class="no obsolete" data-browser="graalvm20_3">No</td>
-<td class="no" data-browser="graalvm20_3_1">No</td>
-<td class="no" data-browser="graalvm21">No</td>
+<td class="no flagged obsolete" data-browser="graalvm20_1">Flag<a href="#graalvm-es2021-note"><sup>[8]</sup></a></td>
+<td class="no flagged obsolete" data-browser="graalvm20_3">Flag<a href="#graalvm-es2021-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[8]</sup></a></td>
+<td class="no flagged" data-browser="graalvm21">Flag<a href="#graalvm-es2021-note"><sup>[8]</sup></a></td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -10723,7 +10723,7 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="babel-core-js-note">  <sup>[4]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[5]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="babel-decorators-legacy-note">  <sup>[6]</sup> Babel 6 still has no official support decorators, but you can use <a href="https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy">this plugin</a>.</p><p id="typescript-es6-note">  <sup>[7]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p></div>
+    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="babel-core-js-note">  <sup>[4]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[5]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="babel-decorators-legacy-note">  <sup>[6]</sup> Babel 6 still has no official support decorators, but you can use <a href="https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy">this plugin</a>.</p><p id="typescript-es6-note">  <sup>[7]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="graalvm-es2021-note">  <sup>[8]</sup> The feature can be enabled via <code>--js.ecmascript-version=2021</code> flag</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
 </body>


### PR DESCRIPTION
`Atomics.wake` has been renamed to `Atomics.notify` in ECMAScript 2019.

See https://tc39.es/ecma262/#sec-additions-and-changes-that-introduce-incompatibilities-with-prior-editions
```
24.4.12: In ECMAScript 2019, Atomics.wake has been renamed to Atomics.notify to prevent confusion with Atomics.wait.
```
