### PR TITLE
Update closure-compiler to v20210808

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -4808,6 +4808,7 @@ exports.tests = [
     res: {
       babel6corejs2: false,
       babel7corejs3: babel.corejs,
+      closure20210808: true,
       typescript1corejs2: typescript.fallthrough,
       typescript3_2corejs3: typescript.corejs,
       ie11: false,
@@ -4853,6 +4854,7 @@ exports.tests = [
         res: {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure20210808: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
           ie11: false,
@@ -4886,6 +4888,7 @@ exports.tests = [
         res: {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure20210808: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
           ie11: false,
@@ -4997,6 +5000,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure20210808: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -5025,6 +5029,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure20210808: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -5053,6 +5058,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure20210808: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -5084,6 +5090,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure20210808: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -5112,6 +5119,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure20210808: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -5140,6 +5148,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure20210808: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -5171,6 +5180,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure20210808: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -5199,6 +5209,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure20210808: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -5227,6 +5238,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure20210808: true,
           ie11: false,
           firefox60: false,
           firefox76: false,
@@ -5258,6 +5270,7 @@ exports.tests = [
     */},
     res : {
       babel7corejs2: true,
+      closure20210808: true,
       typescript1corejs2: false,
       typescript2_7corejs2: true,
       ie11: false,

--- a/environments.json
+++ b/environments.json
@@ -61,7 +61,7 @@
     "short": "Closure 2018.02",
     "family": "Closure",
     "platformtype": "compiler",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -309,8 +309,20 @@
     ]
   },
   "closure20200927": {
-    "full": "Closure Compiler >=v20200927",
+    "full": "Closure Compiler >=v20200927 <v20210808",
     "short": "Closure 2020.09",
+    "family": "Closure",
+    "platformtype": "compiler",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "closure20210808": {
+    "full": "Closure Compiler >=v20210808",
+    "short": "Closure 2021.08",
     "family": "Closure",
     "platformtype": "compiler",
     "obsolete": false,

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -128,14 +128,14 @@
 <th class="platform babel6corejs2 compiler obsolete" data-browser="babel6corejs2"><a href="#babel6corejs2" class="browser-name"><abbr title="Babel 6.5 + core-js 2.5">Babel 6 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs2 compiler obsolete" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
-<th class="platform closure compiler obsolete" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure 2018.02</abbr></a></th>
 <th class="platform closure20190121 compiler obsolete" data-browser="closure20190121"><a href="#closure20190121" class="browser-name"><abbr title="Closure Compiler v20190121">Closure 2019.01</abbr></a></th>
 <th class="platform closure20200101 compiler obsolete" data-browser="closure20200101"><a href="#closure20200101" class="browser-name"><abbr title="Closure Compiler v20200101">Closure 2020.01</abbr></a></th>
 <th class="platform closure20200112 compiler obsolete" data-browser="closure20200112"><a href="#closure20200112" class="browser-name"><abbr title="Closure Compiler &gt;=v20200112 &lt;v20200315">Closure 2020.01</abbr></a></th>
 <th class="platform closure20200315 compiler obsolete" data-browser="closure20200315"><a href="#closure20200315" class="browser-name"><abbr title="Closure Compiler &gt;=v20200315 &lt;v20200517">Closure 2020.03</abbr></a></th>
 <th class="platform closure20200517 compiler obsolete" data-browser="closure20200517"><a href="#closure20200517" class="browser-name"><abbr title="Closure Compiler &gt;=v20200517 &lt;v20200614">Closure 2020.05</abbr></a></th>
 <th class="platform closure20200614 compiler obsolete" data-browser="closure20200614"><a href="#closure20200614" class="browser-name"><abbr title="Closure Compiler &gt;=v20200614 &lt;v20200927">Closure 2020.06</abbr></a></th>
-<th class="platform closure20200927 compiler" data-browser="closure20200927"><a href="#closure20200927" class="browser-name"><abbr title="Closure Compiler &gt;=v20200927">Closure 2020.09</abbr></a></th>
+<th class="platform closure20200927 compiler obsolete" data-browser="closure20200927"><a href="#closure20200927" class="browser-name"><abbr title="Closure Compiler &gt;=v20200927 &lt;v20210808">Closure 2020.09</abbr></a></th>
+<th class="platform closure20210808 compiler" data-browser="closure20210808"><a href="#closure20210808" class="browser-name"><abbr title="Closure Compiler &gt;=v20210808">Closure 2021.08</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_9corejs2 compiler obsolete" data-browser="typescript2_9corejs2"><a href="#typescript2_9corejs2" class="browser-name"><abbr title="TypeScript 2.9 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript3_2corejs2 compiler obsolete" data-browser="typescript3_2corejs2"><a href="#typescript3_2corejs2" class="browser-name"><abbr title="TypeScript 3.2 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -274,14 +274,14 @@
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20200927" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20210808" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -417,14 +417,14 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -560,14 +560,14 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -708,14 +708,14 @@ return true;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -848,14 +848,14 @@ return true;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20200927" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20210808" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
@@ -995,14 +995,14 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1160,14 +1160,14 @@ return 24;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1308,14 +1308,14 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1460,14 +1460,14 @@ return true;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1616,14 +1616,14 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -1764,14 +1764,14 @@ return true;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1908,14 +1908,14 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -2053,14 +2053,14 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -2203,14 +2203,14 @@ return passed;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2355,14 +2355,14 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2497,14 +2497,14 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="closure20200927" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="closure20210808" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">4/4</td>
@@ -2643,14 +2643,14 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2793,14 +2793,14 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -2944,14 +2944,14 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -3090,14 +3090,14 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -3230,14 +3230,14 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200927" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -3378,14 +3378,14 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -3526,14 +3526,14 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -3666,14 +3666,14 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200927" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -3809,14 +3809,14 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -3952,14 +3952,14 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -4092,14 +4092,14 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0.6875" style="background-color:hsl(82,55%,50%)">11/16</td>
-<td class="tally" data-browser="closure20200927" data-tally="0.6875" style="background-color:hsl(82,55%,50%)">11/16</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0.6875" style="background-color:hsl(82,55%,50%)">11/16</td>
+<td class="tally" data-browser="closure20210808" data-tally="0.6875" style="background-color:hsl(82,55%,50%)">11/16</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
@@ -4246,14 +4246,14 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4400,14 +4400,14 @@ p.catch(function(result) {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4544,14 +4544,14 @@ try { Function(&quot;async\n function a(){}&quot;)(); } catch(e) { return true; 
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
-<td class="no" data-browser="closure20200927">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
+<td class="no" data-browser="closure20210808">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4688,14 +4688,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
-<td class="no" data-browser="closure20200927">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
+<td class="no" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -4838,14 +4838,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4990,14 +4990,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -5134,14 +5134,14 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -5283,14 +5283,14 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -5427,14 +5427,14 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -5581,14 +5581,14 @@ p.then(function(result) {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -5735,14 +5735,14 @@ p.then(function(result) {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -5889,14 +5889,14 @@ var p = new C().a();
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -6041,14 +6041,14 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -6186,14 +6186,14 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
-<td class="no" data-browser="closure20200927">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
+<td class="no" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -6329,14 +6329,14 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
-<td class="no" data-browser="closure20200927">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
+<td class="no" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -6481,14 +6481,14 @@ p.then(function(result) {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
-<td class="no" data-browser="closure20200927">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
+<td class="no" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -6621,14 +6621,14 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/17</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/17</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/17</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/17</td>
@@ -6764,14 +6764,14 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6907,14 +6907,14 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7050,14 +7050,14 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7193,14 +7193,14 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7336,14 +7336,14 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7479,14 +7479,14 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7622,14 +7622,14 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7765,14 +7765,14 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7908,14 +7908,14 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8051,14 +8051,14 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8194,14 +8194,14 @@ return typeof Atomics.wake === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8337,14 +8337,14 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8480,14 +8480,14 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8623,14 +8623,14 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8766,14 +8766,14 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8909,14 +8909,14 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9052,14 +9052,14 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9200,14 +9200,14 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9346,14 +9346,14 @@ return (function(){
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9488,14 +9488,14 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
-<td class="tally obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -9636,14 +9636,14 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9785,14 +9785,14 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -9934,14 +9934,14 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10082,14 +10082,14 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10231,14 +10231,14 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10380,14 +10380,14 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10530,14 +10530,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10680,14 +10680,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10831,14 +10831,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10979,14 +10979,14 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11126,14 +11126,14 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11276,14 +11276,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11426,14 +11426,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11577,14 +11577,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11725,14 +11725,14 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11872,14 +11872,14 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12012,14 +12012,14 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -12159,14 +12159,14 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12306,14 +12306,14 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12458,14 +12458,14 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12610,14 +12610,14 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12754,14 +12754,14 @@ return i === 0;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20190121" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200101" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200112" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -12896,14 +12896,14 @@ return i === 0;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -13040,14 +13040,14 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200101">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200112">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200315">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200517">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200614">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
-<td class="no" data-browser="closure20200927">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="closure20200927">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no" data-browser="closure20210808">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -13185,14 +13185,14 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure">Yes</td>
 <td class="no obsolete" data-browser="closure20190121">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200101">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200112">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200315">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200517">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200614">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
-<td class="no" data-browser="closure20200927">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no obsolete" data-browser="closure20200927">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
+<td class="no" data-browser="closure20210808">No<a href="#closure-object-assign-note"><sup>[23]</sup></a></td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -13325,14 +13325,14 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20200927" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20210808" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
@@ -13494,14 +13494,14 @@ function check() {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13655,14 +13655,14 @@ function check() {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13818,14 +13818,14 @@ function check() {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13962,14 +13962,14 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
-<td class="no" data-browser="closure20200927">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
+<td class="no" data-browser="closure20210808">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -14112,14 +14112,14 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -14256,14 +14256,14 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -14400,14 +14400,14 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -14540,14 +14540,14 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200927" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -14690,14 +14690,14 @@ iterator.next().then(function(step){
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -14850,14 +14850,14 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -15005,14 +15005,14 @@ return false;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -15155,14 +15155,14 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="yes obsolete" data-browser="closure20190121">Yes</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -15301,14 +15301,14 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -15441,14 +15441,14 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">4/4</td>
-<td class="tally" data-browser="closure20200927" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="1">4/4</td>
+<td class="tally" data-browser="closure20210808" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">4/4</td>
@@ -15584,14 +15584,14 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -15727,14 +15727,14 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -15870,14 +15870,14 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -16013,14 +16013,14 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -16153,14 +16153,14 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20200927" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20210808" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -16296,14 +16296,14 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -16441,14 +16441,14 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -16585,14 +16585,14 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -16727,14 +16727,14 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20200927" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20210808" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
@@ -16876,14 +16876,14 @@ return false;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -17026,14 +17026,14 @@ return false;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -17180,14 +17180,14 @@ return it.throw().value;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -17320,14 +17320,14 @@ return it.throw().value;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20200927" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20210808" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/3</td>
@@ -17463,14 +17463,14 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -17606,14 +17606,14 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -17750,14 +17750,14 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -17890,14 +17890,14 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/7</td>
@@ -18035,14 +18035,14 @@ return fn + &apos;&apos; === str;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18179,14 +18179,14 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18323,14 +18323,14 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18467,14 +18467,14 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18611,14 +18611,14 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18755,14 +18755,14 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -18899,14 +18899,14 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -19039,14 +19039,14 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200927" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -19182,14 +19182,14 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -19325,14 +19325,14 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -19469,14 +19469,14 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -19611,14 +19611,14 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200927" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -19764,14 +19764,14 @@ return a === &apos;1a2b&apos;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -19912,14 +19912,14 @@ try {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -20052,14 +20052,14 @@ try {
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/8</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/8</td>
@@ -20195,14 +20195,14 @@ return (1n + 2n) === 3n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -20338,14 +20338,14 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -20481,14 +20481,14 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -20624,14 +20624,14 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -20770,14 +20770,14 @@ return view[0] === -0x8000000000000000n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -20916,14 +20916,14 @@ return view[0] === 0n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -21062,14 +21062,14 @@ return view.getBigInt64(0) === 1n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -21208,14 +21208,14 @@ return view.getBigUint64(0) === 1n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -21362,14 +21362,14 @@ Promise.allSettled([
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -21502,14 +21502,14 @@ Promise.allSettled([
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20200927" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -21647,14 +21647,14 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -21796,14 +21796,14 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="yes obsolete" data-browser="closure20200101">Yes</td>
 <td class="yes obsolete" data-browser="closure20200112">Yes</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -21936,14 +21936,14 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/5</td>
-<td class="tally" data-browser="closure20200927" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="1">5/5</td>
+<td class="tally" data-browser="closure20210808" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/5</td>
@@ -22081,14 +22081,14 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -22226,14 +22226,14 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -22371,14 +22371,14 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -22518,14 +22518,14 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -22665,14 +22665,14 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -22813,14 +22813,14 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
 <td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
-<td class="yes" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -22958,14 +22958,14 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -23098,14 +23098,14 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -23247,14 +23247,14 @@ Promise.any([
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -23396,14 +23396,14 @@ Promise.any([
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[25]</sup></a></td>
@@ -23536,14 +23536,14 @@ Promise.any([
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -23681,14 +23681,14 @@ return weakref.deref() === O;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -23825,14 +23825,14 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -23965,14 +23965,14 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">9/9</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/9</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/9</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/9</td>
+<td class="tally" data-browser="closure20210808" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/9</td>
@@ -24114,14 +24114,14 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24260,14 +24260,14 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24406,14 +24406,14 @@ return i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24555,14 +24555,14 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24701,14 +24701,14 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24847,14 +24847,14 @@ return i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24996,14 +24996,14 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -25142,14 +25142,14 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -25288,14 +25288,14 @@ return i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -25432,14 +25432,14 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="yes" data-browser="closure20210808">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -25574,14 +25574,14 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">6/6</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">4/6</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/6</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/6</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
@@ -25720,14 +25720,14 @@ return new C().x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -25872,14 +25872,14 @@ return new C(42).x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -26021,14 +26021,14 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -26170,14 +26170,14 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="no" data-browser="babel7corejs3">No</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -26319,14 +26319,14 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="no" data-browser="babel7corejs3">No</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -26465,14 +26465,14 @@ return new C().x === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -26605,14 +26605,14 @@ return new C().x === 42;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -26751,14 +26751,14 @@ return C.x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -26900,14 +26900,14 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -27046,14 +27046,14 @@ return C.x === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -27186,14 +27186,14 @@ return C.x === 42;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/4</td>
@@ -27335,14 +27335,14 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -27484,14 +27484,14 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -27636,14 +27636,14 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -27788,14 +27788,14 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -27937,14 +27937,14 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -134,14 +134,14 @@
 <th class="platform babel6corejs2 compiler obsolete" data-browser="babel6corejs2"><a href="#babel6corejs2" class="browser-name"><abbr title="Babel 6.5 + core-js 2.5">Babel 6 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs2 compiler obsolete" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
-<th class="platform closure compiler obsolete" data-browser="closure"><a href="#closure" class="browser-name"><abbr title="Closure Compiler v20180204">Closure 2018.02</abbr></a></th>
 <th class="platform closure20190121 compiler obsolete" data-browser="closure20190121"><a href="#closure20190121" class="browser-name"><abbr title="Closure Compiler v20190121">Closure 2019.01</abbr></a></th>
 <th class="platform closure20200101 compiler obsolete" data-browser="closure20200101"><a href="#closure20200101" class="browser-name"><abbr title="Closure Compiler v20200101">Closure 2020.01</abbr></a></th>
 <th class="platform closure20200112 compiler obsolete" data-browser="closure20200112"><a href="#closure20200112" class="browser-name"><abbr title="Closure Compiler &gt;=v20200112 &lt;v20200315">Closure 2020.01</abbr></a></th>
 <th class="platform closure20200315 compiler obsolete" data-browser="closure20200315"><a href="#closure20200315" class="browser-name"><abbr title="Closure Compiler &gt;=v20200315 &lt;v20200517">Closure 2020.03</abbr></a></th>
 <th class="platform closure20200517 compiler obsolete" data-browser="closure20200517"><a href="#closure20200517" class="browser-name"><abbr title="Closure Compiler &gt;=v20200517 &lt;v20200614">Closure 2020.05</abbr></a></th>
 <th class="platform closure20200614 compiler obsolete" data-browser="closure20200614"><a href="#closure20200614" class="browser-name"><abbr title="Closure Compiler &gt;=v20200614 &lt;v20200927">Closure 2020.06</abbr></a></th>
-<th class="platform closure20200927 compiler" data-browser="closure20200927"><a href="#closure20200927" class="browser-name"><abbr title="Closure Compiler &gt;=v20200927">Closure 2020.09</abbr></a></th>
+<th class="platform closure20200927 compiler obsolete" data-browser="closure20200927"><a href="#closure20200927" class="browser-name"><abbr title="Closure Compiler &gt;=v20200927 &lt;v20210808">Closure 2020.09</abbr></a></th>
+<th class="platform closure20210808 compiler" data-browser="closure20210808"><a href="#closure20210808" class="browser-name"><abbr title="Closure Compiler &gt;=v20210808">Closure 2021.08</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_9corejs2 compiler obsolete" data-browser="typescript2_9corejs2"><a href="#typescript2_9corejs2" class="browser-name"><abbr title="TypeScript 2.9 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript3_2corejs2 compiler obsolete" data-browser="typescript3_2corejs2"><a href="#typescript3_2corejs2" class="browser-name"><abbr title="TypeScript 3.2 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -281,14 +281,14 @@ return typeof Realm === &quot;function&quot;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -416,14 +416,14 @@ return typeof Realm === &quot;function&quot;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -560,14 +560,14 @@ return RegExp.lastMatch === 'x';
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -706,14 +706,14 @@ return true;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -848,14 +848,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="no" data-browser="babel7corejs3">No</td>
-<td class="no obsolete" data-browser="closure">No</td>
 <td class="no obsolete" data-browser="closure20190121">No</td>
 <td class="no obsolete" data-browser="closure20200101">No</td>
 <td class="no obsolete" data-browser="closure20200112">No</td>
 <td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
-<td class="no" data-browser="closure20200927">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
+<td class="no" data-browser="closure20210808">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -983,14 +983,14 @@ try {
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/3</td>
@@ -1129,14 +1129,14 @@ return arr.at(0) === 1
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1275,14 +1275,14 @@ return str.at(0) === &apos;a&apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1437,14 +1437,14 @@ return [
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1579,14 +1579,14 @@ return ok;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1714,14 +1714,14 @@ return ok;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -1852,14 +1852,14 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1996,14 +1996,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2131,14 +2131,14 @@ try {
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -2270,14 +2270,14 @@ return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2409,14 +2409,14 @@ return arr.findLast(function (o) { return o.x === 1; }) === 2;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2544,14 +2544,14 @@ return arr.findLast(function (o) { return o.x === 1; }) === 2;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/8</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/8</td>
@@ -2683,14 +2683,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2822,14 +2822,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2961,14 +2961,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3100,14 +3100,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3239,14 +3239,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3378,14 +3378,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3517,14 +3517,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3656,14 +3656,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3802,14 +3802,14 @@ return result === &apos;tromple&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -3937,14 +3937,14 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/1</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/1</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/1</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">1/1</td>
@@ -4083,14 +4083,14 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="babel6corejs2">No<a href="#babel-decorators-legacy-note"><sup>[11]</sup></a></td>
 <td class="no obsolete" data-browser="babel7corejs2">No<a href="#babel-decorators-legacy-note"><sup>[11]</sup></a></td>
 <td class="no" data-browser="babel7corejs3">No<a href="#babel-decorators-legacy-note"><sup>[11]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -4218,14 +4218,14 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/4</td>
@@ -4362,14 +4362,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4510,14 +4510,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4653,14 +4653,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4796,14 +4796,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4931,14 +4931,14 @@ try {
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/7</td>
@@ -5072,14 +5072,14 @@ return set.size === 2
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -5214,14 +5214,14 @@ return set.size === 3
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -5355,14 +5355,14 @@ return set.size === 2
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -5496,14 +5496,14 @@ return set.size === 2
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -5634,14 +5634,14 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -5772,14 +5772,14 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -5910,14 +5910,14 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -6045,14 +6045,14 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -6186,14 +6186,14 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6327,14 +6327,14 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6462,14 +6462,14 @@ return buffer1.byteLength === 0
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -6603,14 +6603,14 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -6745,14 +6745,14 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -6884,14 +6884,14 @@ return !Array.isTemplateObject([])
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -7019,14 +7019,14 @@ return !Array.isTemplateObject([])
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/35</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">35/35</td>
-<td class="tally obsolete" data-browser="closure" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20190121" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20200101" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20200112" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/35</td>
-<td class="tally" data-browser="closure20200927" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/35</td>
+<td class="tally" data-browser="closure20210808" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/35</td>
@@ -7157,14 +7157,14 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -7297,14 +7297,14 @@ return instance[Symbol.iterator]() === instance;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -7438,14 +7438,14 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -7584,14 +7584,14 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -7722,14 +7722,14 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -7860,14 +7860,14 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -7998,14 +7998,14 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -8136,14 +8136,14 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -8274,14 +8274,14 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -8412,14 +8412,14 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -8552,14 +8552,14 @@ return result === &apos;123&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -8690,14 +8690,14 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -8828,14 +8828,14 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -8966,14 +8966,14 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -9104,14 +9104,14 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -9243,14 +9243,14 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -9381,14 +9381,14 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -9519,14 +9519,14 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -9659,14 +9659,14 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -9809,14 +9809,14 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -9959,14 +9959,14 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -10109,14 +10109,14 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -10255,14 +10255,14 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -10401,14 +10401,14 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -10541,14 +10541,14 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -10687,14 +10687,14 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -10827,14 +10827,14 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -10973,14 +10973,14 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -11114,14 +11114,14 @@ let result = &apos;&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -11260,14 +11260,14 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -11400,14 +11400,14 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -11540,14 +11540,14 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -11686,14 +11686,14 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -11826,14 +11826,14 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
@@ -11964,14 +11964,14 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure">?</td>
 <td class="unknown obsolete" data-browser="closure20190121">?</td>
 <td class="unknown obsolete" data-browser="closure20200101">?</td>
 <td class="unknown obsolete" data-browser="closure20200112">?</td>
 <td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown" data-browser="closure20200927">?</td>
+<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="unknown" data-browser="closure20210808">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[12]</sup></a></td>


### PR DESCRIPTION
Support ES2021 features

- String.prototype.replaceAll
- Promise.any
- Logical Assignment
- numeric separatorsl

https://github.com/google/closure-compiler/wiki/Releases#august-8-2021-v20210808