### PR TITLE
Include patch number in Rhino data

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -45,7 +45,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -74,7 +74,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -104,7 +104,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -148,7 +148,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -186,7 +186,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -224,7 +224,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -252,7 +252,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -293,7 +293,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       },
       {
@@ -342,7 +342,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -373,7 +373,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -418,7 +418,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       },
       {
@@ -455,7 +455,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       }
     ]
@@ -493,7 +493,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -521,7 +521,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       }
     ]
@@ -571,7 +571,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -612,7 +612,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -642,7 +642,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -671,7 +671,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -707,7 +707,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -745,7 +745,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -774,7 +774,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -809,7 +809,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -839,7 +839,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -879,7 +879,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -919,7 +919,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -960,7 +960,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -997,7 +997,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1029,7 +1029,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1058,7 +1058,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1097,7 +1097,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -1167,7 +1167,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1202,7 +1202,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1240,7 +1240,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1277,7 +1277,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1314,7 +1314,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1351,7 +1351,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1388,7 +1388,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1425,7 +1425,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1462,7 +1462,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1499,7 +1499,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1536,7 +1536,7 @@ exports.tests = [
           graalvm20: false,
           graalvm20_1: false,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1573,7 +1573,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1610,7 +1610,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1647,7 +1647,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1684,7 +1684,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1721,7 +1721,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -1758,7 +1758,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -1799,7 +1799,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -1849,7 +1849,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7: true
+      rhino1_7_13: true
     }
   },
   {
@@ -1885,7 +1885,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -1922,7 +1922,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -1959,7 +1959,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -2001,7 +2001,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -2036,7 +2036,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -2077,7 +2077,7 @@ exports.tests = [
         graalvm20: true,
         graalvm20_1: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
       {
@@ -2112,7 +2112,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -2147,7 +2147,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       },
       {
@@ -2183,7 +2183,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       },
       {
@@ -2218,7 +2218,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -2253,7 +2253,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       },
       {
@@ -2290,7 +2290,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       },
       {
@@ -2327,7 +2327,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       },
       {
@@ -2364,7 +2364,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -2397,7 +2397,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -2430,7 +2430,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       },
       {
@@ -2467,7 +2467,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       },
       {
@@ -2504,7 +2504,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       },
       {
@@ -2541,7 +2541,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -2574,7 +2574,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -2607,7 +2607,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       }
     ]
@@ -2641,7 +2641,7 @@ exports.tests = [
         graalvm20: true,
         graalvm20_1: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
       {
@@ -2668,7 +2668,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -2701,7 +2701,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -2734,7 +2734,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -2770,7 +2770,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -2799,7 +2799,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: false,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -2837,7 +2837,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7: true
+      rhino1_7_13: true
     }
   },
   {
@@ -2868,7 +2868,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: false,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -2910,7 +2910,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -2946,7 +2946,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -3011,7 +3011,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -3059,7 +3059,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -3109,7 +3109,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -3146,7 +3146,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -3194,7 +3194,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -3230,7 +3230,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: false,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -3258,7 +3258,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -3288,7 +3288,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: false,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -3329,7 +3329,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -3375,7 +3375,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -3418,7 +3418,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -3454,7 +3454,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -3492,7 +3492,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -3531,7 +3531,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -3561,7 +3561,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -3592,7 +3592,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -3623,7 +3623,7 @@ exports.tests = [
         graalvm20: true,
         graalvm20_1: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }, {
       name: 'arrows',
@@ -3649,7 +3649,7 @@ exports.tests = [
         graalvm20: true,
         graalvm20_1: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }, {
       name: '[native code]',
@@ -3675,7 +3675,7 @@ exports.tests = [
         graalvm20: true,
         graalvm20_1: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }, {
       name: 'class expression with implicit constructor',
@@ -3698,7 +3698,7 @@ exports.tests = [
         graalvm20: true,
         graalvm20_1: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }, {
       name: 'class expression with explicit constructor',
@@ -3721,7 +3721,7 @@ exports.tests = [
         graalvm20: true,
         graalvm20_1: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }, {
       name: 'unicode escape sequences in identifiers',
@@ -3742,7 +3742,7 @@ exports.tests = [
         graalvm20: true,
         graalvm20_1: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }, {
       name: 'methods and computed property names',
@@ -3765,7 +3765,7 @@ exports.tests = [
         graalvm20: true,
         graalvm20_1: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }]
   },
@@ -3797,7 +3797,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -3822,7 +3822,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -3858,7 +3858,7 @@ exports.tests = [
       chrome73: true,
       chrome74: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -3894,7 +3894,7 @@ exports.tests = [
       graalvm20: true,
       graalvm20_1: true,
       hermes0_7_0: false,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -3943,7 +3943,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       },
       {
@@ -3986,7 +3986,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       },
       {
@@ -4019,7 +4019,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       },
       {
@@ -4052,7 +4052,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: true
+          rhino1_7_13: true
         }
       }
     ]
@@ -4101,7 +4101,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4131,7 +4131,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4164,7 +4164,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -4214,7 +4214,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4254,7 +4254,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -4287,7 +4287,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4311,7 +4311,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4334,7 +4334,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4357,7 +4357,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4383,7 +4383,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4409,7 +4409,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4436,7 +4436,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4463,7 +4463,7 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -4505,7 +4505,7 @@ exports.tests = [
       graalvm20: graalvm.es2020flag,
       graalvm20_1: true,
       hermes0_7_0: false,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -4555,7 +4555,7 @@ exports.tests = [
         graalvm20: true,
         graalvm20_1: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }, {
       name: '"globalThis" global property has correct property descriptor',
@@ -4602,7 +4602,7 @@ exports.tests = [
         graalvm20: true,
         graalvm20_1: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }]
   },
@@ -4639,7 +4639,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4668,7 +4668,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4697,7 +4697,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4728,7 +4728,7 @@ exports.tests = [
           graalvm20: graalvm.es2020flag,
           graalvm20_1: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4752,7 +4752,7 @@ exports.tests = [
           chrome89: false,
           safari13_1: true,
           safaritp: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -4791,7 +4791,7 @@ exports.tests = [
       graalvm20: graalvm.es2020flag,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -4827,7 +4827,7 @@ exports.tests = [
       graalvm21: true,
       ios13_4: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -4867,7 +4867,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4897,7 +4897,7 @@ exports.tests = [
           safari14: true,
           safaritp: true,
           hermes0_7_0: false,
-          rhino1_7: false,
+          rhino1_7_13: false,
           jerryscript2_3_0: false,
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true
@@ -4941,7 +4941,7 @@ exports.tests = [
           graalvm20: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -4971,7 +4971,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -5010,7 +5010,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5038,7 +5038,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5066,7 +5066,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5097,7 +5097,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5125,7 +5125,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5153,7 +5153,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5184,7 +5184,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5212,7 +5212,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5240,7 +5240,7 @@ exports.tests = [
           graalvm20_3: graalvm.es2021flag,
           graalvm21: true,
           hermes0_7_0: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -5275,7 +5275,7 @@ exports.tests = [
       graalvm20: graalvm.es2020flag,
       graalvm20_1: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -5310,7 +5310,7 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           graalvm20_1: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5344,7 +5344,7 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           graalvm20_1: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5374,7 +5374,7 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           graalvm20_1: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5407,7 +5407,7 @@ exports.tests = [
           graalvm20_3: true,
           babel7corejs3: false,
           typescript3_8corejs3: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5441,7 +5441,7 @@ exports.tests = [
           graalvm20_3: true,
           babel7corejs3: false,
           typescript3_8corejs3: false,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5467,7 +5467,7 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           graalvm20_1: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -5504,7 +5504,7 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           graalvm20_1: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5533,7 +5533,7 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           graalvm20_1: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5558,7 +5558,7 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           graalvm20_1: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]
@@ -5601,7 +5601,7 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5635,7 +5635,7 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5672,7 +5672,7 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       },
       {
@@ -5709,7 +5709,7 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
-          rhino1_7: false
+          rhino1_7_13: false
         }
       }
     ]

--- a/data-es5.js
+++ b/data-es5.js
@@ -25,7 +25,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -54,7 +54,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -82,7 +82,7 @@ exports.tests = [
       opera12_10: true,
       konq4_3: null,
       besen: null,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: null,
       android4_0: null,
       duktape2_0: true,
@@ -111,7 +111,7 @@ exports.tests = [
       opera12_10: true,
       konq4_3: null,
       besen: null,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: null,
       android4_0: null,
       duktape2_0: true,
@@ -144,7 +144,7 @@ exports.tests = [
       opera12: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -179,7 +179,7 @@ exports.tests = [
       opera12: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -221,7 +221,7 @@ exports.tests = [
       opera12: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -251,7 +251,7 @@ exports.tests = [
       opera12: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -283,7 +283,7 @@ exports.tests = [
       konq4_9: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -316,7 +316,7 @@ exports.tests = [
       konq4_9: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -346,7 +346,7 @@ exports.tests = [
       opera12: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -376,7 +376,7 @@ exports.tests = [
       opera12: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -406,7 +406,7 @@ exports.tests = [
       opera12: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -436,7 +436,7 @@ exports.tests = [
       opera12: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -466,7 +466,7 @@ exports.tests = [
       opera12: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -496,7 +496,7 @@ exports.tests = [
       opera12: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -534,7 +534,7 @@ exports.tests = [
       opera12: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -566,7 +566,7 @@ exports.tests = [
       konq4_9: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -603,7 +603,7 @@ exports.tests = [
       konq4_9: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -633,7 +633,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -663,7 +663,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -693,7 +693,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -723,7 +723,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -753,7 +753,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -783,7 +783,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -813,7 +813,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -843,7 +843,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -873,7 +873,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -929,7 +929,7 @@ exports.tests = [
       konq4_9: null,
       konq4_13: null,
       besen: null,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: null,
       android4_0: false,
       duktape2_0: true,
@@ -966,7 +966,7 @@ exports.tests = [
       konq4_9: null,
       konq4_13: null,
       besen: null,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: null,
       android4_0: true,
       duktape2_0: true,
@@ -1000,7 +1000,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -1061,7 +1061,7 @@ exports.tests = [
       jerryscript1_0: false,
       jerryscript2_2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -1082,7 +1082,7 @@ exports.tests = [
       konq4_9: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -1118,7 +1118,7 @@ exports.tests = [
       opera10_50: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: false,
       android4_0: true,
       duktape2_0: true,
@@ -1147,7 +1147,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -1188,7 +1188,7 @@ exports.tests = [
       opera12_10: true,
       konq4_3: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_0: true,
       duktape2_0: true,
@@ -1221,7 +1221,7 @@ exports.tests = [
     opera12: true,
     konq4_13: true,
     besen: true,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: true,
     ejs: true,
     ios7: true,
@@ -1258,7 +1258,7 @@ exports.tests = [
     konq4_9: true,
     konq4_13: true,
     besen: true,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: true,
     ejs: true,
     ios7: true,
@@ -1300,7 +1300,7 @@ exports.tests = [
       konq4_9: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: false,
       android4_1: true,
       duktape2_0: true,
@@ -1335,7 +1335,7 @@ exports.tests = [
       konq4_9: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: false,
       android4_1: true,
       duktape2_0: true,
@@ -1370,7 +1370,7 @@ exports.tests = [
       konq4_9: true,
       konq4_13: true,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: false,
       android4_1: true,
       duktape2_0: true,
@@ -1410,7 +1410,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: null,
       besen: null,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: null,
       android4_0: null,
       duktape2_0: true,
@@ -1442,7 +1442,7 @@ exports.tests = [
       konq4_9: false,
       konq4_13: false,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_4: true,
       duktape2_0: true,
@@ -1474,7 +1474,7 @@ exports.tests = [
       opera12: true,
       konq4_3: null,
       besen: null,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: null,
       android4_0: null,
       duktape2_0: true,
@@ -1507,7 +1507,7 @@ exports.tests = [
       opera12: true,
       konq4_3: null,
       besen: null,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: null,
       android4_0: null,
       duktape2_0: true,
@@ -1543,7 +1543,7 @@ exports.tests = [
       konq4_9: false,
       konq4_13: false,
       besen: true,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: true,
       android4_1: true,
       duktape2_0: true,
@@ -1576,7 +1576,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: null,
       besen: null,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: null,
       android4_0: null,
       duktape2_0: true,
@@ -1618,7 +1618,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: null,
       besen: null,
-      rhino1_7: false,
+      rhino1_7_13: false,
       ejs: null,
       android4_0: null,
       duktape2_0: false,
@@ -1654,7 +1654,7 @@ exports.tests = [
       opera10_50: true,
       konq4_3: null,
       besen: null,
-      rhino1_7: true,
+      rhino1_7_13: true,
       ejs: null,
       android4_0: null,
       duktape2_0: true,
@@ -1705,7 +1705,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
-      rhino1_7: true
+      rhino1_7_13: true
     }
   },
   {
@@ -1739,7 +1739,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -1771,7 +1771,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -1816,7 +1816,7 @@ exports.tests = [
       jerryscript1_0: false,
       jerryscript2_3_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -1849,7 +1849,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -1880,7 +1880,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
-      rhino1_7: true
+      rhino1_7_13: true
     }
   },
   {
@@ -1915,7 +1915,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -1948,7 +1948,7 @@ exports.tests = [
       jerryscript1_0: false,
       jerryscript2_0: true,
       hermes0_7_0: false,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -1985,7 +1985,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
-      rhino1_7: true
+      rhino1_7_13: true
     }
   },
   {
@@ -2019,7 +2019,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
-      rhino1_7: true
+      rhino1_7_13: true
     }
   },
   {
@@ -2051,7 +2051,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
-      rhino1_7: true
+      rhino1_7_13: true
     }
   },
   {
@@ -2084,7 +2084,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -2121,7 +2121,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
-      rhino1_7: true
+      rhino1_7_13: true
     }
   },
   {
@@ -2152,7 +2152,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalLexicalScopeSuccess,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -2183,7 +2183,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
-      rhino1_7: false
+      rhino1_7_13: false
     }
   },
   {
@@ -2214,7 +2214,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
-      rhino1_7: true
+      rhino1_7_13: true
     }
   },
   {
@@ -2245,7 +2245,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: true,
-      rhino1_7: true
+      rhino1_7_13: true
     }
   },
   {
@@ -2276,7 +2276,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript1_0: true,
       hermes0_7_0: hermes.evalStrictMode,
-      rhino1_7: true
+      rhino1_7_13: true
     }
   },
   {
@@ -2313,7 +2313,7 @@ exports.tests = [
       jerryscript1_0: false,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: true
+      rhino1_7_13: true
     }
   }]
 }

--- a/data-es6.js
+++ b/data-es6.js
@@ -51,7 +51,7 @@ exports.tests = [
         graalvm20_1: false,
         jerryscript2_0: false,
         hermes0_7_0: false,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -90,7 +90,7 @@ exports.tests = [
         graalvm20_1: false,
         jerryscript2_0: false,
         hermes0_7_0: false,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ]
@@ -135,7 +135,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -172,7 +172,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -209,7 +209,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -242,7 +242,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -275,7 +275,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -308,7 +308,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -342,7 +342,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -374,7 +374,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -406,7 +406,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -434,7 +434,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -480,7 +480,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -523,7 +523,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -552,7 +552,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -600,7 +600,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -638,7 +638,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -679,7 +679,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -720,7 +720,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -760,7 +760,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -798,7 +798,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -835,7 +835,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -872,7 +872,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -907,7 +907,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -948,7 +948,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -987,7 +987,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1029,7 +1029,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1071,7 +1071,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1112,7 +1112,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1151,7 +1151,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1189,7 +1189,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1227,7 +1227,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1263,7 +1263,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ]
@@ -1313,7 +1313,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -1351,7 +1351,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -1391,7 +1391,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -1432,7 +1432,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1470,7 +1470,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -1505,7 +1505,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1549,7 +1549,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1587,7 +1587,7 @@ exports.tests = [
         graalvm20: true,
         graalvm20_1: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -1625,7 +1625,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -1664,7 +1664,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -1705,7 +1705,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -1747,7 +1747,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1786,7 +1786,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -1822,7 +1822,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1867,7 +1867,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1905,7 +1905,7 @@ exports.tests = [
         graalvm20: true,
         graalvm20_1: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -1949,7 +1949,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1984,7 +1984,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2019,7 +2019,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2059,7 +2059,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2099,7 +2099,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2134,7 +2134,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2168,7 +2168,7 @@ exports.tests = [
         jerryscript2_0: true,
         hermes0_7_0: true,
         jerryscript2_2_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ]
@@ -2213,7 +2213,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2245,7 +2245,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2285,7 +2285,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2324,7 +2324,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2354,7 +2354,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -2398,7 +2398,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2431,7 +2431,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2467,7 +2467,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2497,7 +2497,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2529,7 +2529,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2560,7 +2560,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2591,7 +2591,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2621,7 +2621,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2655,7 +2655,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2687,7 +2687,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2726,7 +2726,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2760,7 +2760,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2795,7 +2795,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2829,7 +2829,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2865,7 +2865,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ]
@@ -2909,7 +2909,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2948,7 +2948,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -2982,7 +2982,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3016,7 +3016,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3054,7 +3054,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3092,7 +3092,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3130,7 +3130,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3168,7 +3168,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3210,7 +3210,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3248,7 +3248,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3286,7 +3286,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3326,7 +3326,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3364,7 +3364,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3404,7 +3404,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3442,7 +3442,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3480,7 +3480,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3513,7 +3513,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3547,7 +3547,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3583,7 +3583,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3617,7 +3617,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3665,7 +3665,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3708,7 +3708,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3745,7 +3745,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3784,7 +3784,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -3834,7 +3834,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3874,7 +3874,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3915,7 +3915,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3955,7 +3955,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -3997,7 +3997,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -4032,7 +4032,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -4076,7 +4076,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -4120,7 +4120,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -4162,7 +4162,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -4198,7 +4198,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -4233,7 +4233,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -4266,7 +4266,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -4299,7 +4299,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -4334,7 +4334,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ]
@@ -4370,7 +4370,7 @@ exports.tests = [
         ie11: true,
         firefox2: false,
         firefox3_5: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         chrome49: true,
         jxa: true,
         safari10: true,
@@ -4401,7 +4401,7 @@ exports.tests = [
         opera10_50: true,
         opera12: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         xs6: true,
@@ -4437,7 +4437,7 @@ exports.tests = [
         opera10_50: true,
         opera12: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         xs6: true,
@@ -4476,7 +4476,7 @@ exports.tests = [
         opera10_50: false,
         opera12_10: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         xs6: true,
@@ -4523,7 +4523,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -4555,7 +4555,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -4585,7 +4585,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -4614,7 +4614,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -4659,7 +4659,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -4697,7 +4697,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -4732,7 +4732,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -4766,7 +4766,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -4803,7 +4803,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -4841,7 +4841,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -4879,7 +4879,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -4913,7 +4913,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -4949,7 +4949,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -5001,7 +5001,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -5044,7 +5044,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -5089,7 +5089,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -5123,7 +5123,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -5164,7 +5164,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -5203,7 +5203,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -5245,7 +5245,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -5285,7 +5285,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -5329,7 +5329,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -5370,7 +5370,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -5410,7 +5410,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -5452,7 +5452,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -5494,7 +5494,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -5536,7 +5536,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -5577,7 +5577,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -5621,7 +5621,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -5665,7 +5665,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -5709,7 +5709,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -5752,7 +5752,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -5799,7 +5799,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -5843,7 +5843,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -5887,7 +5887,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -5931,7 +5931,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -5975,7 +5975,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6018,7 +6018,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6062,7 +6062,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6100,7 +6100,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -6148,7 +6148,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6186,7 +6186,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6224,7 +6224,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6264,7 +6264,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6302,7 +6302,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -6346,7 +6346,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -6382,7 +6382,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -6413,7 +6413,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -6444,7 +6444,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -6487,7 +6487,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6519,7 +6519,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6567,7 +6567,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6603,7 +6603,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6643,7 +6643,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6691,7 +6691,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6738,7 +6738,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -6783,7 +6783,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6820,7 +6820,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6849,7 +6849,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6879,7 +6879,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6908,7 +6908,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -6936,7 +6936,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -6982,7 +6982,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7019,7 +7019,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7058,7 +7058,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7095,7 +7095,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7132,7 +7132,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7169,7 +7169,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7206,7 +7206,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7243,7 +7243,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7281,7 +7281,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7318,7 +7318,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7355,7 +7355,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7392,7 +7392,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7429,7 +7429,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7466,7 +7466,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7503,7 +7503,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7540,7 +7540,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7577,7 +7577,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -7607,7 +7607,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -7661,7 +7661,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -7704,7 +7704,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -7757,7 +7757,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ].concat([ //@@ jph
@@ -7783,7 +7783,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.of',
@@ -7808,7 +7808,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
     }},
     {
       name: '.prototype.subarray',
@@ -7841,7 +7841,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: true
+      rhino1_7_13: true
     }},
     {
       name: '.prototype.join',
@@ -7866,7 +7866,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.indexOf',
@@ -7892,7 +7892,7 @@ exports.tests = [
       jerryscript2_0: false,
       jerryscript2_1_0: true,
       hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
     }},
     {
       name: '.prototype.lastIndexOf',
@@ -7918,7 +7918,7 @@ exports.tests = [
       jerryscript2_0: false,
       jerryscript2_1_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.slice',
@@ -7943,7 +7943,7 @@ exports.tests = [
       jerryscript2_0: false,
       jerryscript2_1_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.every',
@@ -7968,7 +7968,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.filter',
@@ -7992,7 +7992,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.forEach',
@@ -8017,7 +8017,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.map',
@@ -8041,7 +8041,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.reduce',
@@ -8066,7 +8066,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.reduceRight',
@@ -8091,7 +8091,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.reverse',
@@ -8116,7 +8116,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.some',
@@ -8141,7 +8141,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.sort',
@@ -8165,7 +8165,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.copyWithin',
@@ -8191,7 +8191,7 @@ exports.tests = [
       jerryscript2_0: false,
       jerryscript2_1_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.find',
@@ -8216,7 +8216,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.findIndex',
@@ -8241,7 +8241,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.fill',
@@ -8266,7 +8266,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.keys',
@@ -8291,7 +8291,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.values',
@@ -8316,7 +8316,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype.entries',
@@ -8340,7 +8340,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: false
+      rhino1_7_13: false
     }},
     {
       name: '.prototype[Symbol.iterator]',
@@ -8367,7 +8367,7 @@ exports.tests = [
       graalvm20_1: true,
       jerryscript2_0: true,
       hermes0_7_0: true,
-      rhino1_7: true
+      rhino1_7_13: true
     }},
     {
       name: '[Symbol.species]',
@@ -8393,7 +8393,7 @@ exports.tests = [
       jerryscript2_0: false,
       jerryscript2_2_0: true,
       hermes0_7_0: false,
-      rhino1_7: false
+      rhino1_7_13: false
     }}
     ].map(function(m) {
       var eqFn = ' === "function"';
@@ -8457,7 +8457,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -8495,7 +8495,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -8531,7 +8531,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -8567,7 +8567,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -8608,7 +8608,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -8642,7 +8642,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -8677,7 +8677,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -8716,7 +8716,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -8755,7 +8755,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -8789,7 +8789,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -8823,7 +8823,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -8857,7 +8857,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -8892,7 +8892,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -8927,7 +8927,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -8962,7 +8962,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -8996,7 +8996,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9036,7 +9036,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9077,7 +9077,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -9107,7 +9107,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -9155,7 +9155,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9192,7 +9192,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9228,7 +9228,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9262,7 +9262,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9303,7 +9303,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9340,7 +9340,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -9374,7 +9374,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9414,7 +9414,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9455,7 +9455,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9489,7 +9489,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9523,7 +9523,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9557,7 +9557,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9591,7 +9591,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9626,7 +9626,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9661,7 +9661,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9696,7 +9696,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9736,7 +9736,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9777,7 +9777,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -9807,7 +9807,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -9854,7 +9854,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9891,7 +9891,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9927,7 +9927,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -9963,7 +9963,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10003,7 +10003,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10039,7 +10039,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10073,7 +10073,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -10109,7 +10109,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10143,7 +10143,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10185,7 +10185,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10218,7 +10218,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10257,7 +10257,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -10306,7 +10306,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10341,7 +10341,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10378,7 +10378,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10413,7 +10413,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10453,7 +10453,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10487,7 +10487,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -10522,7 +10522,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10556,7 +10556,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10595,7 +10595,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10628,7 +10628,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -10668,7 +10668,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -10713,7 +10713,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -10740,7 +10740,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -10773,7 +10773,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -10810,7 +10810,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -10863,7 +10863,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -10898,7 +10898,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -10932,7 +10932,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -10985,7 +10985,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11019,7 +11019,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11052,7 +11052,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11102,7 +11102,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11136,7 +11136,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11177,7 +11177,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11222,7 +11222,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11297,7 +11297,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11336,7 +11336,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11390,7 +11390,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11424,7 +11424,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11463,7 +11463,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11502,7 +11502,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11543,7 +11543,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11579,7 +11579,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11626,7 +11626,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11663,7 +11663,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11702,7 +11702,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11745,7 +11745,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11802,7 +11802,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11839,7 +11839,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11878,7 +11878,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11913,7 +11913,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11962,7 +11962,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -11996,7 +11996,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12022,7 +12022,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12050,7 +12050,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -12089,7 +12089,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12118,7 +12118,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12149,7 +12149,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12181,7 +12181,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12210,7 +12210,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12240,7 +12240,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12280,7 +12280,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12317,7 +12317,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12345,7 +12345,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12373,7 +12373,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12401,7 +12401,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12430,7 +12430,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12460,7 +12460,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12491,7 +12491,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12534,7 +12534,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12562,7 +12562,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12591,7 +12591,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12621,7 +12621,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12651,7 +12651,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12685,7 +12685,7 @@ exports.tests = [
         safaritp: true,
         webkit: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12716,7 +12716,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12745,7 +12745,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12782,7 +12782,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12823,7 +12823,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12852,7 +12852,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12880,7 +12880,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12909,7 +12909,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12940,7 +12940,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12969,7 +12969,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -12998,7 +12998,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13027,7 +13027,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13057,7 +13057,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13088,7 +13088,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13118,7 +13118,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13149,7 +13149,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13179,7 +13179,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -13217,7 +13217,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13246,7 +13246,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13275,7 +13275,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13303,7 +13303,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13331,7 +13331,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13359,7 +13359,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13387,7 +13387,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13415,7 +13415,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13445,7 +13445,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13475,7 +13475,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13505,7 +13505,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -13542,7 +13542,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13570,7 +13570,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -13607,7 +13607,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13638,7 +13638,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13668,7 +13668,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13698,7 +13698,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13728,7 +13728,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13758,7 +13758,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -13797,7 +13797,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13826,7 +13826,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13856,7 +13856,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13885,7 +13885,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -13923,7 +13923,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13952,7 +13952,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -13981,7 +13981,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -14023,7 +14023,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14056,7 +14056,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14087,7 +14087,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14119,7 +14119,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14152,7 +14152,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14184,7 +14184,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14214,7 +14214,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14246,7 +14246,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14277,7 +14277,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14309,7 +14309,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14344,7 +14344,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14384,7 +14384,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14414,7 +14414,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14446,7 +14446,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14476,7 +14476,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14507,7 +14507,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14536,7 +14536,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14567,7 +14567,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14595,7 +14595,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14641,7 +14641,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -14689,7 +14689,7 @@ exports.tests = [
     jerryscript2_0: false,
     jerryscript2_3_0: true,
     hermes0_7_0: false,
-    rhino1_7: false
+    rhino1_7_13: false
   }
 },
 {
@@ -14731,7 +14731,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -14766,7 +14766,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -14801,7 +14801,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -14834,7 +14834,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14867,7 +14867,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14901,7 +14901,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14935,7 +14935,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -14969,7 +14969,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -15003,7 +15003,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -15043,7 +15043,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -15081,7 +15081,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -15117,7 +15117,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -15166,7 +15166,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -15200,7 +15200,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -15236,7 +15236,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -15273,7 +15273,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -15306,7 +15306,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -15341,7 +15341,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -15379,7 +15379,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.catchDestructuring,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -15416,7 +15416,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -15452,7 +15452,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -15492,7 +15492,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -15537,7 +15537,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -15573,7 +15573,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -15609,7 +15609,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -15643,7 +15643,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -15677,7 +15677,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -15712,7 +15712,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -15747,7 +15747,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -15781,7 +15781,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -15815,7 +15815,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -15850,7 +15850,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -15886,7 +15886,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -15927,7 +15927,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -15968,7 +15968,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16007,7 +16007,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16041,7 +16041,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16080,7 +16080,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16118,7 +16118,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16168,7 +16168,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16202,7 +16202,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16243,7 +16243,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16281,7 +16281,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16314,7 +16314,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16350,7 +16350,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -16387,7 +16387,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -16432,7 +16432,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -16468,7 +16468,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -16504,7 +16504,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -16538,7 +16538,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16573,7 +16573,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16608,7 +16608,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16643,7 +16643,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16676,7 +16676,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16712,7 +16712,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -16753,7 +16753,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -16791,7 +16791,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -16828,7 +16828,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -16871,7 +16871,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -16906,7 +16906,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -16943,7 +16943,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -16980,7 +16980,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -17012,7 +17012,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },{
       name: 'in parameters, function \'length\' property',
@@ -17045,7 +17045,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -17082,7 +17082,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -17117,7 +17117,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -17153,7 +17153,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -17187,7 +17187,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -17218,7 +17218,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -17253,7 +17253,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -17288,7 +17288,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -17350,7 +17350,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -17385,7 +17385,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -17421,7 +17421,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -17466,7 +17466,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -17509,7 +17509,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -17555,7 +17555,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -17598,7 +17598,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -17627,7 +17627,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -17668,7 +17668,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -17705,7 +17705,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -17746,7 +17746,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -17779,7 +17779,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -17819,7 +17819,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -17850,7 +17850,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -17884,7 +17884,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -17915,7 +17915,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -17946,7 +17946,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -17977,7 +17977,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -18008,7 +18008,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -18039,7 +18039,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -18070,7 +18070,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -18102,7 +18102,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -18128,7 +18128,7 @@ exports.tests = [
         opera10_50: true,
         opera12: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         xs6: true,
@@ -18162,7 +18162,7 @@ exports.tests = [
         opera10_50: true,
         opera12: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         xs6: true,
@@ -18207,7 +18207,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript1_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18238,7 +18238,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18274,7 +18274,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18305,7 +18305,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -18352,7 +18352,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -18389,7 +18389,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -18419,7 +18419,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -18448,7 +18448,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18478,7 +18478,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18511,7 +18511,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18541,7 +18541,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18573,7 +18573,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18603,7 +18603,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -18638,7 +18638,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18673,7 +18673,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18702,7 +18702,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18735,7 +18735,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18768,7 +18768,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18799,7 +18799,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18830,7 +18830,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18859,7 +18859,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -18899,7 +18899,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -18934,7 +18934,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -18977,7 +18977,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19006,7 +19006,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: false,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19041,7 +19041,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19077,7 +19077,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19116,7 +19116,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19152,7 +19152,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19191,7 +19191,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19232,7 +19232,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19265,7 +19265,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19305,7 +19305,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -19341,7 +19341,7 @@ exports.tests = [
         opera10_50: true,
         opera12: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         xs6: false,
@@ -19378,7 +19378,7 @@ exports.tests = [
         opera10_50: true,
         opera12: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         xs6: false,
@@ -19424,7 +19424,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: false,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -19464,7 +19464,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -19493,7 +19493,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_4_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -19521,7 +19521,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_4_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -19545,7 +19545,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_4_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ]
@@ -19590,7 +19590,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -19628,7 +19628,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ]
@@ -19674,7 +19674,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19706,7 +19706,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19748,7 +19748,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19790,7 +19790,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19826,7 +19826,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19867,7 +19867,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19893,7 +19893,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19930,7 +19930,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -19967,7 +19967,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20009,7 +20009,7 @@ exports.tests = [
         jerryscript2_0: true,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20059,7 +20059,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -20091,7 +20091,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -20142,7 +20142,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20177,7 +20177,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -20212,7 +20212,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -20245,7 +20245,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -20274,7 +20274,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: false,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -20310,7 +20310,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20346,7 +20346,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20382,7 +20382,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20418,7 +20418,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20454,7 +20454,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20492,7 +20492,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20525,7 +20525,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20558,7 +20558,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20591,7 +20591,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20624,7 +20624,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20657,7 +20657,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20689,7 +20689,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20722,7 +20722,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20755,7 +20755,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20788,7 +20788,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20826,7 +20826,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20859,7 +20859,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20909,7 +20909,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20960,7 +20960,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -20991,7 +20991,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -21028,7 +21028,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -21068,7 +21068,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -21097,7 +21097,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -21126,7 +21126,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -21155,7 +21155,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -21184,7 +21184,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -21214,7 +21214,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ]
@@ -21243,7 +21243,7 @@ exports.tests = [
         safari3_1: true,
         opera10_50: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         xs6: true,
@@ -21273,7 +21273,7 @@ exports.tests = [
         safari5_1: false,
         safari10: true,
         konq4_14: null,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: false,
         node8: true,
         android4_0: false,
@@ -21311,7 +21311,7 @@ exports.tests = [
         opera10_50: true,
         opera12: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         xs6: true,
@@ -21341,7 +21341,7 @@ exports.tests = [
         opera10_50: true,
         opera12: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         jxa: true,
@@ -21369,7 +21369,7 @@ exports.tests = [
         opera10_50: true,
         opera12: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         jxa: true,
@@ -21398,7 +21398,7 @@ exports.tests = [
         chrome5: true,
         safari3_1: true,
         konq4_14: true,
-        rhino1_7: false,
+        rhino1_7_13: false,
         node0_12: true,
         android4_0: true,
         xs6: true,
@@ -21428,7 +21428,7 @@ exports.tests = [
         chrome5: true,
         safari3_1: true,
         konq4_14: true,
-        rhino1_7: false,
+        rhino1_7_13: false,
         node0_12: true,
         android4_0: true,
         jxa: true,
@@ -21458,7 +21458,7 @@ exports.tests = [
         opera10_50: true,
         opera12: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         xs6: true,
@@ -21490,7 +21490,7 @@ exports.tests = [
         opera10_50: true,
         opera12: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         xs6: true,
@@ -21519,7 +21519,7 @@ exports.tests = [
         opera10_50: true,
         opera12: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         xs6: true,
@@ -21573,7 +21573,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -21606,7 +21606,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -21639,7 +21639,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -21671,7 +21671,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -21704,7 +21704,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -21738,7 +21738,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -21772,7 +21772,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -21805,7 +21805,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -21840,7 +21840,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -21876,7 +21876,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -21906,7 +21906,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -21946,7 +21946,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -21980,7 +21980,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -22014,7 +22014,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -22049,7 +22049,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -22084,7 +22084,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -22148,7 +22148,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -22183,7 +22183,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -22225,7 +22225,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -22264,7 +22264,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -22301,7 +22301,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -22345,7 +22345,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -22380,7 +22380,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -22415,7 +22415,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -22451,7 +22451,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_1_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -22482,7 +22482,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -22513,7 +22513,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -22547,7 +22547,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -22582,7 +22582,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -22617,7 +22617,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -22655,7 +22655,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'imul': {
         ejs: true,
@@ -22689,7 +22689,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'sign': {
         ejs: true,
@@ -22717,7 +22717,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'log10': {
         ejs: true,
@@ -22744,7 +22744,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'log2': {
         ejs: true,
@@ -22772,7 +22772,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'log1p': {
         ejs: true,
@@ -22800,7 +22800,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'expm1': {
         ejs: true,
@@ -22827,7 +22827,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'cosh': {
         ejs: true,
@@ -22855,7 +22855,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'sinh': {
         ejs: true,
@@ -22883,7 +22883,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'tanh': {
         ejs: true,
@@ -22911,7 +22911,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'acosh': {
         ejs: true,
@@ -22939,7 +22939,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'asinh': {
         ejs: true,
@@ -22966,7 +22966,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'atanh': {
         ejs: true,
@@ -22994,7 +22994,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'trunc': {
         ejs: true,
@@ -23021,7 +23021,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'fround': {
         ejs: true,
@@ -23053,7 +23053,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       },
       'cbrt': {
         ejs: true,
@@ -23081,7 +23081,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     };
     var eqFn = ' === "function"';
@@ -23128,7 +23128,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     });
   }()),
@@ -23165,7 +23165,7 @@ exports.tests = [
     jerryscript2_0: false,
     jerryscript2_2_0: true,
     hermes0_7_0: true,
-    rhino1_7: false
+    rhino1_7_13: false
   }
 },
 {
@@ -23205,7 +23205,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23238,7 +23238,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23270,7 +23270,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23299,7 +23299,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23329,7 +23329,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23359,7 +23359,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23389,7 +23389,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23420,7 +23420,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23451,7 +23451,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23483,7 +23483,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23515,7 +23515,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -23555,7 +23555,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23588,7 +23588,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23620,7 +23620,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23652,7 +23652,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -23690,7 +23690,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23720,7 +23720,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23752,7 +23752,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23782,7 +23782,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23812,7 +23812,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23842,7 +23842,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -23901,7 +23901,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23933,7 +23933,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -23976,7 +23976,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24019,7 +24019,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -24059,7 +24059,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24091,7 +24091,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24125,7 +24125,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24157,7 +24157,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24192,7 +24192,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24228,7 +24228,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: hermes.class,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -24290,7 +24290,7 @@ exports.tests = [
         phantom: true,
         ejs: false,
         konq4_14: null,
-        rhino1_7: true,
+        rhino1_7_13: true,
         jxa: true,
         duktape2_0: true,
         nashorn1_8: true,
@@ -24344,7 +24344,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript1_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24393,7 +24393,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24442,7 +24442,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript1_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24484,7 +24484,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript1_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24533,7 +24533,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24579,7 +24579,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -24621,7 +24621,7 @@ exports.tests = [
         safari1: false,
         safari12_1: true,
         safaritp: true,
-        rhino1_7: false,
+        rhino1_7_13: false,
         xs6: null,
         jxa: null,
         node0_10: null,
@@ -24666,7 +24666,7 @@ exports.tests = [
         safari1: false,
         safari14: true,
         webkit: false,
-        rhino1_7: false,
+        rhino1_7_13: false,
         xs6: null,
         jxa: null,
         node0_10: null,
@@ -24712,7 +24712,7 @@ exports.tests = [
         chrome49: true,
         safari1: null,
         safari9: true,
-        rhino1_7: false,
+        rhino1_7_13: false,
         xs6: true,
         jxa: true,
         node0_10: null,
@@ -24763,7 +24763,7 @@ exports.tests = [
         graalvm20_1: true,
         jerryscript2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24782,7 +24782,7 @@ exports.tests = [
         safari3_1: true,
         opera10_50: true,
         opera12: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         xs6: true,
@@ -24832,7 +24832,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24863,7 +24863,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24883,7 +24883,7 @@ exports.tests = [
         opera10_50: true,
         opera12: true,
         konq4_14: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         node0_12: true,
         android4_0: true,
         xs6: true,
@@ -24924,7 +24924,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24952,7 +24952,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -24990,7 +24990,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -25024,7 +25024,7 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -25049,7 +25049,7 @@ exports.tests = [
     opera10_50: false,
     opera12: true,
     konq4_14: true,
-    rhino1_7: true,
+    rhino1_7_13: true,
     node0_12: true,
     android4_0: true,
     ie11: false,

--- a/data-esintl.js
+++ b/data-esintl.js
@@ -31,7 +31,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -53,7 +53,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -82,7 +82,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -105,7 +105,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -128,7 +128,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
 // The spec was updated making this test invalid.  It was disabled until it can be fixed
@@ -193,7 +193,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -226,7 +226,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -255,7 +255,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -284,7 +284,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -313,7 +313,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -335,7 +335,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -358,7 +358,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -381,7 +381,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
 // The spec was updated making this test invalid.  It was disabled until it can be fixed
@@ -446,7 +446,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -479,7 +479,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -508,7 +508,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -531,7 +531,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -554,7 +554,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
 // The spec was updated making this test invalid.  It was disabled until it can be fixed
@@ -619,7 +619,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -651,7 +651,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     },
     {
@@ -681,7 +681,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -711,7 +711,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -744,7 +744,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -777,7 +777,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -810,7 +810,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -843,7 +843,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -876,7 +876,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -909,7 +909,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],
@@ -942,7 +942,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7: true
+        rhino1_7_13: true
       }
     }
   ],

--- a/data-esnext.js
+++ b/data-esnext.js
@@ -37,7 +37,7 @@ exports.tests = [
     graalvm19: false,
     graalvm20: false,
     graalvm20_1: false,
-    rhino1_7: false
+    rhino1_7_13: false
   }
 },
 {
@@ -71,7 +71,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -97,7 +97,7 @@ exports.tests = [
     graalvm19: false,
     graalvm20: false,
     graalvm20_1: false,
-    rhino1_7: false
+    rhino1_7_13: false
   }
 },
 {
@@ -127,7 +127,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -155,7 +155,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -178,7 +178,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -201,7 +201,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ]
@@ -231,7 +231,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -254,7 +254,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -276,7 +276,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -298,7 +298,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -317,7 +317,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -336,7 +336,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -355,7 +355,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ]
@@ -380,7 +380,7 @@ exports.tests = [
         firefox52: false,
         chrome70: false,
         safari12: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -397,7 +397,7 @@ exports.tests = [
         firefox52: false,
         chrome70: false,
         safari12: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ]
@@ -426,7 +426,7 @@ exports.tests = [
         safari3_1: true,
         konq4_4: true,
         besen: false,
-        rhino1_7: true,
+        rhino1_7_13: true,
         phantom: true,
         android4_0: true,
         duktape2_0: false,
@@ -457,7 +457,7 @@ exports.tests = [
         safari3_1: true,
         konq4_4: true,
         besen: false,
-        rhino1_7: true,
+        rhino1_7_13: true,
         phantom: true,
         android4_0: true,
         duktape2_0: false,
@@ -494,7 +494,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -515,7 +515,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ]
@@ -538,7 +538,7 @@ exports.tests = [
     firefox10: false,
     firefox60: false,
     chrome77: false,
-    rhino1_7: false
+    rhino1_7_13: false
   }
 },
 {
@@ -561,7 +561,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -580,7 +580,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -600,7 +600,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -625,7 +625,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -642,7 +642,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -659,7 +659,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -676,7 +676,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -693,7 +693,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -710,7 +710,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -727,7 +727,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -746,7 +746,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -763,7 +763,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -780,7 +780,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -797,7 +797,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -814,7 +814,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -832,7 +832,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -849,7 +849,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -866,7 +866,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -885,7 +885,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -914,7 +914,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -943,7 +943,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -972,7 +972,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -997,7 +997,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1022,7 +1022,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1041,7 +1041,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1066,7 +1066,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1085,7 +1085,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1110,7 +1110,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1130,7 +1130,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1155,7 +1155,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1174,7 +1174,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1193,7 +1193,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1218,7 +1218,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1237,7 +1237,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1254,7 +1254,7 @@ exports.tests = [
         firefox10: false,
         firefox60: false,
         chrome77: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ]
@@ -1289,7 +1289,7 @@ exports.tests = [
     babel7corejs3: false,
     typescript3_2corejs3: false,
     closure: false,
-    rhino1_7: false
+    rhino1_7_13: false
   }
 },
 {
@@ -1328,7 +1328,7 @@ exports.tests = [
         babel7corejs3: babel.corejs,
         typescript4corejs3: typescript.corejs,
         graalvm21: graalvm.es2022flag,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1358,7 +1358,7 @@ exports.tests = [
           note_id: 'safari-at-method'
         },
         graalvm21: graalvm.es2022flag,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1406,7 +1406,7 @@ exports.tests = [
         babel7corejs3: babel.corejs,
         typescript4corejs3: typescript.corejs,
         graalvm21: graalvm.es2022flag,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ]
@@ -1436,7 +1436,7 @@ exports.tests = [
     ie11: false,
     opera10_50: false,
     safari12: false,
-    rhino1_7: false
+    rhino1_7_13: false
   }
 },
 {
@@ -1449,7 +1449,7 @@ exports.tests = [
       #x;
       static check(obj) {
         return #x in obj;
-    rhino1_7: false
+    rhino1_7_13: false
       }
     }
     return A.check(new A) && !A.check({});
@@ -1466,7 +1466,7 @@ exports.tests = [
     ie11: false,
     opera10_50: false,
     safari12: false,
-    rhino1_7: false
+    rhino1_7_13: false
   }
 },
 {
@@ -1491,7 +1491,7 @@ exports.tests = [
         firefox90: false,
         opera10_50: false,
         safari12: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1516,7 +1516,7 @@ exports.tests = [
         firefox90: false,
         opera10_50: false,
         safari12: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ]

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -42,7 +42,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs", note_html: "The feature has to be enabled via <code>--experimental-options --js.simdjs</code> flag"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -66,7 +66,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -90,7 +90,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -114,7 +114,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -138,7 +138,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -162,7 +162,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -186,7 +186,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -210,7 +210,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -234,7 +234,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -258,7 +258,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -282,7 +282,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -308,7 +308,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -334,7 +334,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -360,7 +360,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -386,7 +386,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -412,7 +412,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -438,7 +438,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -464,7 +464,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -490,7 +490,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -516,7 +516,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -542,7 +542,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -568,7 +568,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -594,7 +594,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -620,7 +620,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -646,7 +646,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -672,7 +672,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -698,7 +698,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -723,7 +723,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -748,7 +748,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -773,7 +773,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -799,7 +799,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -826,7 +826,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -852,7 +852,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -879,7 +879,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -905,7 +905,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -931,7 +931,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -957,7 +957,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -983,7 +983,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1009,7 +1009,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1035,7 +1035,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1061,7 +1061,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1087,7 +1087,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1113,7 +1113,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1139,7 +1139,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1165,7 +1165,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1191,7 +1191,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1217,7 +1217,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1243,7 +1243,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1268,7 +1268,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1293,7 +1293,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1318,7 +1318,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1344,7 +1344,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1370,7 +1370,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1396,7 +1396,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1422,7 +1422,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1448,7 +1448,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     },
     {
@@ -1472,7 +1472,7 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }
   ],
@@ -1494,7 +1494,7 @@ exports.tests = [
         firefox74: false,
         opera10_50: false,
         chrome77: false,
-        rhino1_7: true,
+        rhino1_7_13: true,
         duktape2_0: false,
         graalvm19: false,
         graalvm20: false,
@@ -1523,7 +1523,7 @@ exports.tests = [
         opera10_50: false,
         chrome77: false,
         besen: true,
-        rhino1_7: true,
+        rhino1_7_13: true,
         duktape2_0: false,
         graalvm19: false,
         graalvm20: false,
@@ -1541,7 +1541,7 @@ exports.tests = [
         firefox74: false,
         opera10_50: false,
         chrome77: false,
-        rhino1_7: true,
+        rhino1_7_13: true,
         duktape2_0: false,
         graalvm19: false,
         graalvm20: false,
@@ -1646,7 +1646,7 @@ exports.tests = [
         opera10_50: false,
         chrome77: false,
         besen: null,
-        rhino1_7: false,
+        rhino1_7_13: false,
         duktape2_0: false,
         graalvm19: false,
         graalvm20: false,
@@ -1670,7 +1670,7 @@ exports.tests = [
     firefox4: false,
     opera10_50: false,
     chrome77: false,
-    rhino1_7: false,
+    rhino1_7_13: false,
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
@@ -1694,7 +1694,7 @@ exports.tests = [
     safari3_1: true,
     konq4_4: true,
     besen: false,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: true,
     android4_0: true,
     duktape2_0: false,
@@ -1722,7 +1722,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -1749,7 +1749,7 @@ exports.tests = [
     safari3_1: true,
     konq4_4: true,
     besen: false,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: true,
     android4_0: true,
     duktape2_0: false,
@@ -1778,7 +1778,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -1807,7 +1807,7 @@ exports.tests = [
     graalvm19: false,
     graalvm20: false,
     graalvm20_1: false,
-    rhino1_7: false
+    rhino1_7_13: false
   },
 },
 {
@@ -1829,7 +1829,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -1855,7 +1855,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -1886,7 +1886,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: false,
     duktape2_0: false,
     nashorn1_8: true,
@@ -1917,7 +1917,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -1942,7 +1942,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -1972,7 +1972,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2001,7 +2001,7 @@ exports.tests = [
     graalvm19: false,
     graalvm20: false,
     graalvm20_1: false,
-    rhino1_7: false
+    rhino1_7_13: false
   }
 },
 {
@@ -2022,7 +2022,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: true,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: false,
     duktape2_0: false,
     nashorn1_8: true,
@@ -2051,7 +2051,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2081,7 +2081,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: false,
     duktape2_0: false,
     nashorn1_8: true,
@@ -2111,7 +2111,7 @@ exports.tests = [
     konq4_4: null,
     konq4_9: false,
     besen: null,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2153,7 +2153,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2197,7 +2197,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2251,7 +2251,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2279,7 +2279,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2314,7 +2314,7 @@ exports.tests = [
     graalvm19: false,
     graalvm20: false,
     graalvm20_1: false,
-    rhino1_7: false
+    rhino1_7_13: false
   },
   separator: 'after'
 },
@@ -2341,7 +2341,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2364,7 +2364,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2389,7 +2389,7 @@ exports.tests = [
     konq4_4: null,
     konq4_9: true,
     besen: null,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2413,7 +2413,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: null,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2433,7 +2433,7 @@ exports.tests = [
     opera7_5: false,
     opera10_50: false,
     chrome77: false,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2458,7 +2458,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2486,7 +2486,7 @@ exports.tests = [
     chrome77: false,
     konq4_3: true,
     besen: true,
-    rhino1_7: true,
+    rhino1_7_13: true,
     ejs: true,
     android4_0: true,
     duktape2_0: false,
@@ -2512,7 +2512,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2536,7 +2536,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2559,7 +2559,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: true,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2587,7 +2587,7 @@ exports.tests = [
     graalvm19: false,
     graalvm20: false,
     graalvm20_1: false,
-    rhino1_7: false
+    rhino1_7_13: false
   },
   separator: 'after'
 },
@@ -2614,7 +2614,7 @@ exports.tests = [
     safari7_1: true,
     konq4_4: false,
     besen: false,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     android4_0: true,
     duktape2_0: true,
@@ -2643,7 +2643,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: false,
     duktape2_0: true,
     nashorn1_8: true,
@@ -2672,7 +2672,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     nashorn1_8: true,
@@ -2700,7 +2700,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: true,
+    rhino1_7_13: true,
     phantom: false,
     duktape2_0: true,
     nashorn1_8: true,
@@ -2727,7 +2727,7 @@ exports.tests = [
     safari3_1: false,
     konq4_4: false,
     besen: false,
-    rhino1_7: false,
+    rhino1_7_13: false,
     phantom: false,
     duktape2_0: false,
     graalvm19: false,
@@ -2769,7 +2769,7 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-    rhino1_7: false
+    rhino1_7_13: false
       }
     }, {
       name: '"global" global property has correct property descriptor',
@@ -2807,7 +2807,7 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7: false
+        rhino1_7_13: false
       }
     }]
   },
@@ -2845,7 +2845,7 @@ exports.tests = [
     graalvm19: true,
     graalvm20: false,
     graalvm20_1: false,
-    rhino1_7: false
+    rhino1_7_13: false
   },
 },
 ];

--- a/environments.json
+++ b/environments.json
@@ -3309,11 +3309,12 @@
     "release": "2021-04-28",
     "obsolete": false
   },
-  "rhino1_7": {
-    "full": "Rhino 1.7",
-    "short": "Rhino 1.7",
+  "rhino1_7_13": {
+    "full": "Rhino 1.7.13",
+    "short": "Rhino 1.7.13",
     "family": "Rhino",
     "platformtype": "engine",
+    "release": "2020-09-02",
     "obsolete": true
   },
   "besen": {

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -198,7 +198,7 @@
 <th class="platform opera74 desktop obsolete" data-browser="opera74"><a href="#opera74" class="browser-name"><abbr title="Opera 74">OP 74</abbr></a></th>
 <th class="platform opera75 desktop" data-browser="opera75"><a href="#opera75" class="browser-name"><abbr title="Opera 75">OP 75</abbr></a></th>
 <th class="platform opera76 desktop" data-browser="opera76"><a href="#opera76" class="browser-name"><abbr title="Opera 76">OP 76</abbr></a></th>
-<th class="platform rhino1_7 engine obsolete" data-browser="rhino1_7"><a href="#rhino1_7" class="browser-name"><abbr title="Rhino 1.7">Rhino 1.7</abbr></a></th>
+<th class="platform rhino1_7_13 engine obsolete" data-browser="rhino1_7_13"><a href="#rhino1_7_13" class="browser-name"><abbr title="Rhino 1.7.13">Rhino 1.7.13</abbr></a></th>
 <th class="platform phantom2_1 engine obsolete" data-browser="phantom2_1"><a href="#phantom2_1" class="browser-name"><abbr title="PhantomJS 2.1">PJS</abbr></a></th>
 <th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-old-note"><sup>[1]</sup></a></th>
 <th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
@@ -342,7 +342,7 @@
 <td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera75" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/3</td>
@@ -483,7 +483,7 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -624,7 +624,7 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -770,7 +770,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -908,7 +908,7 @@ return true;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera75" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/3</td>
@@ -1053,7 +1053,7 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -1216,7 +1216,7 @@ return 24;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -1362,7 +1362,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -1512,7 +1512,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -1666,7 +1666,7 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="no flagged obsolete" data-browser="node0_12">Flag</td>
@@ -1812,7 +1812,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -1954,7 +1954,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -2097,7 +2097,7 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -2245,7 +2245,7 @@ return passed;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -2395,7 +2395,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -2535,7 +2535,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="opera74" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera75" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera76" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/4</td>
@@ -2679,7 +2679,7 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -2827,7 +2827,7 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -2976,7 +2976,7 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -3120,7 +3120,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -3258,7 +3258,7 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera75" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
@@ -3404,7 +3404,7 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -3550,7 +3550,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -3688,7 +3688,7 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera75" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
@@ -3829,7 +3829,7 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -3970,7 +3970,7 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -4108,7 +4108,7 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">16/16</td>
 <td class="tally" data-browser="opera75" data-tally="1">16/16</td>
 <td class="tally" data-browser="opera76" data-tally="1">16/16</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/16</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/16</td>
@@ -4260,7 +4260,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -4412,7 +4412,7 @@ p.catch(function(result) {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -4554,7 +4554,7 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -4696,7 +4696,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -4844,7 +4844,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -4994,7 +4994,7 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -5136,7 +5136,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -5283,7 +5283,7 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -5425,7 +5425,7 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -5577,7 +5577,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -5729,7 +5729,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -5881,7 +5881,7 @@ var p = new C().a();
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -6031,7 +6031,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -6174,7 +6174,7 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -6315,7 +6315,7 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -6465,7 +6465,7 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -6603,7 +6603,7 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="opera74" data-tally="1">17/17</td>
 <td class="tally" data-browser="opera75" data-tally="1">17/17</td>
 <td class="tally" data-browser="opera76" data-tally="1">17/17</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/17</td>
@@ -6744,7 +6744,7 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -6885,7 +6885,7 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -7026,7 +7026,7 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -7167,7 +7167,7 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -7308,7 +7308,7 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -7449,7 +7449,7 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -7590,7 +7590,7 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -7731,7 +7731,7 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -7872,7 +7872,7 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -8013,7 +8013,7 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -8154,7 +8154,7 @@ return typeof Atomics.wake === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -8295,7 +8295,7 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -8436,7 +8436,7 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -8577,7 +8577,7 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -8718,7 +8718,7 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -8859,7 +8859,7 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -9000,7 +9000,7 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -9146,7 +9146,7 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -9290,7 +9290,7 @@ return (function(){
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -9430,7 +9430,7 @@ return (function(){
 <td class="tally obsolete" data-browser="opera74" data-tally="1">16/16</td>
 <td class="tally" data-browser="opera75" data-tally="1">16/16</td>
 <td class="tally" data-browser="opera76" data-tally="1">16/16</td>
-<td class="tally obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
+<td class="tally obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0.625">10/16</td>
@@ -9576,7 +9576,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -9723,7 +9723,7 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -9870,7 +9870,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -10016,7 +10016,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -10163,7 +10163,7 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -10310,7 +10310,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -10458,7 +10458,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -10606,7 +10606,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -10755,7 +10755,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -10901,7 +10901,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -11046,7 +11046,7 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -11194,7 +11194,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -11342,7 +11342,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -11491,7 +11491,7 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -11637,7 +11637,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -11782,7 +11782,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -11920,7 +11920,7 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally obsolete" data-browser="opera74" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera75" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera76" data-tally="1">4/4</td>
-<td class="tally obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -12065,7 +12065,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12210,7 +12210,7 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12360,7 +12360,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12510,7 +12510,7 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12652,7 +12652,7 @@ return i === 0;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete not-applicable" data-browser="rhino1_7" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes obsolete not-applicable" data-browser="rhino1_7_13" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="node0_12" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
@@ -12792,7 +12792,7 @@ return i === 0;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera75" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
@@ -12934,7 +12934,7 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -13077,7 +13077,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -13215,7 +13215,7 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera75" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/3</td>
@@ -13382,7 +13382,7 @@ function check() {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -13541,7 +13541,7 @@ function check() {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -13702,7 +13702,7 @@ function check() {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -13844,7 +13844,7 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -13992,7 +13992,7 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -14134,7 +14134,7 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -14276,7 +14276,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -14414,7 +14414,7 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera75" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
@@ -14562,7 +14562,7 @@ iterator.next().then(function(step){
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -14720,7 +14720,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -14873,7 +14873,7 @@ return false;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -15021,7 +15021,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -15165,7 +15165,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -15303,7 +15303,7 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera75" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera76" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -15444,7 +15444,7 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -15585,7 +15585,7 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -15726,7 +15726,7 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -15867,7 +15867,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -16005,7 +16005,7 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera75" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/3</td>
@@ -16146,7 +16146,7 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -16289,7 +16289,7 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -16431,7 +16431,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -16571,7 +16571,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera75" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/3</td>
@@ -16718,7 +16718,7 @@ return false;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -16866,7 +16866,7 @@ return false;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -17018,7 +17018,7 @@ return it.throw().value;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -17156,7 +17156,7 @@ return it.throw().value;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera75" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/3</td>
@@ -17297,7 +17297,7 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -17438,7 +17438,7 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -17580,7 +17580,7 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -17718,7 +17718,7 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="tally obsolete" data-browser="opera74" data-tally="1">7/7</td>
 <td class="tally" data-browser="opera75" data-tally="1">7/7</td>
 <td class="tally" data-browser="opera76" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/7</td>
@@ -17861,7 +17861,7 @@ return fn + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -18003,7 +18003,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -18145,7 +18145,7 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -18287,7 +18287,7 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -18429,7 +18429,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -18571,7 +18571,7 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -18713,7 +18713,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -18851,7 +18851,7 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera75" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
@@ -18992,7 +18992,7 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -19133,7 +19133,7 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -19275,7 +19275,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -19415,7 +19415,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera75" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
@@ -19566,7 +19566,7 @@ return a === &apos;1a2b&apos;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -19712,7 +19712,7 @@ try {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -19850,7 +19850,7 @@ try {
 <td class="tally obsolete" data-browser="opera74" data-tally="1">8/8</td>
 <td class="tally" data-browser="opera75" data-tally="1">8/8</td>
 <td class="tally" data-browser="opera76" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/8</td>
@@ -19991,7 +19991,7 @@ return (1n + 2n) === 3n;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -20132,7 +20132,7 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -20273,7 +20273,7 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -20414,7 +20414,7 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -20558,7 +20558,7 @@ return view[0] === -0x8000000000000000n;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -20702,7 +20702,7 @@ return view[0] === 0n;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -20846,7 +20846,7 @@ return view.getBigInt64(0) === 1n;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -20990,7 +20990,7 @@ return view.getBigUint64(0) === 1n;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -21142,7 +21142,7 @@ Promise.allSettled([
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -21280,7 +21280,7 @@ Promise.allSettled([
 <td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera75" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
@@ -21423,7 +21423,7 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
@@ -21570,7 +21570,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
@@ -21708,7 +21708,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally obsolete" data-browser="opera74" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="opera75" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="opera76" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/5</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/5</td>
@@ -21851,7 +21851,7 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -21994,7 +21994,7 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -22137,7 +22137,7 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -22282,7 +22282,7 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -22427,7 +22427,7 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -22573,7 +22573,7 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -22716,7 +22716,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -22854,7 +22854,7 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera75" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
@@ -23001,7 +23001,7 @@ Promise.any([
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -23148,7 +23148,7 @@ Promise.any([
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -23286,7 +23286,7 @@ Promise.any([
 <td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera75" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
@@ -23429,7 +23429,7 @@ return weakref.deref() === O;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -23571,7 +23571,7 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -23709,7 +23709,7 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">9/9</td>
 <td class="tally" data-browser="opera75" data-tally="1">9/9</td>
 <td class="tally" data-browser="opera76" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/9</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/9</td>
@@ -23856,7 +23856,7 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -24000,7 +24000,7 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -24144,7 +24144,7 @@ return i === 1;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -24291,7 +24291,7 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -24435,7 +24435,7 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -24579,7 +24579,7 @@ return i === 1;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -24726,7 +24726,7 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -24870,7 +24870,7 @@ return a === 1 &amp;&amp; i === 1;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -25014,7 +25014,7 @@ return i === 1;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -25156,7 +25156,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -25296,7 +25296,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">6/6</td>
 <td class="tally" data-browser="opera75" data-tally="1">6/6</td>
 <td class="tally" data-browser="opera76" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/6</td>
@@ -25440,7 +25440,7 @@ return new C().x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -25590,7 +25590,7 @@ return new C(42).x() === 42;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -25737,7 +25737,7 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -25884,7 +25884,7 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
@@ -26031,7 +26031,7 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
@@ -26175,7 +26175,7 @@ return new C().x === 42;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -26313,7 +26313,7 @@ return new C().x === 42;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera75" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/3</td>
@@ -26457,7 +26457,7 @@ return C.x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -26604,7 +26604,7 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -26748,7 +26748,7 @@ return C.x === 42;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -26886,7 +26886,7 @@ return C.x === 42;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera75" data-tally="1">4/4</td>
 <td class="tally" data-browser="opera76" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/4</td>
@@ -27033,7 +27033,7 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -27180,7 +27180,7 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -27330,7 +27330,7 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -27480,7 +27480,7 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -185,7 +185,7 @@
 <th class="platform opera74 desktop obsolete" data-browser="opera74"><a href="#opera74" class="browser-name"><abbr title="Opera 74">OP 74</abbr></a></th>
 <th class="platform opera75 desktop" data-browser="opera75"><a href="#opera75" class="browser-name"><abbr title="Opera 75">OP 75</abbr></a></th>
 <th class="platform opera76 desktop" data-browser="opera76"><a href="#opera76" class="browser-name"><abbr title="Opera 76">OP 76</abbr></a></th>
-<th class="platform rhino1_7 engine obsolete" data-browser="rhino1_7"><a href="#rhino1_7" class="browser-name"><abbr title="Rhino 1.7">Rhino 1.7</abbr></a></th>
+<th class="platform rhino1_7_13 engine obsolete" data-browser="rhino1_7_13"><a href="#rhino1_7_13" class="browser-name"><abbr title="Rhino 1.7.13">Rhino 1.7.13</abbr></a></th>
 <th class="platform besen engine" data-browser="besen"><a href="#besen" class="browser-name"><abbr title="Bero&apos;s EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>
 <th class="platform phantom2_1 engine obsolete" data-browser="phantom2_1"><a href="#phantom2_1" class="browser-name"><abbr title="PhantomJS 2.1">PJS</abbr></a></th>
 <th class="platform ejs engine unstable" data-browser="ejs"><a href="#ejs" class="browser-name"><abbr title="Echo JS">Echo JS</abbr></a></th>
@@ -325,7 +325,7 @@
 <td class="tally obsolete" data-browser="opera74" data-tally="1">5/5</td>
 <td class="tally" data-browser="opera75" data-tally="1">5/5</td>
 <td class="tally" data-browser="opera76" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">5/5</td>
 <td class="tally" data-browser="besen" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">5/5</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.6" style="background-color:hsl(72,59%,50%)">3/5</td>
@@ -464,7 +464,7 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -605,7 +605,7 @@ return value === 1;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -744,7 +744,7 @@ return { a: true, }.a === true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
@@ -883,7 +883,7 @@ return [1,].length === 1;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
@@ -1022,7 +1022,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -1160,7 +1160,7 @@ return ({ if: 1 }).if === 1;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">13/13</td>
 <td class="tally" data-browser="opera75" data-tally="1">13/13</td>
 <td class="tally" data-browser="opera76" data-tally="1">13/13</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">13/13</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">13/13</td>
 <td class="tally" data-browser="besen" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">13/13</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">13/13</td>
@@ -1301,7 +1301,7 @@ return typeof Object.create === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -1442,7 +1442,7 @@ return typeof Object.defineProperty === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -1583,7 +1583,7 @@ return typeof Object.defineProperties === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -1724,7 +1724,7 @@ return typeof Object.getPrototypeOf === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -1865,7 +1865,7 @@ return typeof Object.keys === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -2006,7 +2006,7 @@ return typeof Object.seal === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -2147,7 +2147,7 @@ return typeof Object.freeze === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -2288,7 +2288,7 @@ return typeof Object.preventExtensions === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -2429,7 +2429,7 @@ return typeof Object.isSealed === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -2570,7 +2570,7 @@ return typeof Object.isFrozen === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -2711,7 +2711,7 @@ return typeof Object.isExtensible === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -2852,7 +2852,7 @@ return typeof Object.getOwnPropertyDescriptor === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -2993,7 +2993,7 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -3129,7 +3129,7 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="tally obsolete" data-browser="opera74" data-tally="1">12/12</td>
 <td class="tally" data-browser="opera75" data-tally="1">12/12</td>
 <td class="tally" data-browser="opera76" data-tally="1">12/12</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">12/12</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">12/12</td>
 <td class="tally" data-browser="besen" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">10/12</td>
@@ -3270,7 +3270,7 @@ return typeof Array.isArray === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -3411,7 +3411,7 @@ return typeof Array.prototype.indexOf === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -3552,7 +3552,7 @@ return typeof Array.prototype.lastIndexOf === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -3693,7 +3693,7 @@ return typeof Array.prototype.every === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -3834,7 +3834,7 @@ return typeof Array.prototype.some === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -3975,7 +3975,7 @@ return typeof Array.prototype.forEach === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -4116,7 +4116,7 @@ return typeof Array.prototype.map === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -4257,7 +4257,7 @@ return typeof Array.prototype.filter === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -4398,7 +4398,7 @@ return typeof Array.prototype.reduce === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -4539,7 +4539,7 @@ return typeof Array.prototype.reduceRight === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -4720,7 +4720,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
@@ -4871,7 +4871,7 @@ try {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
@@ -5007,7 +5007,7 @@ try {
 <td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera75" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally" data-browser="besen" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -5148,7 +5148,7 @@ return "foobar"[3] === "b";
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -5313,7 +5313,7 @@ return typeof String.prototype.split === 'function'
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
@@ -5454,7 +5454,7 @@ return typeof String.prototype.trim === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -5590,7 +5590,7 @@ return typeof String.prototype.trim === 'function';
 <td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera75" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">3/3</td>
 <td class="tally" data-browser="besen" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -5731,7 +5731,7 @@ return typeof Date.prototype.toISOString === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
@@ -5872,7 +5872,7 @@ return typeof Date.now === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -6021,7 +6021,7 @@ try {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -6162,7 +6162,7 @@ return typeof Function.prototype.bind === 'function';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -6303,7 +6303,7 @@ return typeof JSON === 'object';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -6441,7 +6441,7 @@ return typeof JSON === 'object';
 <td class="tally obsolete" data-browser="opera74" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera75" data-tally="1">3/3</td>
 <td class="tally" data-browser="opera76" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">3/3</td>
 <td class="tally" data-browser="besen" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">3/3</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0">0/3</td>
@@ -6583,7 +6583,7 @@ return result;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
@@ -6725,7 +6725,7 @@ return result;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
@@ -6867,7 +6867,7 @@ return result;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="no unstable" data-browser="ejs">No</td>
@@ -7003,7 +7003,7 @@ return result;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">8/8</td>
 <td class="tally" data-browser="opera75" data-tally="1">8/8</td>
 <td class="tally" data-browser="opera76" data-tally="1">8/8</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally" data-browser="besen" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally unstable" data-browser="ejs" data-tally="0.25" style="background-color:hsl(30,75%,50%)">2/8</td>
@@ -7152,7 +7152,7 @@ try {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
@@ -7293,7 +7293,7 @@ return parseInt('010') === 10;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -7432,7 +7432,7 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
@@ -7571,7 +7571,7 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
@@ -7711,7 +7711,7 @@ return _\u200c\u200d;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -7852,7 +7852,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
@@ -7999,7 +7999,7 @@ return result;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
@@ -8144,7 +8144,7 @@ catch(e) {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown unstable" data-browser="ejs">?</td>
@@ -8280,7 +8280,7 @@ catch(e) {
 <td class="tally obsolete" data-browser="opera74" data-tally="1">19/19</td>
 <td class="tally" data-browser="opera75" data-tally="1">19/19</td>
 <td class="tally" data-browser="opera76" data-tally="1">19/19</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0.5263157894736842" style="background-color:hsl(63,62%,50%)">10/19</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.5263157894736842" style="background-color:hsl(63,62%,50%)">10/19</td>
 <td class="tally" data-browser="besen" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0.9473684210526315" style="background-color:hsl(113,44%,50%)">18/19</td>
 <td class="tally unstable" data-browser="ejs" data-tally="1">19/19</td>
@@ -8424,7 +8424,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -8564,7 +8564,7 @@ return this === void undefined &amp;&amp; (function(){ return this === void unde
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -8706,7 +8706,7 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -8862,7 +8862,7 @@ return test(String, &apos;&apos;)
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -9004,7 +9004,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -9144,7 +9144,7 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -9288,7 +9288,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -9432,7 +9432,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -9578,7 +9578,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -9721,7 +9721,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -9862,7 +9862,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -10004,7 +10004,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -10150,7 +10150,7 @@ return (function(x){
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -10290,7 +10290,7 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -10430,7 +10430,7 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -10570,7 +10570,7 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -10710,7 +10710,7 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -10850,7 +10850,7 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>
@@ -10990,7 +10990,7 @@ return typeof foo === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="yes unstable" data-browser="ejs">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -189,7 +189,7 @@
 <th class="platform opera74 desktop obsolete" data-browser="opera74"><a href="#opera74" class="browser-name"><abbr title="Opera 74">OP 74</abbr></a></th>
 <th class="platform opera75 desktop" data-browser="opera75"><a href="#opera75" class="browser-name"><abbr title="Opera 75">OP 75</abbr></a></th>
 <th class="platform opera76 desktop" data-browser="opera76"><a href="#opera76" class="browser-name"><abbr title="Opera 76">OP 76</abbr></a></th>
-<th class="platform rhino1_7 engine obsolete" data-browser="rhino1_7"><a href="#rhino1_7" class="browser-name"><abbr title="Rhino 1.7">Rhino 1.7</abbr></a></th>
+<th class="platform rhino1_7_13 engine obsolete" data-browser="rhino1_7_13"><a href="#rhino1_7_13" class="browser-name"><abbr title="Rhino 1.7.13">Rhino 1.7.13</abbr></a></th>
 <th class="platform phantom2_1 engine obsolete" data-browser="phantom2_1"><a href="#phantom2_1" class="browser-name"><abbr title="PhantomJS 2.1">PJS</abbr></a></th>
 <th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-old-note"><sup>[1]</sup></a></th>
 <th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
@@ -310,7 +310,7 @@
 <td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera75" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">2/2</td>
@@ -430,7 +430,7 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -550,7 +550,7 @@ return Intl.constructor === Object;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -667,7 +667,7 @@ return Intl.constructor === Object;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">5/5</td>
 <td class="tally" data-browser="opera75" data-tally="1">5/5</td>
 <td class="tally" data-browser="opera76" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.2" style="background-color:hsl(24,77%,50%)">1/5</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
@@ -787,7 +787,7 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -907,7 +907,7 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -1027,7 +1027,7 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -1169,7 +1169,7 @@ try {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -1305,7 +1305,7 @@ try {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -1422,7 +1422,7 @@ try {
 <td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera75" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
@@ -1542,7 +1542,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -1659,7 +1659,7 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera75" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
@@ -1779,7 +1779,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -1896,7 +1896,7 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">6/6</td>
 <td class="tally" data-browser="opera75" data-tally="1">6/6</td>
 <td class="tally" data-browser="opera76" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
@@ -2016,7 +2016,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -2136,7 +2136,7 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -2256,7 +2256,7 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -2376,7 +2376,7 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -2518,7 +2518,7 @@ try {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -2654,7 +2654,7 @@ try {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -2771,7 +2771,7 @@ try {
 <td class="tally obsolete" data-browser="opera74" data-tally="1">7/7</td>
 <td class="tally" data-browser="opera75" data-tally="1">7/7</td>
 <td class="tally" data-browser="opera76" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
@@ -2891,7 +2891,7 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -3011,7 +3011,7 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -3131,7 +3131,7 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -3273,7 +3273,7 @@ try {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -3409,7 +3409,7 @@ try {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -3530,7 +3530,7 @@ return tz !== void undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -3658,7 +3658,7 @@ try {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -3775,7 +3775,7 @@ try {
 <td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera75" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
@@ -3895,7 +3895,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -4012,7 +4012,7 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera75" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
@@ -4132,7 +4132,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -4249,7 +4249,7 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera75" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
@@ -4369,7 +4369,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -4486,7 +4486,7 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera75" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
@@ -4606,7 +4606,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -4723,7 +4723,7 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera75" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
@@ -4843,7 +4843,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -4960,7 +4960,7 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera75" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
@@ -5080,7 +5080,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -5197,7 +5197,7 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="opera74" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera75" data-tally="1">1/1</td>
 <td class="tally" data-browser="opera76" data-tally="1">1/1</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">1/1</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">1/1</td>
@@ -5317,7 +5317,7 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -202,7 +202,7 @@
 <th class="platform opera74 desktop obsolete" data-browser="opera74"><a href="#opera74" class="browser-name"><abbr title="Opera 74">OP 74</abbr></a></th>
 <th class="platform opera75 desktop" data-browser="opera75"><a href="#opera75" class="browser-name"><abbr title="Opera 75">OP 75</abbr></a></th>
 <th class="platform opera76 desktop" data-browser="opera76"><a href="#opera76" class="browser-name"><abbr title="Opera 76">OP 76</abbr></a></th>
-<th class="platform rhino1_7 engine obsolete" data-browser="rhino1_7"><a href="#rhino1_7" class="browser-name"><abbr title="Rhino 1.7">Rhino 1.7</abbr></a></th>
+<th class="platform rhino1_7_13 engine obsolete" data-browser="rhino1_7_13"><a href="#rhino1_7_13" class="browser-name"><abbr title="Rhino 1.7.13">Rhino 1.7.13</abbr></a></th>
 <th class="platform phantom2_1 engine obsolete" data-browser="phantom2_1"><a href="#phantom2_1" class="browser-name"><abbr title="PhantomJS 2.1">PJS</abbr></a></th>
 <th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-old-note"><sup>[1]</sup></a></th>
 <th class="platform node0_12 engine obsolete" data-browser="node0_12"><a href="#node0_12" class="browser-name"><abbr title="Node.js">Node 0.12</abbr></a><a href="#harmony-flag-note"><sup>[2]</sup></a></th>
@@ -341,7 +341,7 @@
 <td class="tally obsolete" data-browser="opera74" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera75" data-tally="1">2/2</td>
 <td class="tally" data-browser="opera76" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="1">2/2</td>
@@ -483,7 +483,7 @@ return RegExp.lastMatch === 'x';
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -627,7 +627,7 @@ return true;
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
 <td class="yes obsolete" data-browser="node0_12">Yes</td>
@@ -767,7 +767,7 @@ try {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
@@ -900,7 +900,7 @@ try {
 <td class="tally obsolete" data-browser="opera74" data-tally="0">0/3</td>
 <td class="tally" data-browser="opera75" data-tally="0">0/3</td>
 <td class="tally" data-browser="opera76" data-tally="0">0/3</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/3</td>
@@ -1044,7 +1044,7 @@ return arr.at(0) === 1
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -1188,7 +1188,7 @@ return str.at(0) === &apos;a&apos;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -1348,7 +1348,7 @@ return [
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
 <td class="unknown obsolete" data-browser="node0_12">?</td>
@@ -1488,7 +1488,7 @@ return ok;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
@@ -1553,11 +1553,11 @@ class A {
   #x;
   static check(obj) {
     return #x in obj;
-rhino1_7: false
+rhino1_7_13: false
   }
 }
 return A.check(new A) &amp;&amp; !A.check({});
-  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("9");try{return Function("asyncTestPassed","\nclass A {\n  #x;\n  static check(obj) {\n    return #x in obj;\nrhino1_7: false\n  }\n}\nreturn A.check(new A) && !A.check({});\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("9");return Function("asyncTestPassed","'use strict';"+"\nclass A {\n  #x;\n  static check(obj) {\n    return #x in obj;\nrhino1_7: false\n  }\n}\nreturn A.check(new A) && !A.check({});\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
+  ">test(function(){try{var asyncTestPassed=global.__asyncPassedFn && __asyncPassedFn("9");try{return Function("asyncTestPassed","\nclass A {\n  #x;\n  static check(obj) {\n    return #x in obj;\nrhino1_7_13: false\n  }\n}\nreturn A.check(new A) && !A.check({});\n  ")(asyncTestPassed)}catch(e){asyncTestPassed=global.__strictAsyncPassedFn && __strictAsyncPassedFn("9");return Function("asyncTestPassed","'use strict';"+"\nclass A {\n  #x;\n  static check(obj) {\n    return #x in obj;\nrhino1_7_13: false\n  }\n}\nreturn A.check(new A) && !A.check({});\n  ")(asyncTestPassed)&&"Strict"}}catch(e){return false;}}());
 </script></td>
 <td class="unknown obsolete" data-browser="tr">?</td>
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
@@ -1631,7 +1631,7 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
@@ -1764,7 +1764,7 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="tally obsolete" data-browser="opera74" data-tally="0">0/2</td>
 <td class="tally" data-browser="opera75" data-tally="0">0/2</td>
 <td class="tally" data-browser="opera76" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_12" data-tally="0">0/2</td>
@@ -1900,7 +1900,7 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
@@ -2042,7 +2042,7 @@ try {
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
 <td class="no obsolete" data-browser="node0_12">No</td>
@@ -2186,7 +2186,7 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -2319,7 +2319,7 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/1</td>
 <td class="tally not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/1</td>
 <td class="tally not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/1</td>
-<td class="tally obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/1</td>
+<td class="tally obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/1</td>
 <td class="tally obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/1</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/1</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/1</td>
@@ -2463,7 +2463,7 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -2602,7 +2602,7 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -2735,7 +2735,7 @@ return typeof Realm === &quot;function&quot;
 <td class="tally obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -2877,7 +2877,7 @@ try {
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -3023,7 +3023,7 @@ try {
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -3164,7 +3164,7 @@ try {
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -3305,7 +3305,7 @@ try {
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -3438,7 +3438,7 @@ try {
 <td class="tally obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
-<td class="tally obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
+<td class="tally obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/7</td>
@@ -3577,7 +3577,7 @@ return set.size === 2
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -3717,7 +3717,7 @@ return set.size === 3
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -3856,7 +3856,7 @@ return set.size === 2
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -3995,7 +3995,7 @@ return set.size === 2
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -4131,7 +4131,7 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -4267,7 +4267,7 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -4403,7 +4403,7 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -4536,7 +4536,7 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -4675,7 +4675,7 @@ return buffer1.byteLength === 0
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -4814,7 +4814,7 @@ return buffer1.byteLength === 0
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -4947,7 +4947,7 @@ return buffer1.byteLength === 0
 <td class="tally obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
-<td class="tally obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
+<td class="tally obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/2</td>
@@ -5086,7 +5086,7 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -5226,7 +5226,7 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -5363,7 +5363,7 @@ return !Array.isTemplateObject([])
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -5496,7 +5496,7 @@ return !Array.isTemplateObject([])
 <td class="tally obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/35</td>
 <td class="tally not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/35</td>
 <td class="tally not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/35</td>
-<td class="tally obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/35</td>
+<td class="tally obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/35</td>
 <td class="tally obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/35</td>
 <td class="tally obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/35</td>
 <td class="tally obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/35</td>
@@ -5632,7 +5632,7 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -5770,7 +5770,7 @@ return instance[Symbol.iterator]() === instance;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -5909,7 +5909,7 @@ return &apos;next&apos; in iterator
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -6053,7 +6053,7 @@ return &apos;next&apos; in iterator
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -6189,7 +6189,7 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -6325,7 +6325,7 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -6461,7 +6461,7 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -6597,7 +6597,7 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -6733,7 +6733,7 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -6869,7 +6869,7 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -7007,7 +7007,7 @@ return result === &apos;123&apos;;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -7143,7 +7143,7 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -7279,7 +7279,7 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -7415,7 +7415,7 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -7551,7 +7551,7 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -7688,7 +7688,7 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -7824,7 +7824,7 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -7960,7 +7960,7 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -8098,7 +8098,7 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -8246,7 +8246,7 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -8394,7 +8394,7 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -8542,7 +8542,7 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -8686,7 +8686,7 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -8830,7 +8830,7 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -8968,7 +8968,7 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -9112,7 +9112,7 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -9250,7 +9250,7 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -9394,7 +9394,7 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -9533,7 +9533,7 @@ let result = &apos;&apos;;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -9677,7 +9677,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -9815,7 +9815,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -9953,7 +9953,7 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -10097,7 +10097,7 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -10235,7 +10235,7 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -10371,7 +10371,7 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="no obsolete not-applicable" data-browser="opera74" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera75" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="no not-applicable" data-browser="opera76" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
-<td class="no obsolete not-applicable" data-browser="rhino1_7" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
+<td class="no obsolete not-applicable" data-browser="rhino1_7_13" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">No</td>
 <td class="unknown obsolete not-applicable" data-browser="phantom2_1" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_10" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="node0_12" title="This proposal has not yet reached stage 2, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -174,7 +174,7 @@
 <th class="platform opera74 desktop obsolete" data-browser="opera74"><a href="#opera74" class="browser-name"><abbr title="Opera 74">OP 74</abbr></a></th>
 <th class="platform opera75 desktop" data-browser="opera75"><a href="#opera75" class="browser-name"><abbr title="Opera 75">OP 75</abbr></a></th>
 <th class="platform opera76 desktop" data-browser="opera76"><a href="#opera76" class="browser-name"><abbr title="Opera 76">OP 76</abbr></a></th>
-<th class="platform rhino1_7 engine obsolete" data-browser="rhino1_7"><a href="#rhino1_7" class="browser-name"><abbr title="Rhino 1.7">Rhino 1.7</abbr></a></th>
+<th class="platform rhino1_7_13 engine obsolete" data-browser="rhino1_7_13"><a href="#rhino1_7_13" class="browser-name"><abbr title="Rhino 1.7.13">Rhino 1.7.13</abbr></a></th>
 <th class="platform besen engine" data-browser="besen"><a href="#besen" class="browser-name"><abbr title="Bero&apos;s EcmaScript Engine (version 1.0.0.489)">BESEN</abbr></a></th>
 <th class="platform phantom2_1 engine obsolete" data-browser="phantom2_1"><a href="#phantom2_1" class="browser-name"><abbr title="PhantomJS 2.1">PJS</abbr></a></th>
 <th class="platform node0_10 engine obsolete" data-browser="node0_10"><a href="#node0_10" class="browser-name"><abbr title="Node.js">Node 0.10</abbr></a><a href="#harmony-flag-old-note"><sup>[2]</sup></a></th>
@@ -298,7 +298,7 @@
 <td class="tally obsolete" data-browser="opera74" data-tally="0">0/57</td>
 <td class="tally" data-browser="opera75" data-tally="0">0/57</td>
 <td class="tally" data-browser="opera76" data-tally="0">0/57</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/57</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/57</td>
 <td class="tally" data-browser="besen" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/57</td>
@@ -429,7 +429,7 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -552,7 +552,7 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -675,7 +675,7 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -798,7 +798,7 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -921,7 +921,7 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -1044,7 +1044,7 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -1167,7 +1167,7 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -1290,7 +1290,7 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -1413,7 +1413,7 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -1536,7 +1536,7 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -1659,7 +1659,7 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -1784,7 +1784,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -1909,7 +1909,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -2034,7 +2034,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -2159,7 +2159,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -2284,7 +2284,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -2409,7 +2409,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -2534,7 +2534,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -2659,7 +2659,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -2784,7 +2784,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -2909,7 +2909,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -3034,7 +3034,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -3159,7 +3159,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -3284,7 +3284,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -3409,7 +3409,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -3534,7 +3534,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -3659,7 +3659,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -3784,7 +3784,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -3909,7 +3909,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -4034,7 +4034,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -4159,7 +4159,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -4284,7 +4284,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -4409,7 +4409,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -4534,7 +4534,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -4659,7 +4659,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -4784,7 +4784,7 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -4909,7 +4909,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -5034,7 +5034,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -5159,7 +5159,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -5284,7 +5284,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -5409,7 +5409,7 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -5534,7 +5534,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -5659,7 +5659,7 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -5784,7 +5784,7 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -5909,7 +5909,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -6034,7 +6034,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -6159,7 +6159,7 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -6284,7 +6284,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -6409,7 +6409,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -6534,7 +6534,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -6659,7 +6659,7 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -6784,7 +6784,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -6909,7 +6909,7 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -7034,7 +7034,7 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -7159,7 +7159,7 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -7284,7 +7284,7 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -7407,7 +7407,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -7529,7 +7529,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally obsolete" data-browser="opera74" data-tally="0">0/4</td>
 <td class="tally" data-browser="opera75" data-tally="0">0/4</td>
 <td class="tally" data-browser="opera76" data-tally="0">0/4</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0.75">3/4</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0.75">3/4</td>
 <td class="tally" data-browser="besen" data-tally="0.25">1/4</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0">0/4</td>
@@ -7652,7 +7652,7 @@ return typeof uneval === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -7783,7 +7783,7 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -7906,7 +7906,7 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -8115,7 +8115,7 @@ return true;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -8239,7 +8239,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -8366,7 +8366,7 @@ return 'caller' in function(){};
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no" data-browser="besen">No</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
@@ -8495,7 +8495,7 @@ return (function () {}).arity === 0 &&
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -8626,7 +8626,7 @@ return f(1, 'boo');
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="no" data-browser="besen">No</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
@@ -8751,7 +8751,7 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -8877,7 +8877,7 @@ return new C instanceof C;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -9004,7 +9004,7 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -9129,7 +9129,7 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -9264,7 +9264,7 @@ return executed;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -9389,7 +9389,7 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -9514,7 +9514,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -9641,7 +9641,7 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -9764,7 +9764,7 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -9887,7 +9887,7 @@ return (function(x)x)(1) === 1;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -10010,7 +10010,7 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -10137,7 +10137,7 @@ return str === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -10261,7 +10261,7 @@ return arr[1] === arr;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -10418,7 +10418,7 @@ catch(e) {
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -10581,7 +10581,7 @@ catch(e) {
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -10743,7 +10743,7 @@ global.test((function () {
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -10868,7 +10868,7 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -10998,7 +10998,7 @@ return passed;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -11139,7 +11139,7 @@ try {
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -11262,7 +11262,7 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -11386,7 +11386,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -11509,7 +11509,7 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -11630,7 +11630,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -11753,7 +11753,7 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -11884,7 +11884,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="yes obsolete" data-browser="phantom2_1">Yes</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>
@@ -12007,7 +12007,7 @@ function () { return typeof Object.prototype.watch === 'function' }())</script><
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -12128,7 +12128,7 @@ function () { return typeof Object.prototype.unwatch === 'function' }())</script
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -12249,7 +12249,7 @@ function () { return typeof Object.prototype.eval === 'function' }())</script></
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="yes" data-browser="besen">Yes</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -12372,7 +12372,7 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
@@ -12507,7 +12507,7 @@ try {
 <td class="yes obsolete" data-browser="opera74">Yes</td>
 <td class="yes" data-browser="opera75">Yes</td>
 <td class="yes" data-browser="opera76">Yes</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
@@ -12632,7 +12632,7 @@ return 'lineNumber' in new Error();
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -12757,7 +12757,7 @@ return 'columnNumber' in new Error();
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -12882,7 +12882,7 @@ return 'fileName' in new Error();
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="yes obsolete" data-browser="rhino1_7">Yes</td>
+<td class="yes obsolete" data-browser="rhino1_7_13">Yes</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -13007,7 +13007,7 @@ return 'description' in new Error();
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="no" data-browser="besen">No</td>
 <td class="no obsolete" data-browser="phantom2_1">No</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -13129,7 +13129,7 @@ return 'description' in new Error();
 <td class="tally obsolete" data-browser="opera74" data-tally="0">0/2</td>
 <td class="tally" data-browser="opera75" data-tally="0">0/2</td>
 <td class="tally" data-browser="opera76" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="rhino1_7" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="rhino1_7_13" data-tally="0">0/2</td>
 <td class="tally" data-browser="besen" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="phantom2_1" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="node0_10" data-tally="0.5">1/2</td>
@@ -13254,7 +13254,7 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="yes obsolete" data-browser="node0_10">Yes</td>
@@ -13384,7 +13384,7 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="no obsolete" data-browser="node0_10">No</td>
@@ -13512,7 +13512,7 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no" data-browser="opera75">No</td>
 <td class="no" data-browser="opera76">No</td>
-<td class="no obsolete" data-browser="rhino1_7">No</td>
+<td class="no obsolete" data-browser="rhino1_7_13">No</td>
 <td class="unknown" data-browser="besen">?</td>
 <td class="unknown obsolete" data-browser="phantom2_1">?</td>
 <td class="unknown obsolete" data-browser="node0_10">?</td>

--- a/rhino.js
+++ b/rhino.js
@@ -36,7 +36,7 @@ function executeScript(scriptName) {
     });
 }
 
-// Key for .res (e.g. test.res.rhino1_7), automatic based on rhino version.
+// Key for .res (e.g. test.res.rhino1_7_13), automatic based on rhino version.
 var rhinoKey = (function () {
     var script = 'print(org.mozilla.javascript.ImplementationVersion.get());\n' +
                  'quit()\n';
@@ -46,7 +46,7 @@ var rhinoKey = (function () {
 
     console.log('rhino version is: ' + stdout);
     var match = stdout.match(/Rhino (\d+)\.(\d+)\.(\d+)/);
-    return match[1] + "_" + match[2];
+    return match[1] + "_" + match[2] + "_" + match[3];
 })();
 console.log('rhino result key is: test.res.rhino' + rhinoKey);
 


### PR DESCRIPTION
Although previously we had used `rhino1_7` to describe its compatibility, Rhino hasn't bumped a minor version in over a decade and all the changes happen on `1.7.x`. Accordingly, I think it might be best to include that in the data, particularly because I expect a new version under 1.7 will come out soon with higher ES6 compatibility.