### PR TITLE
Add iOS for String.prototype.replaceAll

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -4426,6 +4426,7 @@ exports.tests = [
       graalvm19: false,
       graalvm20: graalvm.es2020flag,
       graalvm20_1: graalvm.es2021flag,
+      ios13_4: true,
     }
   },
 ];

--- a/environments.json
+++ b/environments.json
@@ -4058,6 +4058,15 @@
     "release": "2019-09-19",
     "obsolete": false
   },
+  "ios13_4": {
+    "full": "iOS Safari",
+    "family": "iOS Safari",
+    "short": "iOS 13.4",
+    "platformtype": "mobile",
+    "equals": "safari13_1",
+    "release": "2020-03-24",
+    "obsolete": false
+  },
   "samsung1": {
     "full": "Samsung Internet for Android 1",
     "family": "Samsung",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -230,6 +230,7 @@
 <th class="platform ios12 mobile" data-browser="ios12"><a href="#ios12" class="browser-name"><abbr title="iOS Safari">iOS 12</abbr></a></th>
 <th class="platform ios12_2 mobile" data-browser="ios12_2"><a href="#ios12_2" class="browser-name"><abbr title="iOS Safari">iOS 12.2</abbr></a></th>
 <th class="platform ios13 mobile" data-browser="ios13"><a href="#ios13" class="browser-name"><abbr title="iOS Safari">iOS 13</abbr></a></th>
+<th class="platform ios13_4 mobile" data-browser="ios13_4"><a href="#ios13_4" class="browser-name"><abbr title="iOS Safari">iOS 13.4</abbr></a></th>
 <th class="platform samsung7 mobile obsolete" data-browser="samsung7"><a href="#samsung7" class="browser-name"><abbr title="Samsung Internet for Android 7">Samsung 7</abbr></a></th>
 <th class="platform samsung8 mobile obsolete" data-browser="samsung8"><a href="#samsung8" class="browser-name"><abbr title="Samsung Internet for Android 8">Samsung 8</abbr></a></th>
 <th class="platform samsung9 mobile obsolete" data-browser="samsung9"><a href="#samsung9" class="browser-name"><abbr title="Samsung Internet for Android 9">Samsung 9</abbr></a></th>
@@ -246,7 +247,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="120">2016 features</td>
+      <tr class="category"><td colspan="121">2016 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -355,6 +356,7 @@
 <td class="tally" data-browser="ios12" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios13" data-tally="1">3/3</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">3/3</td>
@@ -477,6 +479,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -599,6 +602,7 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -726,6 +730,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -845,6 +850,7 @@ return true;
 <td class="tally" data-browser="ios12" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios13" data-tally="1">3/3</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">3/3</td>
@@ -971,6 +977,7 @@ return [1, 2, 3].includes(1)
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1115,6 +1122,7 @@ return 24;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1242,6 +1250,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1254,7 +1263,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="120">2016 misc</td>
+<tr class="category"><td colspan="121">2016 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -1373,6 +1382,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1508,6 +1518,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1635,6 +1646,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1758,6 +1770,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1882,6 +1895,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2011,6 +2025,7 @@ return passed;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2142,6 +2157,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2154,7 +2170,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="120">2017 features</td>
+<tr class="category"><td colspan="121">2017 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
@@ -2263,6 +2279,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="ios12" data-tally="1">4/4</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">4/4</td>
 <td class="tally" data-browser="ios13" data-tally="1">4/4</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">4/4</td>
@@ -2388,6 +2405,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2517,6 +2535,7 @@ return Array.isArray(e)
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2647,6 +2666,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2772,6 +2792,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2891,6 +2912,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="ios12" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios13" data-tally="1">2/2</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">2/2</td>
@@ -3018,6 +3040,7 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3145,6 +3168,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3264,6 +3288,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="ios12" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios13" data-tally="1">2/2</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">2/2</td>
@@ -3386,6 +3411,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3508,6 +3534,7 @@ return Math.min(1,2,3,) === 1;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3627,6 +3654,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="ios12" data-tally="1">16/16</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">16/16</td>
 <td class="tally" data-browser="ios13" data-tally="1">16/16</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">16/16</td>
@@ -3760,6 +3788,7 @@ p.then(function(result) {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3893,6 +3922,7 @@ p.catch(function(result) {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4016,6 +4046,7 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4139,6 +4170,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4268,6 +4300,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4399,6 +4432,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4522,6 +4556,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4650,6 +4685,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4773,6 +4809,7 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4906,6 +4943,7 @@ p.then(function(result) {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5039,6 +5077,7 @@ p.then(function(result) {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5172,6 +5211,7 @@ var p = new C().a();
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5303,6 +5343,7 @@ p.then(function(result) {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5427,6 +5468,7 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5549,6 +5591,7 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5680,6 +5723,7 @@ p.then(function(result) {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5799,6 +5843,7 @@ p.then(function(result) {
 <td class="tally" data-browser="ios12" data-tally="0">0/17</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/17</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/17</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0" data-flagged-tally="0.8823529411764706">0/17</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/17</td>
@@ -5921,6 +5966,7 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -6043,6 +6089,7 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -6165,6 +6212,7 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -6287,6 +6335,7 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -6409,6 +6458,7 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -6531,6 +6581,7 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -6653,6 +6704,7 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -6775,6 +6827,7 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -6897,6 +6950,7 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -7019,6 +7073,7 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -7141,6 +7196,7 @@ return typeof Atomics.wake === &apos;function&apos;;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -7263,6 +7319,7 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -7385,6 +7442,7 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -7507,6 +7565,7 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -7629,6 +7688,7 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -7751,6 +7811,7 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -7873,6 +7934,7 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="no" data-browser="ios12">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios12_2">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no" data-browser="ios13">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
+<td class="no" data-browser="ios13_4">No<a href="#sf-shared-memory-spectre-note"><sup>[19]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-sharedmem-note"><sup>[20]</sup></a></td>
 <td class="no obsolete" data-browser="samsung8">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
 <td class="no obsolete" data-browser="samsung9">No<a href="#chr-shared-memory-spectre-note"><sup>[21]</sup></a></td>
@@ -7885,7 +7947,7 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="120">2017 misc</td>
+<tr class="category"><td colspan="121">2017 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-RegExp_u_flag,_case_folding"><span><a class="anchor" href="#test-RegExp_u_flag,_case_folding">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/525">RegExp &quot;u&quot; flag, case folding</a></span><script data-source="
 return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/\W/iu)
@@ -8000,6 +8062,7 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -8125,6 +8188,7 @@ return (function(){
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -8137,7 +8201,7 @@ return (function(){
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="120">2017 annex b</td>
+<tr class="category"><td colspan="121">2017 annex b</td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -8246,6 +8310,7 @@ return (function(){
 <td class="tally" data-browser="ios12" data-tally="1">16/16</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">16/16</td>
 <td class="tally" data-browser="ios13" data-tally="1">16/16</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">16/16</td>
@@ -8373,6 +8438,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -8501,6 +8567,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -8629,6 +8696,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -8756,6 +8824,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -8884,6 +8953,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -9012,6 +9082,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -9141,6 +9212,7 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -9270,6 +9342,7 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -9400,6 +9473,7 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -9527,6 +9601,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -9653,6 +9728,7 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -9782,6 +9858,7 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -9911,6 +9988,7 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -10041,6 +10119,7 @@ return foo() === &quot;bar&quot;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -10168,6 +10247,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -10294,6 +10374,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -10413,6 +10494,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally" data-browser="ios12" data-tally="1">4/4</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">4/4</td>
 <td class="tally" data-browser="ios13" data-tally="1">4/4</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">4/4</td>
@@ -10539,6 +10621,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -10665,6 +10748,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -10796,6 +10880,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -10927,6 +11012,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -11050,6 +11136,7 @@ return i === 0;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -11062,7 +11149,7 @@ return i === 0;
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="120">2018 features</td>
+<tr class="category"><td colspan="121">2018 features</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -11171,6 +11258,7 @@ return i === 0;
 <td class="tally" data-browser="ios12" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios13" data-tally="1">2/2</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">2/2</td>
@@ -11294,6 +11382,7 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -11418,6 +11507,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -11537,6 +11627,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="ios12" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios13" data-tally="1">3/3</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">3/3</td>
@@ -11685,6 +11776,7 @@ function check() {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -11825,6 +11917,7 @@ function check() {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -11967,6 +12060,7 @@ function check() {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -12090,6 +12184,7 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -12219,6 +12314,7 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -12342,6 +12438,7 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -12465,6 +12562,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -12584,6 +12682,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="ios12" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios13" data-tally="1">2/2</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">2/2</td>
@@ -12713,6 +12812,7 @@ iterator.next().then(function(step){
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -12852,6 +12952,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -12864,7 +12965,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="120">2018 misc</td>
+<tr class="category"><td colspan="121">2018 misc</td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets">&#xA7;</a><a href="https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var p = new Proxy({}, {
@@ -12986,6 +13087,7 @@ return false;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -13115,6 +13217,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -13127,7 +13230,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="120">2019 features</td>
+<tr class="category"><td colspan="121">2019 features</td>
 </tr>
 <tr significance="0.25"><td id="test-Object.fromEntries"><span><a class="anchor" href="#test-Object.fromEntries">&#xA7;</a><a href="https://github.com/tc39/proposal-object-from-entries">Object.fromEntries</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var object = Object.fromEntries(new Map([[&apos;foo&apos;, 42], [&apos;bar&apos;, 23]]));
@@ -13240,6 +13343,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -13359,6 +13463,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally" data-browser="ios12" data-tally="1">4/4</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">4/4</td>
 <td class="tally" data-browser="ios13" data-tally="1">4/4</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">4/4</td>
@@ -13481,6 +13586,7 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -13603,6 +13709,7 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -13725,6 +13832,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -13847,6 +13955,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -13966,6 +14075,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="ios12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="ios12_2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="ios13" data-tally="1">3/3</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/3</td>
@@ -14088,6 +14198,7 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -14212,6 +14323,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -14335,6 +14447,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -14347,7 +14460,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="120">2019 misc</td>
+<tr class="category"><td colspan="121">2019 misc</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://github.com/tc39/proposal-optional-catch-binding">optional catch binding</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
@@ -14456,6 +14569,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally" data-browser="ios12" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios13" data-tally="1">3/3</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">3/3</td>
@@ -14584,6 +14698,7 @@ return false;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -14713,6 +14828,7 @@ return false;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -14846,6 +14962,7 @@ return it.throw().value;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -14965,6 +15082,7 @@ return it.throw().value;
 <td class="tally" data-browser="ios12" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios13" data-tally="1">3/3</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/3</td>
@@ -15087,6 +15205,7 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -15209,6 +15328,7 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -15332,6 +15452,7 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="no" data-browser="ios12">No</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -15451,6 +15572,7 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="tally" data-browser="ios12" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="ios12_2" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally" data-browser="ios13" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
+<td class="tally" data-browser="ios13_4" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)" data-flagged-tally="1">4/7</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)" data-flagged-tally="1">4/7</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">7/7</td>
@@ -15575,6 +15697,7 @@ return fn + &apos;&apos; === str;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -15698,6 +15821,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -15821,6 +15945,7 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -15944,6 +16069,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -16067,6 +16193,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -16190,6 +16317,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -16313,6 +16441,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no flagged obsolete" data-browser="samsung7">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="no flagged obsolete" data-browser="samsung8">Flag<a href="#chrome-harmony-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -16432,6 +16561,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally" data-browser="ios12" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios13" data-tally="1">2/2</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">2/2</td>
@@ -16554,6 +16684,7 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -16676,6 +16807,7 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -16799,6 +16931,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no" data-browser="ios12">No</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -16811,7 +16944,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="120">2020 features</td>
+<tr class="category"><td colspan="121">2020 features</td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-String.prototype.matchAll"><span><a class="anchor" href="#test-String.prototype.matchAll">&#xA7;</a><a href="https://github.com/tc39/String.prototype.matchAll">String.prototype.matchAll</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -16920,6 +17053,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally" data-browser="ios12" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/2</td>
@@ -17052,6 +17186,7 @@ return a === &apos;1a2b&apos;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -17179,6 +17314,7 @@ try {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -17298,6 +17434,7 @@ try {
 <td class="tally" data-browser="ios12" data-tally="0">0/8</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/8</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/8</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">8/8</td>
@@ -17420,6 +17557,7 @@ return (1n + 2n) === 3n;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -17542,6 +17680,7 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -17664,6 +17803,7 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -17786,6 +17926,7 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -17911,6 +18052,7 @@ return view[0] === -0x8000000000000000n;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -18036,6 +18178,7 @@ return view[0] === 0n;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -18161,6 +18304,7 @@ return view.getBigInt64(0) === 1n;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -18286,6 +18430,7 @@ return view.getBigUint64(0) === 1n;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -18419,6 +18564,7 @@ Promise.allSettled([
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -18538,6 +18684,7 @@ Promise.allSettled([
 <td class="tally" data-browser="ios12" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios13" data-tally="1">2/2</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/2</td>
@@ -18662,6 +18809,7 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no" data-browser="ios12">No</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -18790,6 +18938,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="ios12">No</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -18909,6 +19058,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="ios12" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/4</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/4</td>
@@ -19033,6 +19183,7 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -19157,6 +19308,7 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -19281,6 +19433,7 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -19407,6 +19560,7 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -19534,6 +19688,7 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -19546,7 +19701,7 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="unknown" data-browser="opera_mobile54">?</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr class="category"><td colspan="120">Finished (stage 4)</td>
+<tr class="category"><td colspan="121">Finished (stage 4)</td>
 </tr>
 <tr significance="0.25"><td id="test-String.prototype.replaceAll"><span><a class="anchor" href="#test-String.prototype.replaceAll">&#xA7;</a><a href="https://github.com/tc39/proposal-string-replace-all">String.prototype.replaceAll</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &apos;) === &apos;q=query string parameters&apos;;
@@ -19658,6 +19813,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -230,6 +230,7 @@
 <th class="platform ios12 mobile" data-browser="ios12"><a href="#ios12" class="browser-name"><abbr title="iOS Safari">iOS 12</abbr></a></th>
 <th class="platform ios12_2 mobile" data-browser="ios12_2"><a href="#ios12_2" class="browser-name"><abbr title="iOS Safari">iOS 12.2</abbr></a></th>
 <th class="platform ios13 mobile" data-browser="ios13"><a href="#ios13" class="browser-name"><abbr title="iOS Safari">iOS 13</abbr></a></th>
+<th class="platform ios13_4 mobile" data-browser="ios13_4"><a href="#ios13_4" class="browser-name"><abbr title="iOS Safari">iOS 13.4</abbr></a></th>
 <th class="platform samsung7 mobile obsolete" data-browser="samsung7"><a href="#samsung7" class="browser-name"><abbr title="Samsung Internet for Android 7">Samsung 7</abbr></a></th>
 <th class="platform samsung8 mobile obsolete" data-browser="samsung8"><a href="#samsung8" class="browser-name"><abbr title="Samsung Internet for Android 8">Samsung 8</abbr></a></th>
 <th class="platform samsung9 mobile obsolete" data-browser="samsung9"><a href="#samsung9" class="browser-name"><abbr title="Samsung Internet for Android 9">Samsung 9</abbr></a></th>
@@ -351,6 +352,7 @@
 <td class="tally" data-browser="ios12" data-tally="1">5/5</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">5/5</td>
 <td class="tally" data-browser="ios13" data-tally="1">5/5</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">5/5</td>
@@ -471,6 +473,7 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -593,6 +596,7 @@ return value === 1;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -713,6 +717,7 @@ return { a: true, }.a === true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -833,6 +838,7 @@ return [1,].length === 1;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -953,6 +959,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -965,7 +972,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr><th colspan="118" class="separator"></th>
+<tr><th colspan="119" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
@@ -1072,6 +1079,7 @@ return ({ if: 1 }).if === 1;
 <td class="tally" data-browser="ios12" data-tally="1">13/13</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">13/13</td>
 <td class="tally" data-browser="ios13" data-tally="1">13/13</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">13/13</td>
@@ -1194,6 +1202,7 @@ return typeof Object.create === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1316,6 +1325,7 @@ return typeof Object.defineProperty === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1438,6 +1448,7 @@ return typeof Object.defineProperties === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1560,6 +1571,7 @@ return typeof Object.getPrototypeOf === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1682,6 +1694,7 @@ return typeof Object.keys === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1804,6 +1817,7 @@ return typeof Object.seal === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1926,6 +1940,7 @@ return typeof Object.freeze === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2048,6 +2063,7 @@ return typeof Object.preventExtensions === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2170,6 +2186,7 @@ return typeof Object.isSealed === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2292,6 +2309,7 @@ return typeof Object.isFrozen === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2414,6 +2432,7 @@ return typeof Object.isExtensible === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2536,6 +2555,7 @@ return typeof Object.getOwnPropertyDescriptor === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2658,6 +2678,7 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2775,6 +2796,7 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="tally" data-browser="ios12" data-tally="1">12/12</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">12/12</td>
 <td class="tally" data-browser="ios13" data-tally="1">12/12</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">12/12</td>
@@ -2897,6 +2919,7 @@ return typeof Array.isArray === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3019,6 +3042,7 @@ return typeof Array.prototype.indexOf === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3141,6 +3165,7 @@ return typeof Array.prototype.lastIndexOf === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3263,6 +3288,7 @@ return typeof Array.prototype.every === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3385,6 +3411,7 @@ return typeof Array.prototype.some === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3507,6 +3534,7 @@ return typeof Array.prototype.forEach === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3629,6 +3657,7 @@ return typeof Array.prototype.map === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3751,6 +3780,7 @@ return typeof Array.prototype.filter === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3873,6 +3903,7 @@ return typeof Array.prototype.reduce === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3995,6 +4026,7 @@ return typeof Array.prototype.reduceRight === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4157,6 +4189,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4289,6 +4322,7 @@ try {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4406,6 +4440,7 @@ try {
 <td class="tally" data-browser="ios12" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios13" data-tally="1">2/2</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">2/2</td>
@@ -4528,6 +4563,7 @@ return "foobar"[3] === "b";
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4650,6 +4686,7 @@ return typeof String.prototype.trim === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4767,6 +4804,7 @@ return typeof String.prototype.trim === 'function';
 <td class="tally" data-browser="ios12" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios13" data-tally="1">3/3</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">3/3</td>
@@ -4889,6 +4927,7 @@ return typeof Date.prototype.toISOString === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5011,6 +5050,7 @@ return typeof Date.now === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5141,6 +5181,7 @@ try {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5263,6 +5304,7 @@ return typeof Function.prototype.bind === 'function';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5385,6 +5427,7 @@ return typeof JSON === 'object';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5397,7 +5440,7 @@ return typeof JSON === 'object';
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr><th colspan="118" class="separator"></th>
+<tr><th colspan="119" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -5504,6 +5547,7 @@ return typeof JSON === 'object';
 <td class="tally" data-browser="ios12" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">3/3</td>
 <td class="tally" data-browser="ios13" data-tally="1">3/3</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">3/3</td>
@@ -5627,6 +5671,7 @@ return result;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5750,6 +5795,7 @@ return result;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5873,6 +5919,7 @@ return result;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -5990,6 +6037,7 @@ return result;
 <td class="tally" data-browser="ios12" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="ios12_2" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="ios13" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally" data-browser="ios13_4" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">8/8</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">8/8</td>
@@ -6120,6 +6168,7 @@ try {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -6242,6 +6291,7 @@ return parseInt('010') === 10;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -6362,6 +6412,7 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -6482,6 +6533,7 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -6603,6 +6655,7 @@ return _\u200c\u200d;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -6725,6 +6778,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -6853,6 +6907,7 @@ return result;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -6979,6 +7034,7 @@ catch(e) {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -7096,6 +7152,7 @@ catch(e) {
 <td class="tally" data-browser="ios12" data-tally="1">19/19</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">19/19</td>
 <td class="tally" data-browser="ios13" data-tally="1">19/19</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">19/19</td>
@@ -7221,6 +7278,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -7342,6 +7400,7 @@ return this === void undefined &amp;&amp; (function(){ return this === void unde
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -7465,6 +7524,7 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -7602,6 +7662,7 @@ return test(String, &apos;&apos;)
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -7725,6 +7786,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -7846,6 +7908,7 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -7971,6 +8034,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -8096,6 +8160,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -8223,6 +8288,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -8347,6 +8413,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -8469,6 +8536,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -8592,6 +8660,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -8719,6 +8788,7 @@ return (function(x){
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -8840,6 +8910,7 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -8961,6 +9032,7 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -9082,6 +9154,7 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -9203,6 +9276,7 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -9324,6 +9398,7 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -9445,6 +9520,7 @@ return typeof foo === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -219,6 +219,7 @@
 <th class="platform ios12 mobile" data-browser="ios12"><a href="#ios12" class="browser-name"><abbr title="iOS Safari">iOS 12</abbr></a></th>
 <th class="platform ios12_2 mobile" data-browser="ios12_2"><a href="#ios12_2" class="browser-name"><abbr title="iOS Safari">iOS 12.2</abbr></a></th>
 <th class="platform ios13 mobile" data-browser="ios13"><a href="#ios13" class="browser-name"><abbr title="iOS Safari">iOS 13</abbr></a></th>
+<th class="platform ios13_4 mobile" data-browser="ios13_4"><a href="#ios13_4" class="browser-name"><abbr title="iOS Safari">iOS 13.4</abbr></a></th>
 <th class="platform samsung7 mobile obsolete" data-browser="samsung7"><a href="#samsung7" class="browser-name"><abbr title="Samsung Internet for Android 7">Samsung 7</abbr></a></th>
 <th class="platform samsung8 mobile obsolete" data-browser="samsung8"><a href="#samsung8" class="browser-name"><abbr title="Samsung Internet for Android 8">Samsung 8</abbr></a></th>
 <th class="platform samsung9 mobile obsolete" data-browser="samsung9"><a href="#samsung9" class="browser-name"><abbr title="Samsung Internet for Android 9">Samsung 9</abbr></a></th>
@@ -322,6 +323,7 @@
 <td class="tally" data-browser="ios12" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios13" data-tally="1">2/2</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">2/2</td>
@@ -424,6 +426,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -526,6 +529,7 @@ return Intl.constructor === Object;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -625,6 +629,7 @@ return Intl.constructor === Object;
 <td class="tally" data-browser="ios12" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="ios12_2" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="ios13" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="ios13_4" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
@@ -727,6 +732,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -829,6 +835,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -931,6 +938,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1055,6 +1063,7 @@ try {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1173,6 +1182,7 @@ try {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -1272,6 +1282,7 @@ try {
 <td class="tally" data-browser="ios12" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios13" data-tally="1">1/1</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">1/1</td>
@@ -1374,6 +1385,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1473,6 +1485,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally" data-browser="ios12" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios13" data-tally="1">1/1</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">1/1</td>
@@ -1575,6 +1588,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1674,6 +1688,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally" data-browser="ios12" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally" data-browser="ios12_2" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally" data-browser="ios13" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
+<td class="tally" data-browser="ios13_4" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
@@ -1776,6 +1791,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1878,6 +1894,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -1980,6 +1997,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2082,6 +2100,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2206,6 +2225,7 @@ try {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2324,6 +2344,7 @@ try {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -2423,6 +2444,7 @@ try {
 <td class="tally" data-browser="ios12" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally" data-browser="ios12_2" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally" data-browser="ios13" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
+<td class="tally" data-browser="ios13_4" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
@@ -2525,6 +2547,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2627,6 +2650,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2729,6 +2753,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2853,6 +2878,7 @@ try {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -2971,6 +2997,7 @@ try {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -3074,6 +3101,7 @@ return tz !== void undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3184,6 +3212,7 @@ try {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3283,6 +3312,7 @@ try {
 <td class="tally" data-browser="ios12" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios13" data-tally="1">1/1</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">1/1</td>
@@ -3385,6 +3415,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3484,6 +3515,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally" data-browser="ios12" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios13" data-tally="1">1/1</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">1/1</td>
@@ -3586,6 +3618,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3685,6 +3718,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="ios12" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios13" data-tally="1">1/1</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">1/1</td>
@@ -3787,6 +3821,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3886,6 +3921,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="ios12" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios13" data-tally="1">1/1</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">1/1</td>
@@ -3988,6 +4024,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4087,6 +4124,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="ios12" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios13" data-tally="1">1/1</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">1/1</td>
@@ -4189,6 +4227,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4288,6 +4327,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally" data-browser="ios12" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios13" data-tally="1">1/1</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">1/1</td>
@@ -4390,6 +4430,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -4489,6 +4530,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally" data-browser="ios12" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">1/1</td>
 <td class="tally" data-browser="ios13" data-tally="1">1/1</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">1/1</td>
@@ -4591,6 +4633,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -233,6 +233,7 @@
 <th class="platform ios12 mobile" data-browser="ios12"><a href="#ios12" class="browser-name"><abbr title="iOS Safari">iOS 12</abbr></a></th>
 <th class="platform ios12_2 mobile" data-browser="ios12_2"><a href="#ios12_2" class="browser-name"><abbr title="iOS Safari">iOS 12.2</abbr></a></th>
 <th class="platform ios13 mobile" data-browser="ios13"><a href="#ios13" class="browser-name"><abbr title="iOS Safari">iOS 13</abbr></a></th>
+<th class="platform ios13_4 mobile" data-browser="ios13_4"><a href="#ios13_4" class="browser-name"><abbr title="iOS Safari">iOS 13.4</abbr></a></th>
 <th class="platform samsung7 mobile obsolete" data-browser="samsung7"><a href="#samsung7" class="browser-name"><abbr title="Samsung Internet for Android 7">Samsung 7</abbr></a></th>
 <th class="platform samsung8 mobile obsolete" data-browser="samsung8"><a href="#samsung8" class="browser-name"><abbr title="Samsung Internet for Android 8">Samsung 8</abbr></a></th>
 <th class="platform samsung9 mobile obsolete" data-browser="samsung9"><a href="#samsung9" class="browser-name"><abbr title="Samsung Internet for Android 9">Samsung 9</abbr></a></th>
@@ -249,7 +250,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="117">Candidate (stage 3)</td>
+      <tr class="category"><td colspan="118">Candidate (stage 3)</td>
 </tr>
 <tr class="supertest" significance="1"><td id="test-WeakReferences"><span><a class="anchor" href="#test-WeakReferences">&#xA7;</a><a href="https://github.com/tc39/proposal-weakrefs">WeakReferences</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -355,6 +356,7 @@
 <td class="tally" data-browser="ios12" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/2</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/2</td>
@@ -476,6 +478,7 @@ return weakref.deref() === O;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -596,6 +599,7 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -712,6 +716,7 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally" data-browser="ios12" data-tally="0">0/6</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/6</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/6</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0" data-flagged-tally="0.5">0/6</td>
@@ -834,6 +839,7 @@ return new C().x === &apos;x&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="no flagged obsolete" data-browser="samsung9">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
@@ -962,6 +968,7 @@ return new C(42).x() === 42;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="no flagged obsolete" data-browser="samsung9">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
@@ -1087,6 +1094,7 @@ return new C().x() === 42;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="no flagged obsolete" data-browser="samsung9">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
@@ -1212,6 +1220,7 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -1337,6 +1346,7 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -1459,6 +1469,7 @@ return new C().x === 42;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -1575,6 +1586,7 @@ return new C().x === 42;
 <td class="tally" data-browser="ios12" data-tally="0">0/3</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/3</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/3</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/3</td>
@@ -1697,6 +1709,7 @@ return C.x === &apos;x&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -1822,6 +1835,7 @@ return new C().x() === 42;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -1944,6 +1958,7 @@ return C.x === 42;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -2060,6 +2075,7 @@ return C.x === 42;
 <td class="tally" data-browser="ios12" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/4</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/4</td>
@@ -2185,6 +2201,7 @@ return new C().x() === 42;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -2310,6 +2327,7 @@ return new C().x() === 42;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -2438,6 +2456,7 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -2566,6 +2585,7 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -2686,6 +2706,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="no flagged obsolete" data-browser="samsung9">Flag<a href="#chrome-harmony-note"><sup>[8]</sup></a></td>
@@ -2811,6 +2832,7 @@ Promise.any([
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -2927,6 +2949,7 @@ Promise.any([
 <td class="tally" data-browser="ios12" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios12_2" data-tally="1">2/2</td>
 <td class="tally" data-browser="ios13" data-tally="1">2/2</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="1">2/2</td>
@@ -3052,6 +3075,7 @@ return RegExp.lastMatch === 'x';
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3179,6 +3203,7 @@ return true;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -3295,6 +3320,7 @@ return true;
 <td class="tally" data-browser="ios12" data-tally="0">0/9</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/9</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/9</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/9</td>
@@ -3420,6 +3446,7 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -3542,6 +3569,7 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -3664,6 +3692,7 @@ return i === 1;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -3789,6 +3818,7 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -3911,6 +3941,7 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -4033,6 +4064,7 @@ return i === 1;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -4158,6 +4190,7 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -4280,6 +4313,7 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -4402,6 +4436,7 @@ return i === 1;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -4525,6 +4560,7 @@ try {
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -4537,7 +4573,7 @@ try {
 <td class="yes" data-browser="opera_mobile54">Yes</td>
 <td class="yes" data-browser="opera_mobile55">Yes</td>
 </tr>
-<tr class="category"><td colspan="117">Draft (stage 2)</td>
+<tr class="category"><td colspan="118">Draft (stage 2)</td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/tc39/proposal-function.sent">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -4652,6 +4688,7 @@ return result === &apos;tromple&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -4768,6 +4805,7 @@ return result === &apos;tromple&apos;;
 <td class="tally" data-browser="ios12" data-tally="0">0/1</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/1</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/1</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/1</td>
@@ -4895,6 +4933,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -5017,6 +5056,7 @@ return typeof Realm === &quot;function&quot;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -5133,6 +5173,7 @@ return typeof Realm === &quot;function&quot;
 <td class="tally" data-browser="ios12" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/4</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/4</td>
@@ -5258,6 +5299,7 @@ try {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -5387,6 +5429,7 @@ try {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -5511,6 +5554,7 @@ try {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -5635,6 +5679,7 @@ try {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -5751,6 +5796,7 @@ try {
 <td class="tally" data-browser="ios12" data-tally="0">0/7</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/7</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/7</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/7</td>
@@ -5873,6 +5919,7 @@ return set.size === 2
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -5996,6 +6043,7 @@ return set.size === 3
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -6118,6 +6166,7 @@ return set.size === 2
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -6240,6 +6289,7 @@ return set.size === 2
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -6359,6 +6409,7 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -6478,6 +6529,7 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -6597,6 +6649,7 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -6713,6 +6766,7 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally" data-browser="ios12" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/2</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/2</td>
@@ -6835,6 +6889,7 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -6957,6 +7012,7 @@ return buffer1.byteLength === 0
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -7073,6 +7129,7 @@ return buffer1.byteLength === 0
 <td class="tally" data-browser="ios12" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/2</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/2</td>
@@ -7195,6 +7252,7 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -7318,6 +7376,7 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -7438,6 +7497,7 @@ return !Array.isTemplateObject([])
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -7554,6 +7614,7 @@ return !Array.isTemplateObject([])
 <td class="tally" data-browser="ios12" data-tally="0">0/35</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/35</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/35</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/35</td>
@@ -7673,6 +7734,7 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -7794,6 +7856,7 @@ return instance[Symbol.iterator]() === instance;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -7916,6 +7979,7 @@ return &apos;next&apos; in iterator
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -8043,6 +8107,7 @@ return &apos;next&apos; in iterator
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -8162,6 +8227,7 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -8281,6 +8347,7 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -8400,6 +8467,7 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -8519,6 +8587,7 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -8638,6 +8707,7 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -8757,6 +8827,7 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -8878,6 +8949,7 @@ return result === &apos;123&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -8997,6 +9069,7 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -9116,6 +9189,7 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -9235,6 +9309,7 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -9354,6 +9429,7 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -9474,6 +9550,7 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -9593,6 +9670,7 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -9712,6 +9790,7 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -9833,6 +9912,7 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -9964,6 +10044,7 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -10095,6 +10176,7 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -10226,6 +10308,7 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -10353,6 +10436,7 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -10480,6 +10564,7 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -10601,6 +10686,7 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -10728,6 +10814,7 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -10849,6 +10936,7 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -10976,6 +11064,7 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -11098,6 +11187,7 @@ let result = &apos;&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -11225,6 +11315,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -11346,6 +11437,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -11467,6 +11559,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -11594,6 +11687,7 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -11715,6 +11809,7 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -11834,6 +11929,7 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -11846,7 +11942,7 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="unknown" data-browser="opera_mobile54">?</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr class="category"><td colspan="117">Proposal (stage 1)</td>
+<tr class="category"><td colspan="118">Proposal (stage 1)</td>
 </tr>
 <tr significance="0.25" class="optional-feature"><td id="test-do_expressions"><span><a class="anchor" href="#test-do_expressions">&#xA7;</a><a href="https://github.com/tc39/proposal-do-expressions">do expressions</a></span><script data-source="
 return do {
@@ -11958,6 +12054,7 @@ return do {
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12074,6 +12171,7 @@ return do {
 <td class="tally not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -12193,6 +12291,7 @@ return typeof Observable !== &apos;undefined&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12312,6 +12411,7 @@ return typeof Symbol.observable === &apos;symbol&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12431,6 +12531,7 @@ return &apos;subscribe&apos; in Observable.prototype;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12560,6 +12661,7 @@ return nonCallableCheckPassed &amp;&amp; primitiveCheckPassed &amp;&amp; newChec
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12680,6 +12782,7 @@ return Symbol.observable in Observable.prototype &amp;&amp; o[Symbol.observable]
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12799,6 +12902,7 @@ return Observable.of(1, 2, 3) instanceof Observable;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12918,6 +13022,7 @@ return (Observable.from([1,2,3,4]) instanceof Observable) &amp;&amp; (Observable
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13038,6 +13143,7 @@ return typeof Reflect.Realm.immutableRoot === &apos;function&apos;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13161,6 +13267,7 @@ return Math.signbit(NaN) === false
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13277,6 +13384,7 @@ return Math.signbit(NaN) === false
 <td class="tally not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -13398,6 +13506,7 @@ return Math.clamp(2, 4, 6) === 4
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13517,6 +13626,7 @@ return Math.DEG_PER_RAD === Math.PI / 180;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13637,6 +13747,7 @@ return Math.degrees(Math.PI / 2) === 90
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13756,6 +13867,7 @@ return Math.fscale(3, 1, 2, 1, Math.PI) === Math.fround((3 - 1) * (Math.PI - 1) 
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13875,6 +13987,7 @@ return Math.RAD_PER_DEG === 180 / Math.PI;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13995,6 +14108,7 @@ return Math.radians(90) === Math.PI / 2
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14114,6 +14228,7 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14230,6 +14345,7 @@ return Math.scale(0, 3, 5, 8, 10) === 5;
 <td class="tally not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -14349,6 +14465,7 @@ return typeof Promise.try === &apos;function&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14468,6 +14585,7 @@ return Promise.try(function () {}) instanceof Promise;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14589,6 +14707,7 @@ return score === 1;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14715,6 +14834,7 @@ Promise.try(function() {
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14841,6 +14961,7 @@ Promise.try(function() {
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14967,6 +15088,7 @@ Promise.try(function() {
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15093,6 +15215,7 @@ Promise.try(function() {
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15209,6 +15332,7 @@ Promise.try(function() {
 <td class="tally not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
+<td class="tally not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
@@ -15331,6 +15455,7 @@ return C.get(A) + C.get(B) === 3;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15455,6 +15580,7 @@ return C.get(A) + C.get(B) === 5;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15577,6 +15703,7 @@ return C.has(A) + C.has(B);
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15699,6 +15826,7 @@ return C.has(3) + C.has(4);
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15821,6 +15949,7 @@ return C.get(A) + C.get(B) === 3;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -15945,6 +16074,7 @@ return C.get(A) + C.get(B) === 5;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16067,6 +16197,7 @@ return C.has(A) + C.has(B);
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16189,6 +16320,7 @@ return C.has(A) + C.has(B);
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16320,6 +16452,7 @@ return result === &apos;Hello, hello!&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16443,6 +16576,7 @@ return 123i === &apos;string123number123&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16559,6 +16693,7 @@ return 123i === &apos;string123number123&apos;;
 <td class="tally not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
 <td class="tally not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
 <td class="tally not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
+<td class="tally not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
 <td class="tally obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
 <td class="tally obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
 <td class="tally obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/12</td>
@@ -16682,6 +16817,7 @@ return p(&apos;b&apos;) === &apos;ab&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16805,6 +16941,7 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -16928,6 +17065,7 @@ return p(&apos;a&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17051,6 +17189,7 @@ return p(&apos;b&apos;, &apos;c&apos;) === &apos;abc&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17174,6 +17313,7 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abc&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17297,6 +17437,7 @@ return p(&apos;a&apos;, &apos;b&apos;) === &apos;abcab&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17420,6 +17561,7 @@ return p(&apos;a&apos;, &apos;c&apos;, &apos;d&apos;) === &apos;abcd&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17546,6 +17688,7 @@ return p(&apos;a&apos;) === &apos;ab&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17670,6 +17813,7 @@ return p(&apos;a&apos;) === &apos;abc&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17793,6 +17937,7 @@ return o.f(&apos;a&apos;) === &apos;abfalse&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -17916,6 +18061,7 @@ return p(&apos;a&apos;).x === &apos;ab&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -18039,6 +18185,7 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -18155,6 +18302,7 @@ return p(&apos;b&apos;, &apos;c&apos;).x === &apos;abc&apos;;
 <td class="tally not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
+<td class="tally not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
 <td class="tally obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/8</td>
@@ -18274,6 +18422,7 @@ return Object.isFrozen({# foo: 42 #});
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -18393,6 +18542,7 @@ return Object.isFrozen([# 42 #]);
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -18512,6 +18662,7 @@ return Object.isSealed({| foo: 42 |});
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -18631,6 +18782,7 @@ return Object.isSealed([| 42 |]);
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -18758,6 +18910,7 @@ try {
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -18886,6 +19039,7 @@ try {
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -19013,6 +19167,7 @@ try {
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -19141,6 +19296,7 @@ try {
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -19265,6 +19421,7 @@ return results.length === 3
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -19381,6 +19538,7 @@ return results.length === 3
 <td class="tally not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -19500,6 +19658,7 @@ return [1, 2, 3].lastItem === 3;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -19619,6 +19778,7 @@ return [1, 2, 3].lastIndex === 2;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -19735,6 +19895,7 @@ return [1, 2, 3].lastIndex === 2;
 <td class="tally not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
 <td class="tally not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
 <td class="tally not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
+<td class="tally not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
 <td class="tally obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
 <td class="tally obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
 <td class="tally obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/26</td>
@@ -19859,6 +20020,7 @@ return map.size === 2
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -19981,6 +20143,7 @@ return map.size === 2
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20104,6 +20267,7 @@ return map.size === 2
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20223,6 +20387,7 @@ return new Map([[1, 4], [2, 5], [3, 6]]).every(it =&gt; typeof it === &apos;numb
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20345,6 +20510,7 @@ return map.size === 2
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20464,6 +20630,7 @@ return new Map([[1, 2], [2, 3], [3, 4]]).find(it =&gt; it % 2) === 3;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20583,6 +20750,7 @@ return new Map([[1, 2], [2, 3], [3, 4]]).findKey(it =&gt; it % 2) === 2;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20703,6 +20871,7 @@ return new Map([[1, 2], [2, NaN]]).includes(2)
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20823,6 +20992,7 @@ return new Map([[1, 2], [2, NaN]]).keyOf(2) === 1
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -20946,6 +21116,7 @@ return map.size === 3
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21069,6 +21240,7 @@ return map.size === 3
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21192,6 +21364,7 @@ return map.size === 3
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21311,6 +21484,7 @@ return new Map([[&apos;a&apos;, 1], [&apos;b&apos;, 2], [&apos;c&apos;, 3], ]).r
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21430,6 +21604,7 @@ return new Map([[1, 4], [2, 5], [3, 6]]).some(it =&gt; it % 2);
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21553,6 +21728,7 @@ return set.size === 3
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21676,6 +21852,7 @@ return set.deleteAll(2, 3) === true
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21795,6 +21972,7 @@ return new Set([1, 2, 3]).every(it =&gt; typeof it === &apos;number&apos;);
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -21917,6 +22095,7 @@ return set.size === 2
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22036,6 +22215,7 @@ return new Set([1, 2, 3]).find(it =&gt; !(it % 2)) === 2;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22155,6 +22335,7 @@ return new Set([1, 2, 3]).join(&apos;|&apos;) === &apos;1|2|3&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22278,6 +22459,7 @@ return set.size === 3
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22397,6 +22579,7 @@ return new Set([1, 2, 3]).reduce((memo, it) =&gt; memo + it) === 6;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22516,6 +22699,7 @@ return new Set([1, 2, 3]).some(it =&gt; it % 2);
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22644,6 +22828,7 @@ return !map.has(a)
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22772,6 +22957,7 @@ return set.has(a)
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -22900,6 +23086,7 @@ return !set.has(a)
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -23027,6 +23214,7 @@ return second === gen2.next().value;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -23143,6 +23331,7 @@ return second === gen2.next().value;
 <td class="tally not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -23262,6 +23451,7 @@ return Number.fromString(&apos;42&apos;) === 42;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -23381,6 +23571,7 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -23497,6 +23688,7 @@ return BigInt.fromString(&apos;42&apos;) === 42n;
 <td class="tally not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
+<td class="tally not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
 <td class="tally obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/3</td>
@@ -23620,6 +23812,7 @@ return [...iterator].join() === &apos;a,c&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -23743,6 +23936,7 @@ return [...iterator].join() === &apos;1,3&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -23866,6 +24060,7 @@ return [...iterator].join() === &apos;a,1,c,3&apos;;
 <td class="unknown not-applicable" data-browser="ios12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios12_2" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="ios13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="ios13_4" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung8" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="samsung9" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -206,6 +206,7 @@
 <th class="platform ios12 mobile" data-browser="ios12"><a href="#ios12" class="browser-name"><abbr title="iOS Safari">iOS 12</abbr></a></th>
 <th class="platform ios12_2 mobile" data-browser="ios12_2"><a href="#ios12_2" class="browser-name"><abbr title="iOS Safari">iOS 12.2</abbr></a></th>
 <th class="platform ios13 mobile" data-browser="ios13"><a href="#ios13" class="browser-name"><abbr title="iOS Safari">iOS 13</abbr></a></th>
+<th class="platform ios13_4 mobile" data-browser="ios13_4"><a href="#ios13_4" class="browser-name"><abbr title="iOS Safari">iOS 13.4</abbr></a></th>
 <th class="platform samsung7 mobile obsolete" data-browser="samsung7"><a href="#samsung7" class="browser-name"><abbr title="Samsung Internet for Android 7">Samsung 7</abbr></a></th>
 <th class="platform samsung8 mobile obsolete" data-browser="samsung8"><a href="#samsung8" class="browser-name"><abbr title="Samsung Internet for Android 8">Samsung 8</abbr></a></th>
 <th class="platform samsung9 mobile obsolete" data-browser="samsung9"><a href="#samsung9" class="browser-name"><abbr title="Samsung Internet for Android 9">Samsung 9</abbr></a></th>
@@ -313,6 +314,7 @@
 <td class="tally" data-browser="ios12" data-tally="0">0/57</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/57</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/57</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/57</td>
@@ -427,6 +429,7 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -533,6 +536,7 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -639,6 +643,7 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -745,6 +750,7 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -851,6 +857,7 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -957,6 +964,7 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -1063,6 +1071,7 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -1169,6 +1178,7 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -1275,6 +1285,7 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -1381,6 +1392,7 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -1487,6 +1499,7 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -1595,6 +1608,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -1703,6 +1717,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -1811,6 +1826,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -1919,6 +1935,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -2027,6 +2044,7 @@ return simdBoolTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -2135,6 +2153,7 @@ return simdBoolTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -2243,6 +2262,7 @@ return simdAllTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -2351,6 +2371,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -2459,6 +2480,7 @@ return simdAllTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -2567,6 +2589,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -2675,6 +2698,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -2783,6 +2807,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -2891,6 +2916,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -2999,6 +3025,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -3107,6 +3134,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -3215,6 +3243,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -3323,6 +3352,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -3431,6 +3461,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -3539,6 +3570,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -3647,6 +3679,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -3755,6 +3788,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -3863,6 +3897,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -3971,6 +4006,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -4079,6 +4115,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -4187,6 +4224,7 @@ return simdBoolTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -4295,6 +4333,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -4403,6 +4442,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -4511,6 +4551,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -4619,6 +4660,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -4727,6 +4769,7 @@ return simdAllTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -4835,6 +4878,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -4943,6 +4987,7 @@ return simdIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -5051,6 +5096,7 @@ return simdIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -5159,6 +5205,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -5267,6 +5314,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -5375,6 +5423,7 @@ return simdFloatTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -5483,6 +5532,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -5591,6 +5641,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -5699,6 +5750,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -5807,6 +5859,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -5915,6 +5968,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -6023,6 +6077,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -6131,6 +6186,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -6239,6 +6295,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -6347,6 +6404,7 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -6453,6 +6511,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -6465,7 +6524,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no" data-browser="opera_mobile54">No</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="104" class="separator"></th>
+<tr><th colspan="105" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-decompilation"><span><a class="anchor" href="#test-decompilation">&#xA7;</a>decompilation</span></td>
 <td class="tally obsolete" data-browser="konq4_13" data-tally="0">0/4</td>
@@ -6558,6 +6617,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally" data-browser="ios12" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/4</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/4</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/4</td>
@@ -6664,6 +6724,7 @@ return typeof uneval === &apos;function&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -6778,6 +6839,7 @@ return &apos;toSource&apos; in Object.prototype
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -6884,6 +6946,7 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -7076,6 +7139,7 @@ return true;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -7183,6 +7247,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -7195,7 +7260,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="unknown" data-browser="opera_mobile54">?</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="104" class="separator"></th>
+<tr><th colspan="105" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#test-function_caller_property">&#xA7;</a>function &quot;caller&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;caller&apos; in function(){};
@@ -7293,6 +7358,7 @@ return 'caller' in function(){};
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -7405,6 +7471,7 @@ return (function () {}).arity === 0 &&
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -7519,6 +7586,7 @@ return f(1, 'boo');
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -7627,6 +7695,7 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -7639,7 +7708,7 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no" data-browser="opera_mobile54">No</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="104" class="separator"></th>
+<tr><th colspan="105" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-class_extends_null"><span><a class="anchor" href="#test-class_extends_null">&#xA7;</a><a href="https://github.com/tc39/ecma262/issues/543">class extends null</a></span><script data-source="
 class C extends null {}
@@ -7736,6 +7805,7 @@ return new C instanceof C;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -7846,6 +7916,7 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -7954,6 +8025,7 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -8072,6 +8144,7 @@ return executed;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -8180,6 +8253,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -8288,6 +8362,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -8300,7 +8375,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="opera_mobile54">No</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="104" class="separator"></th>
+<tr><th colspan="105" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Array_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (JS 1.8 style)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions#Differences_to_the_older_JS1.7JS1.8_comprehensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -8398,6 +8473,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -8504,6 +8580,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -8610,6 +8687,7 @@ return (function(x)x)(1) === 1;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -8716,6 +8794,7 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -8826,6 +8905,7 @@ return str === &quot;foobarbaz&quot;;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -8933,6 +9013,7 @@ return arr[1] === arr;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -8945,7 +9026,7 @@ return arr[1] === arr;
 <td class="no" data-browser="opera_mobile54">No</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="104" class="separator"></th>
+<tr><th colspan="105" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#test-Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 /* global Iterator */
@@ -9073,6 +9154,7 @@ catch(e) {
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -9219,6 +9301,7 @@ catch(e) {
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -9364,6 +9447,7 @@ global.test((function () {
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -9472,6 +9556,7 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -9585,6 +9670,7 @@ return passed;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -9597,7 +9683,7 @@ return passed;
 <td class="unknown" data-browser="opera_mobile54">?</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="104" class="separator"></th>
+<tr><th colspan="105" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#test-RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
@@ -9709,6 +9795,7 @@ try {
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -9815,6 +9902,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -9922,6 +10010,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -9934,7 +10023,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no" data-browser="opera_mobile54">No</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="104" class="separator"></th>
+<tr><th colspan="105" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-String.prototype.quote"><span><a class="anchor" href="#test-String.prototype.quote">&#xA7;</a>String.prototype.quote <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/quote" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
@@ -10028,6 +10117,7 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -10132,6 +10222,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -10144,7 +10235,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="unknown" data-browser="opera_mobile54">?</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="104" class="separator"></th>
+<tr><th colspan="105" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#test-Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
@@ -10238,6 +10329,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -10352,6 +10444,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -10364,7 +10457,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="unknown" data-browser="opera_mobile54">?</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="104" class="separator"></th>
+<tr><th colspan="105" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.watch === &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch === 'function' }())</script></td>
@@ -10458,6 +10551,7 @@ function () { return typeof Object.prototype.watch === 'function' }())</script><
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -10562,6 +10656,7 @@ function () { return typeof Object.prototype.unwatch === 'function' }())</script
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -10666,6 +10761,7 @@ function () { return typeof Object.prototype.eval === 'function' }())</script></
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -10772,6 +10868,7 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="unknown" data-browser="ios12">?</td>
 <td class="unknown" data-browser="ios12_2">?</td>
 <td class="unknown" data-browser="ios13">?</td>
+<td class="unknown" data-browser="ios13_4">?</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -10784,7 +10881,7 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no" data-browser="opera_mobile54">No</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="104" class="separator"></th>
+<tr><th colspan="105" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#test-error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 try {
@@ -10890,6 +10987,7 @@ try {
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="yes" data-browser="ios13">Yes</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>
@@ -10998,6 +11096,7 @@ return 'lineNumber' in new Error();
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -11106,6 +11205,7 @@ return 'columnNumber' in new Error();
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -11214,6 +11314,7 @@ return 'fileName' in new Error();
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -11322,6 +11423,7 @@ return 'description' in new Error();
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="no obsolete" data-browser="samsung7">No</td>
 <td class="no obsolete" data-browser="samsung8">No</td>
 <td class="no obsolete" data-browser="samsung9">No</td>
@@ -11334,7 +11436,7 @@ return 'description' in new Error();
 <td class="no" data-browser="opera_mobile54">No</td>
 <td class="no" data-browser="opera_mobile55">No</td>
 </tr>
-<tr><th colspan="104" class="separator"></th>
+<tr><th colspan="105" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-global"><span><a class="anchor" href="#test-global">&#xA7;</a>global</span></td>
 <td class="tally obsolete" data-browser="konq4_13" data-tally="0">0/2</td>
@@ -11427,6 +11529,7 @@ return 'description' in new Error();
 <td class="tally" data-browser="ios12" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios12_2" data-tally="0">0/2</td>
 <td class="tally" data-browser="ios13" data-tally="0">0/2</td>
+<td class="tally" data-browser="ios13_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung7" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung8" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="samsung9" data-tally="0">0/2</td>
@@ -11535,6 +11638,7 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -11648,6 +11752,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no" data-browser="ios12">No</td>
 <td class="no" data-browser="ios12_2">No</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="unknown obsolete" data-browser="samsung7">?</td>
 <td class="unknown obsolete" data-browser="samsung8">?</td>
 <td class="unknown obsolete" data-browser="samsung9">?</td>
@@ -11759,6 +11864,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="yes" data-browser="ios12">Yes</td>
 <td class="yes" data-browser="ios12_2">Yes</td>
 <td class="no" data-browser="ios13">No</td>
+<td class="no" data-browser="ios13_4">No</td>
 <td class="yes obsolete" data-browser="samsung7">Yes</td>
 <td class="yes obsolete" data-browser="samsung8">Yes</td>
 <td class="yes obsolete" data-browser="samsung9">Yes</td>


### PR DESCRIPTION
webkit.org says: iOS support `replaceAll` from  13.1
https://webkit.org/blog/10247/new-webkit-features-in-safari-13-1/

MDN says: iOS support `replaceAll` from 13.4
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll

What resource should I believe?)

https://en.wikipedia.org/wiki/IOS_13