### PR TITLE
Firefox 92 will support object.hasOwn by default

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -1476,6 +1476,7 @@ exports.tests = [
         firefox2: false,
         firefox90: false,
         firefox91: firefox.nightly,
+        firefox92: true,
         opera10_50: false,
         safari12: false,
         rhino1_7_13: false

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -1734,7 +1734,7 @@ return ok;
 <td class="tally" data-browser="firefox89" data-tally="0">0/2</td>
 <td class="tally" data-browser="firefox90" data-tally="0">0/2</td>
 <td class="tally unstable" data-browser="firefox91" data-tally="0" data-flagged-tally="1">0/2</td>
-<td class="tally unstable" data-browser="firefox92" data-tally="0" data-flagged-tally="1">0/2</td>
+<td class="tally unstable" data-browser="firefox92" data-tally="0.5" style="background-color:hsl(60,64%,50%)" data-flagged-tally="1">1/2</td>
 <td class="tally obsolete" data-browser="opera12_10" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome85" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="chrome86" data-tally="0">0/2</td>
@@ -1871,7 +1871,7 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="no" data-browser="firefox89">No</td>
 <td class="no" data-browser="firefox90">No</td>
 <td class="no flagged unstable" data-browser="firefox91">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox92">Flag<a href="#firefox-nightly-note"><sup>[6]</sup></a></td>
+<td class="yes unstable" data-browser="firefox92">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome85">No</td>
 <td class="no obsolete" data-browser="chrome86">No</td>


### PR DESCRIPTION
According to [this](https://bugzilla.mozilla.org/show_bug.cgi?id=1721149), Firefox 92 will support object.hasOwn by default