### PR TITLE
Firefox 93 enables Class static initialization blocks

### DIFF
--- a/data-esnext.js
+++ b/data-esnext.js
@@ -1449,6 +1449,7 @@ exports.tests = [
       note_id: 'ff-static-init-blocks',
       note_html: 'The feature has to be enabled via <code>javascript.options.experimental.class_static_blocks=true</code> flag.'
     },
+    firefox93: true,
     ie11: false,
     opera10_50: false,
     safari12: false,

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -1611,7 +1611,7 @@ return ok;
 <td class="no flagged" data-browser="firefox90">Flag<a href="#ff-static-init-blocks-note"><sup>[9]</sup></a></td>
 <td class="no flagged" data-browser="firefox91">Flag<a href="#ff-static-init-blocks-note"><sup>[9]</sup></a></td>
 <td class="no flagged unstable" data-browser="firefox92">Flag<a href="#ff-static-init-blocks-note"><sup>[9]</sup></a></td>
-<td class="no flagged unstable" data-browser="firefox93">Flag<a href="#ff-static-init-blocks-note"><sup>[9]</sup></a></td>
+<td class="yes unstable" data-browser="firefox93">Yes</td>
 <td class="no obsolete" data-browser="opera12_10">No</td>
 <td class="no obsolete" data-browser="chrome85">No</td>
 <td class="no obsolete" data-browser="chrome86">No</td>


### PR DESCRIPTION
Firefox 93 enables Class static initialization blocks by default:
https://bugzilla.mozilla.org/show_bug.cgi?id=1725689