### PR TITLE
Add test for spread parameters after optional chaining

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -4591,6 +4591,28 @@ exports.tests = [
           hermes0_7_0: true,
         }
       },
+      {
+        name: 'spread parameters after optional chaining',
+        exec: function(){/*
+          var fn = null;
+          var n = null;
+          var o = {};
+
+          return fn?.(...[], 1) === void undefined && fn?.(...[], ...[]) === void undefined && o.method?.(...[], 1) === void undefined && n?.method(...[], 1) === void undefined;
+        */},
+        res : {
+          ie11: false,
+          firefox10: false,
+          firefox52: false,
+          firefox73: false,
+          firefox74: true,
+          chrome77: false,
+          chrome80: false,
+          chrome89: false,
+          safari13_1: true,
+          safaritp: true,
+        }
+      }
     ]
   },
   {

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -21336,140 +21336,140 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes" data-browser="opera_mobile61">Yes</td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-optional_chaining_operator_(?.)"><span><a class="anchor" href="#test-optional_chaining_operator_(?.)">&#xA7;</a><a href="https://github.com/tc39/proposal-optional-chaining">optional chaining operator (?.)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
-<td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
-<td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20200927" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="typescript3_9corejs3" data-tally="1">4/4</td>
-<td class="tally" data-browser="typescript4corejs3" data-tally="1">4/4</td>
-<td class="tally" data-browser="es7shim" data-tally="0">0/4</td>
-<td class="tally" data-browser="ie11" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox68" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox73" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="firefox74" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox75" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox76" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox77" data-tally="1">4/4</td>
-<td class="tally" data-browser="firefox78" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox79" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox80" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox81" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox82" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox83" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="firefox84" data-tally="1">4/4</td>
-<td class="tally" data-browser="firefox85" data-tally="1">4/4</td>
-<td class="tally" data-browser="firefox86" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="firefox87" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="firefox88" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="chrome79" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally obsolete" data-browser="chrome80" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome81" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome83" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome84" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="chrome85" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome86" data-tally="1">4/4</td>
-<td class="tally" data-browser="chrome87" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="chrome88" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="chrome89" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge18" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="edge80" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge81" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge83" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge84" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="edge85" data-tally="1">4/4</td>
-<td class="tally" data-browser="edge86" data-tally="1">4/4</td>
-<td class="tally" data-browser="edge87" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="safari12" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="safari13" data-tally="0">0/4</td>
-<td class="tally" data-browser="safari13_1" data-tally="1">4/4</td>
-<td class="tally" data-browser="safari14" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="safari14_1" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="safaritp" data-tally="1">4/4</td>
-<td class="tally unstable" data-browser="webkit" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera63" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera64" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera65" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally obsolete" data-browser="opera66" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally obsolete" data-browser="opera67" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera68" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera69" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera70" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node0_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node0_12" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node4" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node6_5" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node7" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node7_6" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node8" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node8_3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node8_7" data-tally="0">0/4</td>
-<td class="tally" data-browser="node8_10" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node10_0" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node10_4" data-tally="0">0/4</td>
-<td class="tally" data-browser="node10_9" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node11_0" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node12_0" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node12_5" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="node12_9" data-tally="0">0/4</td>
-<td class="tally" data-browser="node12_11" data-tally="0">0/4</td>
-<td class="tally" data-browser="node13_0" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally" data-browser="node13_2" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally" data-browser="node14_0" data-tally="1">4/4</td>
-<td class="tally" data-browser="node14_5" data-tally="1">4/4</td>
-<td class="tally" data-browser="node14_6" data-tally="1">4/4</td>
-<td class="tally" data-browser="node15_0" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="duktape2_2" data-tally="0">0/4</td>
-<td class="tally" data-browser="duktape2_3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="jerryscript2_3_0" data-tally="0">0/4</td>
-<td class="tally" data-browser="jerryscript2_4_0" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="graalvm19" data-tally="0">0/4</td>
-<td class="tally" data-browser="graalvm19_3_6" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="graalvm20" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally obsolete" data-browser="graalvm20_1" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">4/4</td>
-<td class="tally" data-browser="graalvm20_3_1" data-tally="1">4/4</td>
-<td class="tally" data-browser="graalvm21" data-tally="1">4/4</td>
-<td class="tally" data-browser="hermes0_7_0" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ios11" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="ios11_3" data-tally="0">0/4</td>
-<td class="tally" data-browser="ios12" data-tally="0">0/4</td>
-<td class="tally" data-browser="ios12_2" data-tally="0">0/4</td>
-<td class="tally" data-browser="ios13" data-tally="0">0/4</td>
-<td class="tally" data-browser="ios13_4" data-tally="1">4/4</td>
-<td class="tally" data-browser="ios14" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="samsung10" data-tally="0">0/4</td>
-<td class="tally" data-browser="samsung11" data-tally="0">0/4</td>
-<td class="tally" data-browser="samsung12" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally" data-browser="samsung13" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera_mobile55" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="opera_mobile56" data-tally="0" data-flagged-tally="1">0/4</td>
-<td class="tally obsolete" data-browser="opera_mobile57" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera_mobile58" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="opera_mobile59" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera_mobile60" data-tally="1">4/4</td>
-<td class="tally" data-browser="opera_mobile61" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="tr" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="babel7corejs3" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="closure" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/5</td>
+<td class="tally" data-browser="closure20200927" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="typescript3_6corejs3" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="typescript3_7corejs3" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="typescript3_8corejs3" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="typescript3_9corejs3" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="typescript4corejs3" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="es7shim" data-tally="0">0/5</td>
+<td class="tally" data-browser="ie11" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="firefox68" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="firefox73" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="firefox74" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox75" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox76" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox77" data-tally="1">5/5</td>
+<td class="tally" data-browser="firefox78" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox79" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox80" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox81" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox82" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox83" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="firefox84" data-tally="1">5/5</td>
+<td class="tally" data-browser="firefox85" data-tally="1">5/5</td>
+<td class="tally" data-browser="firefox86" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="firefox87" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="firefox88" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="chrome79" data-tally="0" data-flagged-tally="0.8">0/5</td>
+<td class="tally obsolete" data-browser="chrome80" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="chrome81" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="chrome83" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="chrome84" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="chrome85" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="chrome86" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="chrome87" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally unstable" data-browser="chrome88" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally unstable" data-browser="chrome89" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="edge18" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="edge80" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="edge81" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="edge83" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="edge84" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="edge85" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="edge86" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="edge87" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="safari12" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="safari12_1" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="safari13" data-tally="0">0/5</td>
+<td class="tally" data-browser="safari13_1" data-tally="1">5/5</td>
+<td class="tally" data-browser="safari14" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="safari14_1" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="safaritp" data-tally="1">5/5</td>
+<td class="tally unstable" data-browser="webkit" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="opera63" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="opera64" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="opera65" data-tally="0" data-flagged-tally="0.8">0/5</td>
+<td class="tally obsolete" data-browser="opera66" data-tally="0" data-flagged-tally="0.8">0/5</td>
+<td class="tally obsolete" data-browser="opera67" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="opera68" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="opera69" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="opera70" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node0_10" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node0_12" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node4" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node6_5" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node7" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node7_6" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node8" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node8_3" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node8_7" data-tally="0">0/5</td>
+<td class="tally" data-browser="node8_10" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node10_0" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node10_4" data-tally="0">0/5</td>
+<td class="tally" data-browser="node10_9" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node11_0" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node12_0" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node12_5" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="node12_9" data-tally="0">0/5</td>
+<td class="tally" data-browser="node12_11" data-tally="0">0/5</td>
+<td class="tally" data-browser="node13_0" data-tally="0" data-flagged-tally="0.8">0/5</td>
+<td class="tally" data-browser="node13_2" data-tally="0" data-flagged-tally="0.8">0/5</td>
+<td class="tally" data-browser="node14_0" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="node14_5" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="node14_6" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="node15_0" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="duktape2_0" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="duktape2_1" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="duktape2_2" data-tally="0">0/5</td>
+<td class="tally" data-browser="duktape2_3" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="jerryscript2_3_0" data-tally="0">0/5</td>
+<td class="tally" data-browser="jerryscript2_4_0" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="graalvm19" data-tally="0">0/5</td>
+<td class="tally" data-browser="graalvm19_3_6" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="graalvm20" data-tally="0" data-flagged-tally="0.8">0/5</td>
+<td class="tally obsolete" data-browser="graalvm20_1" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="graalvm20_3" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="graalvm20_3_1" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="graalvm21" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="android4_4" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ios11" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="ios11_3" data-tally="0">0/5</td>
+<td class="tally" data-browser="ios12" data-tally="0">0/5</td>
+<td class="tally" data-browser="ios12_2" data-tally="0">0/5</td>
+<td class="tally" data-browser="ios13" data-tally="0">0/5</td>
+<td class="tally" data-browser="ios13_4" data-tally="1">5/5</td>
+<td class="tally" data-browser="ios14" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="samsung10" data-tally="0">0/5</td>
+<td class="tally" data-browser="samsung11" data-tally="0">0/5</td>
+<td class="tally" data-browser="samsung12" data-tally="0" data-flagged-tally="0.8">0/5</td>
+<td class="tally" data-browser="samsung13" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="opera_mobile55" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="opera_mobile56" data-tally="0" data-flagged-tally="0.8">0/5</td>
+<td class="tally obsolete" data-browser="opera_mobile57" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="opera_mobile58" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally obsolete" data-browser="opera_mobile59" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="opera_mobile60" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="opera_mobile61" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 </tr>
 <tr class="subtest" data-parent="optional_chaining_operator_(?.)" id="test-optional_chaining_operator_(?.)_optional_property_access"><td><span><a class="anchor" href="#test-optional_chaining_operator_(?.)_optional_property_access">&#xA7;</a>optional property access</span><script data-source="
 var foo = { baz: 42 };
@@ -22037,6 +22037,149 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="yes" data-browser="opera_mobile60">Yes</td>
 <td class="yes" data-browser="opera_mobile61">Yes</td>
 </tr>
+<tr class="subtest" data-parent="optional_chaining_operator_(?.)" id="test-optional_chaining_operator_(?.)_spread_parameters_after_optional_chaining"><td><span><a class="anchor" href="#test-optional_chaining_operator_(?.)_spread_parameters_after_optional_chaining">&#xA7;</a>spread parameters after optional chaining</span><script data-source="
+var fn = null;
+var n = null;
+var o = {};
+
+return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void undefined &amp;&amp; o.method?.(...[], 1) === void undefined &amp;&amp; n?.method(...[], 1) === void undefined;
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("153");try{return Function("asyncTestPassed","\nvar fn = null;\nvar n = null;\nvar o = {};\n\nreturn fn?.(...[], 1) === void undefined && fn?.(...[], ...[]) === void undefined && o.method?.(...[], 1) === void undefined && n?.method(...[], 1) === void undefined;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("153");return Function("asyncTestPassed","'use strict';"+"\nvar fn = null;\nvar n = null;\nvar o = {};\n\nreturn fn?.(...[], 1) === void undefined && fn?.(...[], ...[]) === void undefined && o.method?.(...[], 1) === void undefined && n?.method(...[], 1) === void undefined;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+</script></td>
+<td class="unknown obsolete" data-browser="tr">?</td>
+<td class="unknown obsolete" data-browser="babel6corejs2">?</td>
+<td class="unknown obsolete" data-browser="babel7corejs2">?</td>
+<td class="unknown" data-browser="babel7corejs3">?</td>
+<td class="unknown obsolete" data-browser="closure">?</td>
+<td class="unknown obsolete" data-browser="closure20190121">?</td>
+<td class="unknown obsolete" data-browser="closure20200101">?</td>
+<td class="unknown obsolete" data-browser="closure20200112">?</td>
+<td class="unknown obsolete" data-browser="closure20200315">?</td>
+<td class="unknown obsolete" data-browser="closure20200517">?</td>
+<td class="unknown obsolete" data-browser="closure20200614">?</td>
+<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
+<td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
+<td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
+<td class="unknown obsolete" data-browser="typescript3_6corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_7corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_8corejs3">?</td>
+<td class="unknown obsolete" data-browser="typescript3_9corejs3">?</td>
+<td class="unknown" data-browser="typescript4corejs3">?</td>
+<td class="unknown" data-browser="es7shim">?</td>
+<td class="no" data-browser="ie11">No</td>
+<td class="no obsolete" data-browser="firefox68">No</td>
+<td class="no obsolete" data-browser="firefox73">No</td>
+<td class="yes obsolete" data-browser="firefox74">Yes</td>
+<td class="yes obsolete" data-browser="firefox75">Yes</td>
+<td class="yes obsolete" data-browser="firefox76">Yes</td>
+<td class="yes obsolete" data-browser="firefox77">Yes</td>
+<td class="yes" data-browser="firefox78">Yes</td>
+<td class="yes obsolete" data-browser="firefox79">Yes</td>
+<td class="yes obsolete" data-browser="firefox80">Yes</td>
+<td class="yes obsolete" data-browser="firefox81">Yes</td>
+<td class="yes obsolete" data-browser="firefox82">Yes</td>
+<td class="yes obsolete" data-browser="firefox83">Yes</td>
+<td class="yes obsolete" data-browser="firefox84">Yes</td>
+<td class="yes" data-browser="firefox85">Yes</td>
+<td class="yes" data-browser="firefox86">Yes</td>
+<td class="yes unstable" data-browser="firefox87">Yes</td>
+<td class="yes unstable" data-browser="firefox88">Yes</td>
+<td class="unknown obsolete" data-browser="opera12_10">?</td>
+<td class="no obsolete" data-browser="chrome79">No</td>
+<td class="no obsolete" data-browser="chrome80">No</td>
+<td class="no obsolete" data-browser="chrome81">No</td>
+<td class="no obsolete" data-browser="chrome83">No</td>
+<td class="no obsolete" data-browser="chrome84">No</td>
+<td class="no obsolete" data-browser="chrome85">No</td>
+<td class="no" data-browser="chrome86">No</td>
+<td class="no" data-browser="chrome87">No</td>
+<td class="no unstable" data-browser="chrome88">No</td>
+<td class="no unstable" data-browser="chrome89">No</td>
+<td class="no obsolete" data-browser="edge18">No</td>
+<td class="no obsolete" data-browser="edge80">No</td>
+<td class="no obsolete" data-browser="edge81">No</td>
+<td class="no obsolete" data-browser="edge83">No</td>
+<td class="no obsolete" data-browser="edge84">No</td>
+<td class="no obsolete" data-browser="edge85">No</td>
+<td class="no" data-browser="edge86">No</td>
+<td class="no" data-browser="edge87">No</td>
+<td class="unknown obsolete" data-browser="safari12">?</td>
+<td class="unknown obsolete" data-browser="safari12_1">?</td>
+<td class="unknown obsolete" data-browser="safari13">?</td>
+<td class="yes" data-browser="safari13_1">Yes</td>
+<td class="yes" data-browser="safari14">Yes</td>
+<td class="yes unstable" data-browser="safari14_1">Yes</td>
+<td class="yes unstable" data-browser="safaritp">Yes</td>
+<td class="yes unstable" data-browser="webkit">Yes</td>
+<td class="unknown obsolete" data-browser="opera63">?</td>
+<td class="no obsolete" data-browser="opera64">No</td>
+<td class="no obsolete" data-browser="opera65">No</td>
+<td class="no obsolete" data-browser="opera66">No</td>
+<td class="no obsolete" data-browser="opera67">No</td>
+<td class="no obsolete" data-browser="opera68">No</td>
+<td class="no" data-browser="opera69">No</td>
+<td class="no" data-browser="opera70">No</td>
+<td class="unknown obsolete" data-browser="phantom2_1">?</td>
+<td class="unknown obsolete" data-browser="node0_10">?</td>
+<td class="unknown obsolete" data-browser="node0_12">?</td>
+<td class="unknown obsolete" data-browser="node4">?</td>
+<td class="unknown obsolete" data-browser="node6_5">?</td>
+<td class="unknown obsolete" data-browser="node7">?</td>
+<td class="unknown obsolete" data-browser="node7_6">?</td>
+<td class="unknown obsolete" data-browser="node8">?</td>
+<td class="unknown obsolete" data-browser="node8_3">?</td>
+<td class="unknown obsolete" data-browser="node8_7">?</td>
+<td class="unknown" data-browser="node8_10">?</td>
+<td class="unknown obsolete" data-browser="node10_0">?</td>
+<td class="unknown obsolete" data-browser="node10_4">?</td>
+<td class="unknown" data-browser="node10_9">?</td>
+<td class="unknown obsolete" data-browser="node11_0">?</td>
+<td class="unknown obsolete" data-browser="node12_0">?</td>
+<td class="unknown obsolete" data-browser="node12_5">?</td>
+<td class="unknown obsolete" data-browser="node12_9">?</td>
+<td class="no" data-browser="node12_11">No</td>
+<td class="no" data-browser="node13_0">No</td>
+<td class="no" data-browser="node13_2">No</td>
+<td class="no" data-browser="node14_0">No</td>
+<td class="no" data-browser="node14_5">No</td>
+<td class="no" data-browser="node14_6">No</td>
+<td class="no" data-browser="node15_0">No</td>
+<td class="unknown obsolete" data-browser="duktape2_0">?</td>
+<td class="unknown obsolete" data-browser="duktape2_1">?</td>
+<td class="unknown obsolete" data-browser="duktape2_2">?</td>
+<td class="unknown" data-browser="duktape2_3">?</td>
+<td class="unknown obsolete" data-browser="jerryscript2_3_0">?</td>
+<td class="unknown" data-browser="jerryscript2_4_0">?</td>
+<td class="unknown obsolete" data-browser="graalvm19">?</td>
+<td class="unknown" data-browser="graalvm19_3_6">?</td>
+<td class="unknown obsolete" data-browser="graalvm20">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_1">?</td>
+<td class="unknown obsolete" data-browser="graalvm20_3">?</td>
+<td class="unknown" data-browser="graalvm20_3_1">?</td>
+<td class="unknown" data-browser="graalvm21">?</td>
+<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="unknown obsolete" data-browser="android4_4">?</td>
+<td class="unknown obsolete" data-browser="android4_4_3">?</td>
+<td class="unknown obsolete" data-browser="ios10_3">?</td>
+<td class="unknown obsolete" data-browser="ios11">?</td>
+<td class="unknown obsolete" data-browser="ios11_3">?</td>
+<td class="unknown" data-browser="ios12">?</td>
+<td class="unknown" data-browser="ios12_2">?</td>
+<td class="unknown" data-browser="ios13">?</td>
+<td class="yes" data-browser="ios13_4">Yes</td>
+<td class="yes" data-browser="ios14">Yes</td>
+<td class="unknown obsolete" data-browser="samsung10">?</td>
+<td class="unknown" data-browser="samsung11">?</td>
+<td class="no" data-browser="samsung12">No</td>
+<td class="no" data-browser="samsung13">No</td>
+<td class="no obsolete" data-browser="opera_mobile55">No</td>
+<td class="no obsolete" data-browser="opera_mobile56">No</td>
+<td class="no obsolete" data-browser="opera_mobile57">No</td>
+<td class="no obsolete" data-browser="opera_mobile58">No</td>
+<td class="no obsolete" data-browser="opera_mobile59">No</td>
+<td class="no" data-browser="opera_mobile60">No</td>
+<td class="no" data-browser="opera_mobile61">No</td>
+</tr>
 <tr significance="0.25"><td id="test-nullish_coalescing_operator_(??)"><span><a class="anchor" href="#test-nullish_coalescing_operator_(??)">&#xA7;</a><a href="https://github.com/tc39/proposal-nullish-coalescing">nullish coalescing operator (??)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return (null ?? 42) === 42 &amp;&amp;
   (undefined ?? 42) === 42 &amp;&amp;
@@ -22044,7 +22187,7 @@ return (null ?? 42) === 42 &amp;&amp;
   (&apos;&apos; ?? 42) === &apos;&apos; &amp;&amp;
   (0 ?? 42) === 0 &amp;&amp;
   isNaN(NaN ?? 42);
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("153");try{return Function("asyncTestPassed","\nreturn (null ?? 42) === 42 &&\n  (undefined ?? 42) === 42 &&\n  (false ?? 42) === false &&\n  ('' ?? 42) === '' &&\n  (0 ?? 42) === 0 &&\n  isNaN(NaN ?? 42);\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("153");return Function("asyncTestPassed","'use strict';"+"\nreturn (null ?? 42) === 42 &&\n  (undefined ?? 42) === 42 &&\n  (false ?? 42) === false &&\n  ('' ?? 42) === '' &&\n  (0 ?? 42) === 0 &&\n  isNaN(NaN ?? 42);\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("154");try{return Function("asyncTestPassed","\nreturn (null ?? 42) === 42 &&\n  (undefined ?? 42) === 42 &&\n  (false ?? 42) === false &&\n  ('' ?? 42) === '' &&\n  (0 ?? 42) === 0 &&\n  isNaN(NaN ?? 42);\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("154");return Function("asyncTestPassed","'use strict';"+"\nreturn (null ?? 42) === 42 &&\n  (undefined ?? 42) === 42 &&\n  (false ?? 42) === false &&\n  ('' ?? 42) === '' &&\n  (0 ?? 42) === 0 &&\n  isNaN(NaN ?? 42);\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -22185,7 +22328,7 @@ return (null ?? 42) === 42 &amp;&amp;
 </tr>
 <tr significance="0.25"><td id="test-String.prototype.replaceAll"><span><a class="anchor" href="#test-String.prototype.replaceAll">&#xA7;</a><a href="https://github.com/tc39/proposal-string-replace-all">String.prototype.replaceAll</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &apos;) === &apos;q=query string parameters&apos;;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("154");try{return Function("asyncTestPassed","\nreturn 'q=query+string+parameters'.replaceAll('+', ' ') === 'q=query string parameters';\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("154");return Function("asyncTestPassed","'use strict';"+"\nreturn 'q=query+string+parameters'.replaceAll('+', ' ') === 'q=query string parameters';\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("155");try{return Function("asyncTestPassed","\nreturn 'q=query+string+parameters'.replaceAll('+', ' ') === 'q=query string parameters';\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("155");return Function("asyncTestPassed","'use strict';"+"\nreturn 'q=query+string+parameters'.replaceAll('+', ' ') === 'q=query string parameters';\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -22466,7 +22609,7 @@ Promise.any([
 ]).then(it =&gt; {
   if (it === 2) asyncTestPassed();
 });
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("156");try{return Function("asyncTestPassed","\nPromise.any([\n  Promise.reject(1),\n  Promise.resolve(2),\n  Promise.resolve(3)\n]).then(it => {\n  if (it === 2) asyncTestPassed();\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("156");return Function("asyncTestPassed","'use strict';"+"\nPromise.any([\n  Promise.reject(1),\n  Promise.resolve(2),\n  Promise.resolve(3)\n]).then(it => {\n  if (it === 2) asyncTestPassed();\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("157");try{return Function("asyncTestPassed","\nPromise.any([\n  Promise.reject(1),\n  Promise.resolve(2),\n  Promise.resolve(3)\n]).then(it => {\n  if (it === 2) asyncTestPassed();\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("157");return Function("asyncTestPassed","'use strict';"+"\nPromise.any([\n  Promise.reject(1),\n  Promise.resolve(2),\n  Promise.resolve(3)\n]).then(it => {\n  if (it === 2) asyncTestPassed();\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -22611,7 +22754,7 @@ Promise.any([
 ]).catch(error =&gt; {
   if (error instanceof AggregateError &amp;&amp; error.errors.length === 3) asyncTestPassed();
 });
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("157");try{return Function("asyncTestPassed","\nPromise.any([\n  Promise.reject(1),\n  Promise.reject(2),\n  Promise.reject(3)\n]).catch(error => {\n  if (error instanceof AggregateError && error.errors.length === 3) asyncTestPassed();\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("157");return Function("asyncTestPassed","'use strict';"+"\nPromise.any([\n  Promise.reject(1),\n  Promise.reject(2),\n  Promise.reject(3)\n]).catch(error => {\n  if (error instanceof AggregateError && error.errors.length === 3) asyncTestPassed();\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("158");try{return Function("asyncTestPassed","\nPromise.any([\n  Promise.reject(1),\n  Promise.reject(2),\n  Promise.reject(3)\n]).catch(error => {\n  if (error instanceof AggregateError && error.errors.length === 3) asyncTestPassed();\n});\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("158");return Function("asyncTestPassed","'use strict';"+"\nPromise.any([\n  Promise.reject(1),\n  Promise.reject(2),\n  Promise.reject(3)\n]).catch(error => {\n  if (error instanceof AggregateError && error.errors.length === 3) asyncTestPassed();\n});\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -22888,7 +23031,7 @@ Promise.any([
 var O = {};
 var weakref = new WeakRef(O);
 return weakref.deref() === O;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("159");try{return Function("asyncTestPassed","\nvar O = {};\nvar weakref = new WeakRef(O);\nreturn weakref.deref() === O;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("159");return Function("asyncTestPassed","'use strict';"+"\nvar O = {};\nvar weakref = new WeakRef(O);\nreturn weakref.deref() === O;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("160");try{return Function("asyncTestPassed","\nvar O = {};\nvar weakref = new WeakRef(O);\nreturn weakref.deref() === O;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("160");return Function("asyncTestPassed","'use strict';"+"\nvar O = {};\nvar weakref = new WeakRef(O);\nreturn weakref.deref() === O;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -23028,7 +23171,7 @@ return weakref.deref() === O;
 <tr class="subtest" data-parent="WeakReferences" id="test-WeakReferences_a_href=_https://github.com/tc39/proposal-weakrefs#finalizers_FinalizationRegistry_minimal_support_/a"><td><span><a class="anchor" href="#test-WeakReferences_a_href=_https://github.com/tc39/proposal-weakrefs#finalizers_FinalizationRegistry_minimal_support_/a">&#xA7;</a><a href="https://github.com/tc39/proposal-weakrefs#finalizers">FinalizationRegistry minimal support</a></span><script data-source="
 var fr = new FinalizationRegistry(function() {});
 return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
-        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("160");try{return Function("asyncTestPassed","\nvar fr = new FinalizationRegistry(function() {});\nreturn Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("160");return Function("asyncTestPassed","'use strict';"+"\nvar fr = new FinalizationRegistry(function() {});\nreturn Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+        ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("161");try{return Function("asyncTestPassed","\nvar fr = new FinalizationRegistry(function() {});\nreturn Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;\n        ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("161");return Function("asyncTestPassed","'use strict';"+"\nvar fr = new FinalizationRegistry(function() {});\nreturn Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;\n        ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -23309,7 +23452,7 @@ a ||= 2;
 b ||= 2;
 c ||= 2;
 return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("162");try{return Function("asyncTestPassed","\nlet a;\nlet b = 0;\nlet c = 1;\na ||= 2;\nb ||= 2;\nc ||= 2;\nreturn a === 2 && b === 2 && c === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("162");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet b = 0;\nlet c = 1;\na ||= 2;\nb ||= 2;\nc ||= 2;\nreturn a === 2 && b === 2 && c === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("163");try{return Function("asyncTestPassed","\nlet a;\nlet b = 0;\nlet c = 1;\na ||= 2;\nb ||= 2;\nc ||= 2;\nreturn a === 2 && b === 2 && c === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("163");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet b = 0;\nlet c = 1;\na ||= 2;\nb ||= 2;\nc ||= 2;\nreturn a === 2 && b === 2 && c === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -23451,7 +23594,7 @@ let a = 1;
 let i = 1;
 a ||= ++i;
 return a === 1 &amp;&amp; i === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("163");try{return Function("asyncTestPassed","\nlet a = 1;\nlet i = 1;\na ||= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("163");return Function("asyncTestPassed","'use strict';"+"\nlet a = 1;\nlet i = 1;\na ||= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("164");try{return Function("asyncTestPassed","\nlet a = 1;\nlet i = 1;\na ||= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("164");return Function("asyncTestPassed","'use strict';"+"\nlet a = 1;\nlet i = 1;\na ||= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -23593,7 +23736,7 @@ let i = 1;
 var obj = { get x() { return 1 }, set x(n) { i++; } };
 obj.x ||= 2;
 return i === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("164");try{return Function("asyncTestPassed","\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ||= 2;\nreturn i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("164");return Function("asyncTestPassed","'use strict';"+"\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ||= 2;\nreturn i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("165");try{return Function("asyncTestPassed","\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ||= 2;\nreturn i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("165");return Function("asyncTestPassed","'use strict';"+"\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ||= 2;\nreturn i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -23738,7 +23881,7 @@ a &amp;&amp;= 2;
 b &amp;&amp;= 2;
 c &amp;&amp;= 2;
 return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("165");try{return Function("asyncTestPassed","\nlet a;\nlet b = 0;\nlet c = 1;\na &&= 2;\nb &&= 2;\nc &&= 2;\nreturn typeof a === 'undefined' && b === 0 && c === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("165");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet b = 0;\nlet c = 1;\na &&= 2;\nb &&= 2;\nc &&= 2;\nreturn typeof a === 'undefined' && b === 0 && c === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("166");try{return Function("asyncTestPassed","\nlet a;\nlet b = 0;\nlet c = 1;\na &&= 2;\nb &&= 2;\nc &&= 2;\nreturn typeof a === 'undefined' && b === 0 && c === 2;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("166");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet b = 0;\nlet c = 1;\na &&= 2;\nb &&= 2;\nc &&= 2;\nreturn typeof a === 'undefined' && b === 0 && c === 2;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -23880,7 +24023,7 @@ let a;
 let i = 1;
 a &amp;&amp;= ++i;
 return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("166");try{return Function("asyncTestPassed","\nlet a;\nlet i = 1;\na &&= ++i;\nreturn typeof a === 'undefined' && i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("166");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet i = 1;\na &&= ++i;\nreturn typeof a === 'undefined' && i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("167");try{return Function("asyncTestPassed","\nlet a;\nlet i = 1;\na &&= ++i;\nreturn typeof a === 'undefined' && i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("167");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet i = 1;\na &&= ++i;\nreturn typeof a === 'undefined' && i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -24022,7 +24165,7 @@ let i = 1;
 var obj = { get x() { return }, set x(n) { i++; } };
 obj.x &amp;&amp;= 2;
 return i === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("167");try{return Function("asyncTestPassed","\nlet i = 1;\nvar obj = { get x() { return }, set x(n) { i++; } };\nobj.x &&= 2;\nreturn i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("167");return Function("asyncTestPassed","'use strict';"+"\nlet i = 1;\nvar obj = { get x() { return }, set x(n) { i++; } };\nobj.x &&= 2;\nreturn i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("168");try{return Function("asyncTestPassed","\nlet i = 1;\nvar obj = { get x() { return }, set x(n) { i++; } };\nobj.x &&= 2;\nreturn i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("168");return Function("asyncTestPassed","'use strict';"+"\nlet i = 1;\nvar obj = { get x() { return }, set x(n) { i++; } };\nobj.x &&= 2;\nreturn i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -24167,7 +24310,7 @@ a ??= 2;
 b ??= 2;
 c ??= 2;
 return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("168");try{return Function("asyncTestPassed","\nlet a;\nlet b = 0;\nlet c = 1;\na ??= 2;\nb ??= 2;\nc ??= 2;\nreturn a === 2 && b === 0 && c === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("168");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet b = 0;\nlet c = 1;\na ??= 2;\nb ??= 2;\nc ??= 2;\nreturn a === 2 && b === 0 && c === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("169");try{return Function("asyncTestPassed","\nlet a;\nlet b = 0;\nlet c = 1;\na ??= 2;\nb ??= 2;\nc ??= 2;\nreturn a === 2 && b === 0 && c === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("169");return Function("asyncTestPassed","'use strict';"+"\nlet a;\nlet b = 0;\nlet c = 1;\na ??= 2;\nb ??= 2;\nc ??= 2;\nreturn a === 2 && b === 0 && c === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -24309,7 +24452,7 @@ let a = 1;
 let i = 1;
 a ??= ++i;
 return a === 1 &amp;&amp; i === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("169");try{return Function("asyncTestPassed","\nlet a = 1;\nlet i = 1;\na ??= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("169");return Function("asyncTestPassed","'use strict';"+"\nlet a = 1;\nlet i = 1;\na ??= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("170");try{return Function("asyncTestPassed","\nlet a = 1;\nlet i = 1;\na ??= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("170");return Function("asyncTestPassed","'use strict';"+"\nlet a = 1;\nlet i = 1;\na ??= ++i;\nreturn a === 1 && i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -24451,7 +24594,7 @@ let i = 1;
 var obj = { get x() { return 1 }, set x(n) { i++; } };
 obj.x ??= 2;
 return i === 1;
-      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("170");try{return Function("asyncTestPassed","\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ??= 2;\nreturn i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("170");return Function("asyncTestPassed","'use strict';"+"\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ??= 2;\nreturn i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+      ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("171");try{return Function("asyncTestPassed","\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ??= 2;\nreturn i === 1;\n      ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("171");return Function("asyncTestPassed","'use strict';"+"\nlet i = 1;\nvar obj = { get x() { return 1 }, set x(n) { i++; } };\nobj.x ??= 2;\nreturn i === 1;\n      ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
@@ -24591,7 +24734,7 @@ return i === 1;
 <tr significance="0.25"><td id="test-numeric_separators"><span><a class="anchor" href="#test-numeric_separators">&#xA7;</a><a href="https://github.com/tc39/proposal-numeric-separator">numeric separators</a></span><script data-source="
 return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
   0b1010_0001_1000_0101 === 0b1010000110000101;
-    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("171");try{return Function("asyncTestPassed","\nreturn 1_000_000.000_001 === 1000000.000001 &&\n  0b1010_0001_1000_0101 === 0b1010000110000101;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("171");return Function("asyncTestPassed","'use strict';"+"\nreturn 1_000_000.000_001 === 1000000.000001 &&\n  0b1010_0001_1000_0101 === 0b1010000110000101;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+    ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("172");try{return Function("asyncTestPassed","\nreturn 1_000_000.000_001 === 1000000.000001 &&\n  0b1010_0001_1000_0101 === 0b1010000110000101;\n    ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("172");return Function("asyncTestPassed","'use strict';"+"\nreturn 1_000_000.000_001 === 1000000.000001 &&\n  0b1010_0001_1000_0101 === 0b1010000110000101;\n    ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>


### PR DESCRIPTION
Ref: https://github.com/babel/babel/issues/13001

I couldn't manually verify the Firefox and Safari data, but @jridgewell wrote that they work in https://github.com/babel/babel/issues/13001 so I copied the same versions for the other optional chaining features.