### PR TITLE
Custom compat tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-ECMAScript compatibility tables
-==================================================
+# ECMAScript compatibility tables
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/kangax/compat-table?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/kangax/es5-compat-table/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 
-Editing the tests
------------------
+## Editing the tests
 
 Edit the `data-es5.js`, `data-es6.js`, `data-esnext.js`, or `data-non-standard.js` files to adjust the tests and their recorded browser results. Run `node build.js` to build the HTML files from these JavaScript sources.
 
@@ -16,8 +14,7 @@ The test code is placed in multi-line comments (as in [this hack](http://tomasz.
 
 Most tests have a `significance` rating, which affects how a platform's total support percentage is calculated. A test rated `"large"` (representing a landmark, transformative feature) is worth 1, one rated `"medium"` (representing a significant feature that's less universally useful, or is primarily connected to another feature) is worth 0.5, and one rated `"small"` (representing a useful but subtle improvement from the previous spec) is worth 0.25. `"tiny"` (0.125) should be reserved for very meager changes (such as changes to an existing function's parameters or side-effects) that nonetheless don't fall under the category of another feature.
 
-In order to test compilers
------------------
+## In order to test compilers
 
 Run `npm install` to install the compilers under test (and remember to `npm update` them frequently).
 Then run `node build.js compilers` to create compiler test pages under `es6/compilers`. Currently only the ES6 tests produce compiler test pages.
@@ -25,11 +22,64 @@ Open the compilers' HTML files in a browser with close to zero native ES6 suppor
 
 Note that some tests cannot be compiled correctly, as they rely on runtime `eval()` results to ensure that, for instance, certain syntactic constructs are syntax errors. These will fail on the compiler test pages. Support for those features should be divined manually.
 
-In order to test Node.js
------------------
+## In order to test Node.js
 
 After installing dependencies using `npm install`, first compile a fresh ES6 HTML file using `node build.js`.
 
 Then, run `node .`, where `node` is the executable you wish to test, along with any desired flags (such as `--es-staging`). The results should be printed in colour in stdout: <span style='background:black;color:forestgreen'>green</span> results indicate correct support, <span style='background:black;color:aqua'>cyan</span> results indicate support that incorrectly requires strict mode, and <span style='background:black;color:crimson'>red</span> indicates no support.
 
 Note that this script is currently hard-coded to only display ES6 results.
+
+## Creating custom compat tables
+Custom compat tables can be created by providing a custom environments json file and/or custom test results. Additonally, the current browser results can be excluded.
+
+Running `node build.js --environments=./customEnv.json --customResults=./customResults.json -x` would result in a custom compat table for just 'My Engine', containing 3 columns (version 1.0.0, 1.1.0 and 2.0.0). The 'current browser' results are excluded (due to the `-x` flag). And all tests would fail, except `proper tail calls (tail call optimisation)` > `direct recursion` for version 2.0.0.
+
+The `environments` option can be used to create compat tables that for example focuses on different versions of the same browser/engine.
+The `customResults` option can be used to override and augment the results already contained within the compat tables. This allows for adding test results for browsers that aren't part of repo yet, like a new browser/engine or a new version, like a nightly.
+
+### customEnv.json example
+```json
+{
+  "myEngine2.0.0": {
+    "full": "My Engine 2.0.0-NIGHTLY",
+    "short": "My Engine 2.0.0-NIGHTLY",
+    "family": "myengine",
+    "platformtype": "engine",
+    "release": "2022-02-14"
+  },
+  "myEngine1.1.0": {
+    "full": "My Engine 1.1.0",
+    "short": "My Engine 1.1.0",
+    "family": "myengine",
+    "platformtype": "engine",
+    "release": "2022-01-06"
+  },
+  "myEngine1.0.0": {
+    "full": "My Engine 1.0.0",
+    "short": "My Engine 1.0.0",
+    "family": "myengine",
+    "platformtype": "engine",
+    "release": "2020-09-02"
+  }
+}
+```
+### /customResults.json example
+```json
+{
+  "es5": {},
+  "es6": {
+    "proper tail calls (tail call optimisation)": {
+      "subtests": {
+        "direct recursion": {
+          "myEngine2.0.0": true
+        }
+      }
+    }
+  },
+  "es2016plus": {},
+  "esnext": {},
+  "esintl": {},
+  "nonStandard": {}
+}
+```

--- a/build.js
+++ b/build.js
@@ -463,9 +463,9 @@ function dataToHtml(skeleton, rawBrowsers, tests, compiler, customResults) {
   },{});
 
   // Adjust platformType header colspans to match # of browsers displayed by default
-  Object.keys(noOfBrowserPerPlatformType).forEach(function (platformType) {
-	  var count = noOfBrowserPerPlatformType[platformType];
-      $('table thead tr:first-child th#' + platformType + '-header').attr('colspan', count);
+  Object.keys(noOfBrowserPerPlatformType).forEach(platformType => {
+    const count = noOfBrowserPerPlatformType[platformType];
+    $(`table thead tr:first-child th#${platformType}-header`).attr('colspan', count);
   });
 
   function getHtmlId(id) {

--- a/build.js
+++ b/build.js
@@ -33,7 +33,17 @@ var cheerio = require('cheerio');
 var fl = require('fast-levenshtein');
 // var child_process = require('child_process');
 
-var useCompilers = String(process.argv[2]).toLowerCase() === "compilers";
+var useCompilers = false;
+
+process.argv.slice(2).forEach(function(arg) {
+	var parts = String(arg).toLowerCase().split('=');
+
+	switch (parts[0]) {
+		case 'compilers':
+			useCompilers = true;
+			break;
+	}
+});
 
 var STAGE2 = 'draft (stage 2)';
 

--- a/build.js
+++ b/build.js
@@ -764,7 +764,7 @@ function testScript(fn, transformFn, rowNum) {
     // see if the code is encoded in a comment
     var expr = (fn+"").match(/[^]*\/\*([^]*)\*\/\}$/);
     // if there wasn't an expression, make the function statement into one
-    if (!expr || excludeCurrentBrowser) {
+    if (!expr) {
       if (transformFn) {
         try {
           expr = transformFn("("+fn+")");
@@ -774,7 +774,7 @@ function testScript(fn, transformFn, rowNum) {
       } else {
         expr = deindentFunc(fn);
       }
-      return cheerio.load('')('<script>test(\n' + expr + '())</script>').attr('data-source', expr);
+      return cheerio.load('')(excludeCurrentBrowser ? '<script></script>' : '<script>test(\n' + expr + '())</script>').attr('data-source', expr);
     } else {
       expr = deindentFunc(expr[1]);
       var transformed = false;
@@ -802,7 +802,7 @@ function testScript(fn, transformFn, rowNum) {
         transformed ? '' + strictAsyncFn + ' && function(){"use strict";' + codeString + '}() && "Strict"'
         : 'Function("asyncTestPassed","\'use strict\';"+' + codeString + ')(asyncTestPassed)';
 
-      return cheerio.load('')('<script>' +
+      return cheerio.load('')(excludeCurrentBrowser ? '<script></script>' : '<script>' +
          'test(function(){'
         +  'try{'
         +    'var asyncTestPassed=' + asyncFn + ';'

--- a/build.js
+++ b/build.js
@@ -33,6 +33,7 @@ var fl = require('fast-levenshtein');
 // var child_process = require('child_process');
 
 var useCompilers = false;
+var excludeCurrentBrowser = false;
 var environments;
 
 process.argv.slice(2).forEach(function(arg) {
@@ -44,6 +45,9 @@ process.argv.slice(2).forEach(function(arg) {
 			break;
 		case 'environments':
 			environments = require(parts[1]);
+			break;
+		case 'excludecurrent':
+			excludeCurrentBrowser = true;
 			break;
 	}
 });
@@ -443,6 +447,11 @@ function dataToHtml(skeleton, rawBrowsers, tests, compiler) {
     mobile: 0
   };
 
+  if (excludeCurrentBrowser) {
+    $('table').addClass('no-current');
+    $('table thead tr:first-child th:first-child').attr('colspan', 1);
+  }
+
   // rawBrowsers includes very obsolete browsers which mustn't be printed, but should
   // be used by interpolateResults(). All other uses should use this, which filters
   // the very obsolete ones out.
@@ -764,7 +773,7 @@ function testScript(fn, transformFn, rowNum) {
     // see if the code is encoded in a comment
     var expr = (fn+"").match(/[^]*\/\*([^]*)\*\/\}$/);
     // if there wasn't an expression, make the function statement into one
-    if (!expr) {
+    if (!expr || excludeCurrentBrowser) {
       if (transformFn) {
         try {
           expr = transformFn("("+fn+")");

--- a/build.js
+++ b/build.js
@@ -22,6 +22,7 @@
 
 require('object.assign').shim();
 var pickBy = require('lodash.pickby');
+const { parseArgs } = require('@pkgjs/parseargs');
 
 var interpolateAllResults = require('./build-utils/interpolate-all-results');
 
@@ -32,27 +33,11 @@ var cheerio = require('cheerio');
 var fl = require('fast-levenshtein');
 // var child_process = require('child_process');
 
-var useCompilers = false;
-var excludeCurrentBrowser = false;
-var environments;
+const {values: {environments: environmentsPath = './environments.json'}, flags, positionals} = parseArgs();
 
-process.argv.slice(2).forEach(function(arg) {
-	var parts = String(arg).toLowerCase().split('=');
-
-	switch (parts[0]) {
-		case 'compilers':
-			useCompilers = true;
-			break;
-		case 'environments':
-			environments = require(parts[1]);
-			break;
-		case 'excludecurrent':
-			excludeCurrentBrowser = true;
-			break;
-	}
-});
-
-if (!environments) environments = require('./environments');
+const environments = JSON.parse(fs.readFileSync(__dirname + path.sep + environmentsPath, 'utf-8'));
+const useCompilers = positionals.includes('compilers');
+const excludeCurrentBrowser = flags.x === true;
 
 var STAGE2 = 'draft (stage 2)';
 

--- a/es5/skeleton.html
+++ b/es5/skeleton.html
@@ -108,10 +108,10 @@
       <thead>
         <tr>
           <th colspan="3" class="platformtype"></th>
-          <th colspan="1" class="platformtype" id="compiler-header" style="background: #ffdfa4">Compilers/polyfills</th>
-          <th colspan="18" class="platformtype" id="desktop-header" style="background: #fff4c3">Desktop browsers</th>
-          <th colspan="8" class="platformtype" id="engine-header" style="background: #f8e8a0">Servers/runtimes</th>
-          <th colspan="2" class="platformtype" id="mobile-header" style="background: #f8daa0">Mobile</th>
+          <th class="platformtype" id="compiler-header" style="background: #ffdfa4">Compilers/polyfills</th>
+          <th class="platformtype" id="desktop-header" style="background: #fff4c3">Desktop browsers</th>
+          <th class="platformtype" id="engine-header" style="background: #f8e8a0">Servers/runtimes</th>
+          <th class="platformtype" id="mobile-header" style="background: #f8daa0">Mobile</th>
         </tr>
         <tr>
           <th class="test-name">Feature name</th>

--- a/master.css
+++ b/master.css
@@ -47,6 +47,9 @@ th abbr {
 th:nth-child(3) {
     min-width: 10px;
 }
+th[colspan="0"] {
+    display: none;	
+}
 td {
     background: #eee; position:relative; margin-left: -10px; font-size: 14px;
 }

--- a/master.css
+++ b/master.css
@@ -46,10 +46,10 @@ th abbr {
 th:nth-child(3) {
     min-width: 10px;
 }
-table.no-current th:nth-child(2),
-table.no-current th:nth-child(3),
-table.no-current td:nth-child(2),
-table.no-current td:nth-child(3) {
+table.no-current th.current,
+table.no-current th.current + th,
+table.no-current td.current,
+table.no-current td.current + td {
 	display: none;
 }
 th[colspan="0"] {

--- a/master.css
+++ b/master.css
@@ -30,7 +30,6 @@ body {
 }
 table {
     margin-bottom: 2em;
-    min-width: 100%;
 }
 thead {
     background: white;

--- a/master.css
+++ b/master.css
@@ -47,8 +47,14 @@ th abbr {
 th:nth-child(3) {
     min-width: 10px;
 }
+table.no-current th:nth-child(2),
+table.no-current th:nth-child(3),
+table.no-current td:nth-child(2),
+table.no-current td:nth-child(3) {
+	display: none;
+}
 th[colspan="0"] {
-    display: none;	
+    display: none;
 }
 td {
     background: #eee; position:relative; margin-left: -10px; font-size: 14px;

--- a/master.js
+++ b/master.js
@@ -120,7 +120,7 @@ $(function() {
     );
   };
 
-  $('tr.supertest').each(function() {
+  $('table:not(no-current) tr.supertest').each(function() {
     var tr = $(this);
     var subtests = tr.nextUntil('tr:not(.subtest)');
     if (subtests.length === 0) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "main": "node.js",
   "engine": {
-    "node": ">= 0.11.12",
+    "node": ">= 15",
     "npm": ">= 3.0"
   },
   "repository": {
@@ -13,6 +13,7 @@
   "private": true,
   "dependencies": {
     "@babel/standalone": "latest",
+    "@pkgjs/parseargs": "^0.3.0",
     "chalk": "^1.1.3",
     "cheerio": "^0.20.0",
     "core-js-bundle": "^3.0.0",


### PR DESCRIPTION
As discussed in #1790 a prototype to allow creating custom compat tables

Usage `node build environments=./custom.json excludecurrent`

With `custom.json` being a custom environments file, for example having the following content:
```
{
  "rhino1_7_13": {
    "full": "Rhino 1.7.13",
    "short": "Rhino 1.7.13",
    "family": "Rhino",
    "platformtype": "engine",
    "release": "2020-09-02"
  },
  "rhino1_7_14": {
    "full": "Rhino 1.7.14",
    "short": "Rhino 1.7.14",
    "family": "Rhino",
    "platformtype": "engine",
    "release": "2022-01-06"
  }
}
```

This PR is a draft, just to get the discusion going. Needs cleanup + more:
- Hide engines from the legenda that aren't used in the provided environments file
- Hide unstable/obsolete checkboxes if the provided environments file doesn't contain any unstable/obsolete browsers
- Remove sort by Engine Type, if only one engine type is is used with the environments file
- Remove entire platformType header if the browsers in the environments file are all of the same platformType

One question: the code in build.js isn't using modern JavaScript features. Is that on purpose?  

Closes #1790 
Closes #1198