### PR TITLE
Add results for Hermes 0.8.1 to 0.11.0

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -6099,7 +6099,8 @@ exports.tests = [
           safaritp: true,
           duktape2_0: false,
           rhino1_7_13: false,
-          hermes0_7_0: false
+          hermes0_7_0: false,
+          hermes0_10_0: true
         }
       },
       {
@@ -6130,7 +6131,8 @@ exports.tests = [
           safaritp: true,
           duktape2_0: false,
           rhino1_7_13: false,
-          hermes0_7_0: false
+          hermes0_7_0: false,
+          hermes0_10_0: true
         }
       }
     ]

--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -4861,7 +4861,8 @@ exports.tests = [
           safari13_1: true,
           safaritp: true,
           duktape2_0: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       }
     ]
@@ -5451,7 +5452,8 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           graalvm20_1: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -5485,7 +5487,8 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           graalvm20_1: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -5515,7 +5518,8 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           graalvm20_1: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -5549,7 +5553,8 @@ exports.tests = [
           graalvm20_1: false,
           graalvm20_3: true,
           typescript3_8corejs3: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -5584,7 +5589,8 @@ exports.tests = [
           graalvm20_1: false,
           graalvm20_3: true,
           typescript3_8corejs3: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -5610,7 +5616,8 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           graalvm20_1: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       }
     ]
@@ -5647,7 +5654,8 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           graalvm20_1: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -5680,6 +5688,7 @@ exports.tests = [
           node16_11: true,
           safari15: true,
           duktape2_0: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -5708,7 +5717,8 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           graalvm20_1: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -5733,7 +5743,8 @@ exports.tests = [
           graalvm19: false,
           graalvm20: true,
           graalvm20_1: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       }
     ]
@@ -5776,7 +5787,8 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -5810,7 +5822,8 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -5847,7 +5860,8 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -5884,7 +5898,8 @@ exports.tests = [
           safaritp: true,
           graalvm20: false,
           graalvm20_1: true,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       }
     ]
@@ -5917,7 +5932,8 @@ exports.tests = [
       safari12: false,
       safari15: true,
       duktape2_0: false,
-      rhino1_7_13: false
+      rhino1_7_13: false,
+      hermes0_7_0: false
     }
   },
   {
@@ -5956,7 +5972,8 @@ exports.tests = [
           babel7corejs3: babel.corejs,
           typescript4corejs3: typescript.corejs,
           graalvm21: graalvm.es2022flag,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -5988,7 +6005,8 @@ exports.tests = [
           babel7corejs3: babel.corejs,
           typescript4corejs3: typescript.corejs,
           graalvm21: graalvm.es2022flag,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -6036,7 +6054,8 @@ exports.tests = [
           babel7corejs3: babel.corejs,
           typescript4corejs3: typescript.corejs,
           graalvm21: graalvm.es2022flag,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       }
     ]
@@ -6069,7 +6088,8 @@ exports.tests = [
           safari12: false,
           safaritp: true,
           duktape2_0: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -6099,7 +6119,8 @@ exports.tests = [
           safari12: false,
           safaritp: true,
           duktape2_0: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_7_0: false
         }
       }
     ]
@@ -6141,7 +6162,8 @@ exports.tests = [
       opera10_50: false,
       safari12: false,
       duktape2_0: false,
-      rhino1_7_13: false
+      rhino1_7_13: false,
+      hermes0_7_0: false
     },
   },
   {
@@ -6169,6 +6191,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -6190,6 +6213,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           rhino1_7_14: true,
+          hermes0_7_0: true
         }
       },
       {
@@ -6211,6 +6235,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -6232,6 +6257,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           rhino1_7_14: true,
+          hermes0_7_0: true
         }
       },
       {
@@ -6253,6 +6279,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -6274,6 +6301,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           rhino1_7_14: true,
+          hermes0_7_0: true
         }
       },
       {
@@ -6295,6 +6323,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -6316,6 +6345,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           rhino1_7_14: true,
+          hermes0_7_0: true
         }
       },
       {
@@ -6337,6 +6367,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -6358,6 +6389,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           rhino1_7_14: true,
+          hermes0_7_0: true
         }
       },
       {
@@ -6379,6 +6411,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -6400,6 +6433,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           rhino1_7_14: true,
+          hermes0_7_0: true
         }
       },
       {
@@ -6421,6 +6455,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -6442,6 +6477,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: true,
           rhino1_7_14: true,
+          hermes0_7_0: true
         }
       },
       {
@@ -6463,6 +6499,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
+          hermes0_7_0: false
         }
       },
       {
@@ -6484,6 +6521,7 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
+          hermes0_7_0: false
         }
       },
     ]
@@ -6502,6 +6540,7 @@ exports.tests = [
         res: {
           safari15: true,
           chrome90: true,
+          hermes0_7_0: false
         }
       },
       {
@@ -6528,6 +6567,7 @@ exports.tests = [
           node16_0: false,
           safari15: true,
           chrome90: false,
+          hermes0_7_0: false
         }
       }
     ]

--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -678,7 +678,8 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -707,7 +708,8 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -811,7 +813,8 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -1067,7 +1070,8 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -1096,7 +1100,8 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -3084,7 +3089,8 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -3530,7 +3536,8 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -3608,7 +3615,8 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -3639,7 +3647,8 @@ exports.tests = [
           graalvm20: true,
           graalvm20_1: true,
           hermes0_7_0: false,
-          rhino1_7_13: false
+          rhino1_7_13: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -4862,7 +4871,8 @@ exports.tests = [
           safaritp: true,
           duktape2_0: false,
           rhino1_7_13: false,
-          hermes0_7_0: false
+          hermes0_7_0: false,
+          hermes0_8_1: true
         }
       }
     ]
@@ -6191,7 +6201,8 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
-          hermes0_7_0: false
+          hermes0_7_0: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -6235,7 +6246,8 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
-          hermes0_7_0: false
+          hermes0_7_0: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -6279,7 +6291,8 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
-          hermes0_7_0: false
+          hermes0_7_0: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -6323,7 +6336,8 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
-          hermes0_7_0: false
+          hermes0_7_0: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -6367,7 +6381,8 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
-          hermes0_7_0: false
+          hermes0_7_0: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -6411,7 +6426,8 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
-          hermes0_7_0: false
+          hermes0_7_0: false,
+          hermes0_8_1: true
         }
       },
       {
@@ -6455,7 +6471,8 @@ exports.tests = [
           safari15: true,
           duktape2_0: false,
           rhino1_7_14: false,
-          hermes0_7_0: false
+          hermes0_7_0: false,
+          hermes0_8_1: true
         }
       },
       {

--- a/data-es5.js
+++ b/data-es5.js
@@ -1419,6 +1419,7 @@ exports.tests = [
       edge80: true,
       duktape2_0: true,
       rhino1_7_14: true,
+      hermes0_7_0: true
     }
   }, {
     name: 'Number.prototype.toExponential throws on ±Infinity fractionDigits',
@@ -1449,6 +1450,7 @@ exports.tests = [
       edge80: true,
       duktape2_0: true,
       rhino1_7_14: true,
+      hermes0_7_0: true
     }
   }, {
     name: 'Number.prototype.toExponential does not throw on edge cases',
@@ -1474,6 +1476,7 @@ exports.tests = [
       safari11: true,
       duktape2_0: true,
       rhino1_7_14: true,
+      hermes0_7_0: true
     }
   }],
 },

--- a/data-es6.js
+++ b/data-es6.js
@@ -915,7 +915,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_11_0: false
       }
     },
     {
@@ -1270,7 +1271,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_11_0: false
       }
     }
   ]
@@ -1512,7 +1514,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_11_0: false
       }
     },
     {
@@ -1830,7 +1833,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_11_0: false
       }
     },
     {
@@ -15518,7 +15522,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_11_0: false
       }
     }
   ],

--- a/data-es6.js
+++ b/data-es6.js
@@ -6530,7 +6530,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_8_1: true
       }
     },
     {
@@ -8733,7 +8734,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7_13: true
+        rhino1_7_13: true,
+        hermes0_8_1: true
       }
     },
     {
@@ -9431,7 +9433,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7_13: true
+        rhino1_7_13: true,
+        hermes0_8_1: true
       }
     },
     {
@@ -13045,7 +13048,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_8_1: true
       }
     },
     {
@@ -13560,7 +13564,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_8_1: false
       }
     },
     {
@@ -13815,7 +13820,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_8_1: false
       }
     },
     {
@@ -17415,7 +17421,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_2_0: true,
         hermes0_7_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_8_1: true
       }
     },
     {
@@ -17452,6 +17459,7 @@ exports.tests = [
         hermes0_7_0: false,
         rhino1_7_13: false,
         rhino1_7_14: true,
+        hermes0_8_1: true
       }
     },
     {

--- a/data-es6.js
+++ b/data-es6.js
@@ -4596,7 +4596,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_9_0: true
       }
     },
     {
@@ -4625,7 +4626,8 @@ exports.tests = [
         jerryscript2_0: false,
         jerryscript2_3_0: true,
         hermes0_7_0: false,
-        rhino1_7_13: true
+        rhino1_7_13: true,
+        hermes0_9_0: true
       }
     }
   ],

--- a/data-es6.js
+++ b/data-es6.js
@@ -20284,7 +20284,8 @@ exports.tests = [
         firefox48: true,
         firefox60: true,
         firefox70: true,
-        firefox99: true
+        firefox99: true,
+        hermes0_7_0: true
       }
     },
     {
@@ -22364,7 +22365,8 @@ exports.tests = [
         safari4: false,
         safari5: false,
         safari5_1: true,
-        safari15: true
+        safari15: true,
+        hermes0_7_0: true
       }
     },
     {

--- a/data-esintl.js
+++ b/data-esintl.js
@@ -327,7 +327,8 @@ exports.tests = [
         rhino1_7_13: false,
         hermes0_7_0: false,
         hermes0_8_1: false,
-        hermes0_9_0: false
+        hermes0_9_0: false,
+        hermes0_11_0: false
       }
     },
     {

--- a/data-esintl.js
+++ b/data-esintl.js
@@ -325,7 +325,8 @@ exports.tests = [
         graalvm20: true,
         graalvm20_1: true,
         rhino1_7_13: false,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        hermes0_8_1: false
       }
     },
     {

--- a/data-esintl.js
+++ b/data-esintl.js
@@ -31,7 +31,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -53,7 +54,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     }
   ],
@@ -82,7 +84,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -105,7 +108,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -128,7 +132,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
 // The spec was updated making this test invalid.  It was disabled until it can be fixed
@@ -193,7 +198,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -228,7 +234,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: true,
-        rhino1_7_13: true
+        rhino1_7_13: true,
+        hermes0_7_0: false
       }
     }
   ],
@@ -257,7 +264,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     }
   ],
@@ -286,7 +294,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     }
   ],
@@ -315,7 +324,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -360,7 +370,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -383,7 +394,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
 // The spec was updated making this test invalid.  It was disabled until it can be fixed
@@ -448,7 +460,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -483,7 +496,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: true
+        rhino1_7_13: true,
+        hermes0_7_0: false
       }
     }
   ],
@@ -512,7 +526,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -535,7 +550,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -558,7 +574,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
 // The spec was updated making this test invalid.  It was disabled until it can be fixed
@@ -623,7 +640,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -657,7 +675,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: true,
-        rhino1_7_13: true
+        rhino1_7_13: true,
+        hermes0_7_0: false
       }
     },
     {
@@ -687,7 +706,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -717,7 +737,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     }
   ],
@@ -750,7 +771,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: true
+        rhino1_7_13: true,
+        hermes0_7_0: true
       }
     }
   ],
@@ -783,7 +805,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: true
+        rhino1_7_13: true,
+        hermes0_7_0: true
       }
     }
   ],
@@ -816,7 +839,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: true
+        rhino1_7_13: true,
+        hermes0_7_0: true
       }
     }
   ],
@@ -849,7 +873,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: true
+        rhino1_7_13: true,
+        hermes0_7_0: true
       }
     }
   ],
@@ -882,7 +907,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: true
+        rhino1_7_13: true,
+        hermes0_7_0: true
       }
     }
   ],
@@ -915,7 +941,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: true
+        rhino1_7_13: true,
+        hermes0_7_0: true
       }
     }
   ],
@@ -948,7 +975,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-        rhino1_7_13: true
+        rhino1_7_13: true,
+        hermes0_7_0: true
       }
     }
   ],

--- a/data-esintl.js
+++ b/data-esintl.js
@@ -326,7 +326,8 @@ exports.tests = [
         graalvm20_1: true,
         rhino1_7_13: false,
         hermes0_7_0: false,
-        hermes0_8_1: false
+        hermes0_8_1: false,
+        hermes0_9_0: false
       }
     },
     {

--- a/data-esnext.js
+++ b/data-esnext.js
@@ -37,7 +37,8 @@ exports.tests = [
     graalvm19: false,
     graalvm20: false,
     graalvm20_1: false,
-    rhino1_7_13: false
+    rhino1_7_13: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -71,7 +72,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     }
   ],
@@ -97,7 +99,8 @@ exports.tests = [
     graalvm19: false,
     graalvm20: false,
     graalvm20_1: false,
-    rhino1_7_13: false
+    rhino1_7_13: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -128,7 +131,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -157,7 +161,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -181,7 +186,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -205,7 +211,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     }
   ]
@@ -236,7 +243,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -260,7 +268,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -283,7 +292,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -306,7 +316,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -326,7 +337,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: graalvm.es2021flag,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -346,7 +358,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -366,7 +379,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     }
   ]
@@ -392,7 +406,8 @@ exports.tests = [
         chrome70: false,
         safari12: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -410,7 +425,8 @@ exports.tests = [
         chrome70: false,
         safari12: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     }
   ]
@@ -448,7 +464,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         graalvm20: true,
-        graalvm20_1: true
+        graalvm20_1: true,
+        hermes0_7_0: true
       }
     },
     {
@@ -479,7 +496,8 @@ exports.tests = [
         nashorn10: true,
         graalvm19: true,
         graalvm20: true,
-        graalvm20_1: true
+        graalvm20_1: true,
+        hermes0_7_0: true
       }
     }
   ]
@@ -508,7 +526,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -530,7 +549,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     }
   ]
@@ -554,7 +574,8 @@ exports.tests = [
     firefox60: false,
     chrome77: false,
     duktape2_0: false,
-    rhino1_7_13: false
+    rhino1_7_13: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -578,7 +599,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -598,7 +620,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -619,7 +642,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -645,7 +669,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -663,7 +688,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -681,7 +707,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -699,7 +726,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -717,7 +745,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -735,7 +764,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -753,7 +783,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -773,7 +804,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -791,7 +823,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -809,7 +842,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -827,7 +861,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -845,7 +880,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -864,7 +900,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -882,7 +919,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -900,7 +938,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -920,7 +959,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -950,7 +990,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -980,7 +1021,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1010,7 +1052,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1036,7 +1079,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1062,7 +1106,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1082,7 +1127,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1108,7 +1154,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1128,7 +1175,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1154,7 +1202,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1175,7 +1224,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1201,7 +1251,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1221,7 +1272,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1241,7 +1293,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1267,7 +1320,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1287,7 +1341,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1305,7 +1360,8 @@ exports.tests = [
         firefox60: false,
         chrome77: false,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     }
   ]
@@ -1341,7 +1397,8 @@ exports.tests = [
     babel7corejs3: false,
     typescript3_2corejs3: false,
     closure: false,
-    rhino1_7_13: false
+    rhino1_7_13: false,
+    hermes0_7_0: true
   }
 },
 {
@@ -1371,7 +1428,8 @@ exports.tests = [
         safari12: false,
         safaritp: true,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1395,7 +1453,8 @@ exports.tests = [
         safari12: false,
         safaritp: true,
         duktape2_0: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     }
   ]

--- a/data-esnext.js
+++ b/data-esnext.js
@@ -1429,7 +1429,8 @@ exports.tests = [
         safaritp: true,
         duktape2_0: false,
         rhino1_7_13: false,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        hermes0_11_0: true
       }
     },
     {
@@ -1454,7 +1455,8 @@ exports.tests = [
         safaritp: true,
         duktape2_0: false,
         rhino1_7_13: false,
-        hermes0_7_0: false
+        hermes0_7_0: false,
+        hermes0_11_0: true
       }
     }
   ]

--- a/data-non-standard.js
+++ b/data-non-standard.js
@@ -42,7 +42,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs", note_html: "The feature has to be enabled via <code>--experimental-options --js.simdjs</code> flag"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -66,7 +67,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -90,7 +92,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -114,7 +117,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -138,7 +142,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -162,7 +167,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -186,7 +192,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -210,7 +217,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -234,7 +242,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -258,7 +267,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -282,7 +292,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -308,7 +319,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -334,7 +346,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -360,7 +373,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -386,7 +400,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -412,7 +427,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -438,7 +454,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -464,7 +481,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -490,7 +508,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -516,7 +535,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -542,7 +562,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -568,7 +589,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -594,7 +616,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -620,7 +643,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -646,7 +670,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -672,7 +697,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -698,7 +724,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -723,7 +750,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -748,7 +776,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -773,7 +802,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -799,7 +829,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -826,7 +857,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -852,7 +884,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -879,7 +912,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -905,7 +939,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -931,7 +966,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -957,7 +993,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -983,7 +1020,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1009,7 +1047,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1035,7 +1074,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1061,7 +1101,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1087,7 +1128,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1113,7 +1155,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1139,7 +1182,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1165,7 +1209,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1191,7 +1236,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1217,7 +1263,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1243,7 +1290,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1268,7 +1316,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1293,7 +1342,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1318,7 +1368,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1344,7 +1395,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1370,7 +1422,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1396,7 +1449,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1422,7 +1476,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1448,7 +1503,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1472,7 +1528,8 @@ exports.tests = [
         graalvm19: {val: 'flagged', note_id: "graalvm-simdjs"},
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     }
   ],
@@ -1498,7 +1555,8 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm20: false,
-        graalvm20_1: false
+        graalvm20_1: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1527,7 +1585,8 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm20: false,
-        graalvm20_1: false
+        graalvm20_1: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1545,7 +1604,8 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm20: false,
-        graalvm20_1: false
+        graalvm20_1: false,
+        hermes0_7_0: false
       }
     },
     {
@@ -1650,7 +1710,8 @@ exports.tests = [
         duktape2_0: false,
         graalvm19: false,
         graalvm20: false,
-        graalvm20_1: false
+        graalvm20_1: false,
+        hermes0_7_0: false
       }
     }
   ]
@@ -1674,7 +1735,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   },
   separator: 'after'
 },
@@ -1700,7 +1762,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: true,
     graalvm20: true,
-    graalvm20_1: true
+    graalvm20_1: true,
+    hermes0_7_0: false
   }
 },
 {
@@ -1727,7 +1790,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -1755,7 +1819,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: true,
     graalvm20: true,
-    graalvm20_1: true
+    graalvm20_1: true,
+    hermes0_7_0: false
   }
 },
 {
@@ -1783,7 +1848,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   },
   separator: 'after'
 },
@@ -1807,7 +1873,8 @@ exports.tests = [
     graalvm19: false,
     graalvm20: false,
     graalvm20_1: false,
-    rhino1_7_13: false
+    rhino1_7_13: false,
+    hermes0_7_0: false
   },
 },
 {
@@ -1834,7 +1901,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -1860,7 +1928,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -1897,7 +1966,8 @@ exports.tests = [
       note_id: 'graalvm-nashorn-compat',
       note_html: 'The feature has to be enabled via the <code>--nashorn-compat</code> flag.'
     },
-	graalvm20: {val: "flagged", note_id: 'graalvm-nashorn-compat'}
+	graalvm20: {val: "flagged", note_id: 'graalvm-nashorn-compat'},
+    hermes0_7_0: false
   }
 },
 {
@@ -1922,7 +1992,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -1947,7 +2018,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   },
   separator: 'after'
 },
@@ -1977,7 +2049,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2001,7 +2074,8 @@ exports.tests = [
     graalvm19: false,
     graalvm20: false,
     graalvm20_1: false,
-    rhino1_7_13: false
+    rhino1_7_13: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2030,7 +2104,8 @@ exports.tests = [
     nashorn10: true,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2056,7 +2131,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2089,7 +2165,8 @@ exports.tests = [
     nashorn10: true,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2116,7 +2193,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   },
   separator: 'after'
 },
@@ -2158,7 +2236,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2202,7 +2281,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2284,7 +2364,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2314,7 +2395,8 @@ exports.tests = [
     graalvm19: false,
     graalvm20: false,
     graalvm20_1: false,
-    rhino1_7_13: false
+    rhino1_7_13: false,
+    hermes0_7_0: false
   },
   separator: 'after'
 },
@@ -2346,7 +2428,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2369,7 +2452,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2394,7 +2478,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   },
   separator: 'after'
 },
@@ -2418,7 +2503,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2438,7 +2524,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   },
   separator: 'after'
 },
@@ -2463,7 +2550,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   },
 },
 {
@@ -2492,7 +2580,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   },
   separator: 'after'
 },
@@ -2517,7 +2606,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2541,7 +2631,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2564,7 +2655,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   },
 },
 {
@@ -2587,7 +2679,8 @@ exports.tests = [
     graalvm19: false,
     graalvm20: false,
     graalvm20_1: false,
-    rhino1_7_13: false
+    rhino1_7_13: false,
+    hermes0_7_0: false
   },
   separator: 'after'
 },
@@ -2624,7 +2717,8 @@ exports.tests = [
     nashorn10: true,
     graalvm19: true,
     graalvm20: true,
-    graalvm20_1: true
+    graalvm20_1: true,
+    hermes0_7_0: true
   }
 },
 {
@@ -2652,7 +2746,8 @@ exports.tests = [
     nashorn10: true,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2681,7 +2776,8 @@ exports.tests = [
     nashorn10: true,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2709,7 +2805,8 @@ exports.tests = [
     nashorn10: true,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   }
 },
 {
@@ -2733,7 +2830,8 @@ exports.tests = [
     duktape2_0: false,
     graalvm19: false,
     graalvm20: false,
-    graalvm20_1: false
+    graalvm20_1: false,
+    hermes0_7_0: false
   },
   separator: 'after'
 },
@@ -2771,7 +2869,8 @@ exports.tests = [
         graalvm19: true,
         graalvm20: true,
         graalvm20_1: true,
-    rhino1_7_13: false
+    rhino1_7_13: false,
+        hermes0_7_0: true
       }
     }, {
       name: '"global" global property has correct property descriptor',
@@ -2810,7 +2909,8 @@ exports.tests = [
         graalvm19: false,
         graalvm20: false,
         graalvm20_1: false,
-        rhino1_7_13: false
+        rhino1_7_13: false,
+        hermes0_7_0: false
       }
     }]
   },
@@ -2848,7 +2948,8 @@ exports.tests = [
     graalvm19: true,
     graalvm20: false,
     graalvm20_1: false,
-    rhino1_7_13: false
+    rhino1_7_13: false,
+    hermes0_7_0: false
   },
 },
 ];

--- a/environments.json
+++ b/environments.json
@@ -4958,6 +4958,22 @@
       "non-standard"
     ]
   },
+  "hermes0_9_0": {
+    "full": "Hermes 0.9.0",
+    "family": "Hermes",
+    "short": "Hermes 0.9.0",
+    "platformtype": "engine",
+    "release": "2021-09-02",
+    "obsolete": false,
+    "test_suites": [
+      "es5",
+      "es6",
+      "es2016plus",
+      "esnext",
+      "esintl",
+      "non-standard"
+    ]
+  },
   "android1_5": {
     "full": "Android Browser 1.5 (Cupcake)",
     "family": "Android Browser",

--- a/environments.json
+++ b/environments.json
@@ -4974,6 +4974,22 @@
       "non-standard"
     ]
   },
+  "hermes0_10_0": {
+    "full": "Hermes 0.10.0",
+    "family": "Hermes",
+    "short": "Hermes 0.10.0",
+    "platformtype": "engine",
+    "release": "2021-11-14",
+    "obsolete": false,
+    "test_suites": [
+      "es5",
+      "es6",
+      "es2016plus",
+      "esnext",
+      "esintl",
+      "non-standard"
+    ]
+  },
   "android1_5": {
     "full": "Android Browser 1.5 (Cupcake)",
     "family": "Android Browser",

--- a/environments.json
+++ b/environments.json
@@ -4990,6 +4990,22 @@
       "non-standard"
     ]
   },
+  "hermes0_11_0": {
+    "full": "Hermes 0.11.0",
+    "family": "Hermes",
+    "short": "Hermes 0.11.0",
+    "platformtype": "engine",
+    "release": "2022-01-27",
+    "obsolete": false,
+    "test_suites": [
+      "es5",
+      "es6",
+      "es2016plus",
+      "esnext",
+      "esintl",
+      "non-standard"
+    ]
+  },
   "android1_5": {
     "full": "Android Browser 1.5 (Cupcake)",
     "family": "Android Browser",

--- a/environments.json
+++ b/environments.json
@@ -4936,7 +4936,10 @@
     "test_suites": [
       "es5",
       "es6",
-      "es2016plus"
+      "es2016plus",
+      "esnext",
+      "esintl",
+      "non-standard"
     ]
   },
   "android1_5": {

--- a/environments.json
+++ b/environments.json
@@ -4942,6 +4942,22 @@
       "non-standard"
     ]
   },
+  "hermes0_8_1": {
+    "full": "Hermes 0.8.1",
+    "family": "Hermes",
+    "short": "Hermes 0.8.1",
+    "platformtype": "engine",
+    "release": "2021-07-12",
+    "obsolete": false,
+    "test_suites": [
+      "es5",
+      "es6",
+      "es2016plus",
+      "esnext",
+      "esintl",
+      "non-standard"
+    ]
+  },
   "android1_5": {
     "full": "Android Browser 1.5 (Cupcake)",
     "family": "Android Browser",

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -255,6 +255,10 @@
 <th class="platform graalvm20_3_1 engine" data-browser="graalvm20_3_1"><a href="#graalvm20_3_1" class="browser-name"><abbr title="GraalVM JavaScript 20.3.1">GraalVM 20.3.1</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
 <th class="platform graalvm21 engine" data-browser="graalvm21"><a href="#graalvm21" class="browser-name"><abbr title="GraalVM JavaScript 21.0.0">GraalVM 21.0.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
 <th class="platform hermes0_7_0 engine" data-browser="hermes0_7_0"><a href="#hermes0_7_0" class="browser-name"><abbr title="Hermes 0.7.0">Hermes 0.7.0</abbr></a></th>
+<th class="platform hermes0_8_1 engine" data-browser="hermes0_8_1"><a href="#hermes0_8_1" class="browser-name"><abbr title="Hermes 0.8.1">Hermes 0.8.1</abbr></a></th>
+<th class="platform hermes0_9_0 engine" data-browser="hermes0_9_0"><a href="#hermes0_9_0" class="browser-name"><abbr title="Hermes 0.9.0">Hermes 0.9.0</abbr></a></th>
+<th class="platform hermes0_10_0 engine" data-browser="hermes0_10_0"><a href="#hermes0_10_0" class="browser-name"><abbr title="Hermes 0.10.0">Hermes 0.10.0</abbr></a></th>
+<th class="platform hermes0_11_0 engine" data-browser="hermes0_11_0"><a href="#hermes0_11_0" class="browser-name"><abbr title="Hermes 0.11.0">Hermes 0.11.0</abbr></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios10_3 mobile obsolete" data-browser="ios10_3"><a href="#ios10_3" class="browser-name"><abbr title="iOS Safari">iOS &gt;=10.3 &lt;11</abbr></a></th>
@@ -282,7 +286,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="156"><span>2016 features</span></td>
+      <tr class="category"><td colspan="160"><span>2016 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-exponentiation_(**)_operator"><span><a class="anchor" href="#test-exponentiation_(**)_operator">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-exp-operator">exponentiation (**) operator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Exponentiation_(**)" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -416,6 +420,10 @@
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">3/3</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">3/3</td>
@@ -574,6 +582,10 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -732,6 +744,10 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -895,6 +911,10 @@ return true;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1050,6 +1070,10 @@ return true;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">4/4</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">4/4</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">4/4</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">4/4</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">4/4</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">4/4</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">4/4</td>
@@ -1211,6 +1235,10 @@ return [1, 2, 3].includes(1)
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1370,6 +1398,10 @@ return [,].includes()
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1550,6 +1582,10 @@ return 24;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1713,6 +1749,10 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1736,7 +1776,7 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr class="category"><td colspan="156"><span>2016 misc</span></td>
+<tr class="category"><td colspan="160"><span>2016 misc</span></td>
 </tr>
 <tr significance="0.125"><td id="test-generator_functions_can&apos;t_be_used_with_new"><span><a class="anchor" href="#test-generator_functions_can&apos;t_be_used_with_new">&#xA7;</a><a href="http://www.ecma-international.org/ecma-262/7.0/index.html#sec-createdynamicfunction">generator functions can&apos;t be used with &quot;new&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*#Generators_are_not_constructable" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;<a href="#new-gen-fn-note"><sup>[7]</sup></a></span><script data-source="
 function * generator() {
@@ -1880,6 +1920,10 @@ return true;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2051,6 +2095,10 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2214,6 +2262,10 @@ return true;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2373,6 +2425,10 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2533,6 +2589,10 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2698,6 +2758,10 @@ return passed;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2865,6 +2929,10 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2888,7 +2956,7 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr class="category"><td colspan="156"><span>2017 features</span></td>
+<tr class="category"><td colspan="160"><span>2017 features</span></td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-constructor">Object static methods</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/4</td>
@@ -3022,6 +3090,10 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">4/4</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">4/4</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">4/4</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">4/4</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">4/4</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">4/4</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">4/4</td>
@@ -3183,6 +3255,10 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3348,6 +3424,10 @@ return Array.isArray(e)
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3514,6 +3594,10 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3675,6 +3759,10 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3830,6 +3918,10 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">2/2</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">2/2</td>
@@ -3993,6 +4085,10 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -4156,6 +4252,10 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -4311,6 +4411,10 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">2/2</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">2/2</td>
@@ -4469,6 +4573,10 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -4627,6 +4735,10 @@ return Math.min(1,2,3,) === 1;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -4782,6 +4894,10 @@ return Math.min(1,2,3,) === 1;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">16/16</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">16/16</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/16</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0.3125" style="background-color:hsl(37,72%,50%)">5/16</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0.3125" style="background-color:hsl(37,72%,50%)">5/16</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0.3125" style="background-color:hsl(37,72%,50%)">5/16</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0.3125" style="background-color:hsl(37,72%,50%)">5/16</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0.9375" style="background-color:hsl(112,44%,50%)">15/16</td>
@@ -4951,6 +5067,10 @@ p.then(function(result) {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5120,6 +5240,10 @@ p.catch(function(result) {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5279,6 +5403,10 @@ try { Function(&quot;async\n function a(){await 0}&quot;)(); } catch(e) { return
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5438,6 +5566,10 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5603,6 +5735,10 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5770,6 +5906,10 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5929,6 +6069,10 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -6093,6 +6237,10 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -6252,6 +6400,10 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -6421,6 +6573,10 @@ p.then(function(result) {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -6590,6 +6746,10 @@ p.then(function(result) {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -6759,6 +6919,10 @@ var p = new C().a();
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -6926,6 +7090,10 @@ p.then(function(result) {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -7086,6 +7254,10 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -7244,6 +7416,10 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -7411,6 +7587,10 @@ p.then(function(result) {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -7566,6 +7746,10 @@ p.then(function(result) {
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">17/17</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">17/17</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/17</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/17</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/17</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/17</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0.9411764705882353" style="background-color:hsl(112,44%,50%)">16/17</td>
@@ -7724,6 +7908,10 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -7882,6 +8070,10 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -8040,6 +8232,10 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -8198,6 +8394,10 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -8356,6 +8556,10 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -8514,6 +8718,10 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -8672,6 +8880,10 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -8830,6 +9042,10 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -8988,6 +9204,10 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -9146,6 +9366,10 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -9304,6 +9528,10 @@ return typeof Atomics.notify === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -9462,6 +9690,10 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -9620,6 +9852,10 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -9778,6 +10014,10 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -9936,6 +10176,10 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -10094,6 +10338,10 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -10252,6 +10500,10 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -10275,7 +10527,7 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr class="category"><td colspan="156"><span>2017 misc</span></td>
+<tr class="category"><td colspan="160"><span>2017 misc</span></td>
 </tr>
 <tr significance="0.125"><td id="test-RegExp_u_flag,_case_folding"><span><a class="anchor" href="#test-RegExp_u_flag,_case_folding">&#xA7;</a><a href="https://github.com/tc39/ecma262/pull/525">RegExp &quot;u&quot; flag, case folding</a></span><script data-source="
 return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/\W/iu)
@@ -10415,6 +10667,10 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -10576,6 +10832,10 @@ return (function(){
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -10599,7 +10859,7 @@ return (function(){
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr class="category"><td colspan="156"><span>2017 annex b</span></td>
+<tr class="category"><td colspan="160"><span>2017 annex b</span></td>
 </tr>
 <tr class="supertest optional-feature" significance="0.125"><td id="test-Object.prototype_getter/setter_methods"><span><a class="anchor" href="#test-Object.prototype_getter/setter_methods">&#xA7;</a><a href="https://tc39.github.io/ecma262/#sec-object.prototype.__defineGetter__">Object.prototype getter/setter methods</a></span></td>
 <td class="tally obsolete not-applicable" data-browser="tr" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
@@ -10733,6 +10993,10 @@ return (function(){
 <td class="tally not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
+<td class="tally not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.375" style="background-color:hsl(45,69%,50%)" data-flagged-tally="0.625">6/16</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.375" style="background-color:hsl(45,69%,50%)" data-flagged-tally="0.625">6/16</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">16/16</td>
@@ -10896,6 +11160,10 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -11060,6 +11328,10 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -11224,6 +11496,10 @@ return true;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -11387,6 +11663,10 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -11551,6 +11831,10 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -11715,6 +11999,10 @@ return true;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -11880,6 +12168,10 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -12045,6 +12337,10 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -12211,6 +12507,10 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -12374,6 +12674,10 @@ return true;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -12536,6 +12840,10 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -12701,6 +13009,10 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -12866,6 +13178,10 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -13032,6 +13348,10 @@ return foo() === &quot;bar&quot;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="no flagged obsolete" data-browser="android4_4">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="no flagged obsolete" data-browser="android4_4_3">Flag<a href="#chrome-experimental-note"><sup>[4]</sup></a></td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -13195,6 +13515,10 @@ return true;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -13357,6 +13681,10 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -13512,6 +13840,10 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
+<td class="tally not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
+<td class="tally not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
+<td class="tally not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
+<td class="tally not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">4/4</td>
@@ -13674,6 +14006,10 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -13836,6 +14172,10 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -14003,6 +14343,10 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -14170,6 +14514,10 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -14329,6 +14677,10 @@ return i === 0;
 <td class="yes not-applicable" data-browser="graalvm20_3_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="graalvm21" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes not-applicable" data-browser="hermes0_7_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_8_1" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_9_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_10_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
+<td class="yes not-applicable" data-browser="hermes0_11_0" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -14352,7 +14704,7 @@ return i === 0;
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr class="category"><td colspan="156"><span>2018 features</span></td>
+<tr class="category"><td colspan="160"><span>2018 features</span></td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-object_rest/spread_properties"><span><a class="anchor" href="#test-object_rest/spread_properties">&#xA7;</a><a href="https://github.com/tc39/proposal-object-rest-spread">object rest/spread properties</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -14486,6 +14838,10 @@ return i === 0;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">2/2</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/2</td>
@@ -14645,6 +15001,10 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -14805,6 +15165,10 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -14960,6 +15324,10 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">3/3</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/3</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/3</td>
@@ -15144,6 +15512,10 @@ function check() {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -15320,6 +15692,10 @@ function check() {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -15498,6 +15874,10 @@ function check() {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -15657,6 +16037,10 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -15822,6 +16206,10 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -15981,6 +16369,10 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -16140,6 +16532,10 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -16295,6 +16691,10 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">2/2</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/2</td>
@@ -16460,6 +16860,10 @@ iterator.next().then(function(step){
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -16635,6 +17039,10 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -16658,7 +17066,7 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr class="category"><td colspan="156"><span>2018 misc</span></td>
+<tr class="category"><td colspan="160"><span>2018 misc</span></td>
 </tr>
 <tr significance="0.125"><td id="test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets"><span><a class="anchor" href="#test-Proxy_ownKeys_handler,_duplicate_keys_for_non-extensible_targets">&#xA7;</a><a href="https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys">Proxy &quot;ownKeys&quot; handler, duplicate keys for non-extensible targets</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var p = new Proxy({}, {
@@ -16805,6 +17213,10 @@ return false;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -16970,6 +17382,10 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -16993,7 +17409,7 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr class="category"><td colspan="156"><span>2019 features</span></td>
+<tr class="category"><td colspan="160"><span>2019 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Symbol.prototype.description"><span><a class="anchor" href="#test-Symbol.prototype.description">&#xA7;</a><a href="https://github.com/tc39/proposal-Symbol-description">Symbol.prototype.description</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
@@ -17127,6 +17543,10 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">3/3</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/3</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/3</td>
@@ -17285,6 +17705,10 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -17443,6 +17867,10 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -17602,6 +18030,10 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -17761,6 +18193,10 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -17916,6 +18352,10 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">4/4</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">4/4</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">4/4</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">4/4</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">4/4</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">4/4</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0.5" style="background-color:hsl(60,64%,50%)">2/4</td>
@@ -18074,6 +18514,10 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -18232,6 +18676,10 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -18390,6 +18838,10 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -18548,6 +19000,10 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -18703,6 +19159,10 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">3/3</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/3</td>
@@ -18861,6 +19321,10 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -19021,6 +19485,10 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -19180,6 +19648,10 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -19203,7 +19675,7 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr class="category"><td colspan="156"><span>2019 misc</span></td>
+<tr class="category"><td colspan="160"><span>2019 misc</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-optional_catch_binding"><span><a class="anchor" href="#test-optional_catch_binding">&#xA7;</a><a href="https://github.com/tc39/proposal-optional-catch-binding">optional catch binding</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/3</td>
@@ -19337,6 +19809,10 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">3/3</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/3</td>
@@ -19501,6 +19977,10 @@ return false;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -19666,6 +20146,10 @@ return false;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -19835,6 +20319,10 @@ return it.throw().value;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -19990,6 +20478,10 @@ return it.throw().value;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">7/7</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">7/7</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0.14285714285714285" style="background-color:hsl(17,79%,50%)">1/7</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0.5714285714285714" style="background-color:hsl(68,60%,50%)">4/7</td>
@@ -20150,6 +20642,10 @@ return fn + &apos;&apos; === str;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -20309,6 +20805,10 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -20468,6 +20968,10 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -20627,6 +21131,10 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -20786,6 +21294,10 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -20945,6 +21457,10 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -21104,6 +21620,10 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -21259,6 +21779,10 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">2/2</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/2</td>
@@ -21417,6 +21941,10 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -21575,6 +22103,10 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -21734,6 +22266,10 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -21757,7 +22293,7 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr class="category"><td colspan="156"><span>2020 features</span></td>
+<tr class="category"><td colspan="160"><span>2020 features</span></td>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-String.prototype.matchAll"><span><a class="anchor" href="#test-String.prototype.matchAll">&#xA7;</a><a href="https://github.com/tc39/String.prototype.matchAll">String.prototype.matchAll</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0">0/2</td>
@@ -21891,6 +22427,10 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">2/2</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/2</td>
@@ -22059,6 +22599,10 @@ return a === &apos;1a2b&apos;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -22222,6 +22766,10 @@ try {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -22377,6 +22925,10 @@ try {
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">8/8</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">8/8</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/8</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/8</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/8</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/8</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/8</td>
@@ -22535,6 +23087,10 @@ return (1n + 2n) === 3n;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -22693,6 +23249,10 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -22851,6 +23411,10 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -23009,6 +23573,10 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -23170,6 +23738,10 @@ return view[0] === -0x8000000000000000n;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -23331,6 +23903,10 @@ return view[0] === 0n;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -23492,6 +24068,10 @@ return view.getBigInt64(0) === 1n;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -23653,6 +24233,10 @@ return view.getBigUint64(0) === 1n;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -23822,6 +24406,10 @@ Promise.allSettled([
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -23977,6 +24565,10 @@ Promise.allSettled([
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">2/2</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/2</td>
@@ -24137,6 +24729,10 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -24301,6 +24897,10 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -24456,6 +25056,10 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="graalvm21" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">5/5</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">5/5</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">5/5</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/5</td>
@@ -24616,6 +25220,10 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -24776,6 +25384,10 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -24936,6 +25548,10 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -25098,6 +25714,10 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -25259,7 +25879,11 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -25423,6 +26047,10 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -25446,7 +26074,7 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr class="category"><td colspan="156"><span>2021 features</span></td>
+<tr class="category"><td colspan="160"><span>2021 features</span></td>
 </tr>
 <tr significance="0.25"><td id="test-String.prototype.replaceAll"><span><a class="anchor" href="#test-String.prototype.replaceAll">&#xA7;</a><a href="https://github.com/tc39/proposal-string-replace-all">String.prototype.replaceAll</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &apos;) === &apos;q=query string parameters&apos;;
@@ -25583,6 +26211,10 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -25738,6 +26370,10 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">2/2</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/2</td>
@@ -25902,6 +26538,10 @@ Promise.any([
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -26066,6 +26706,10 @@ Promise.any([
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -26221,6 +26865,10 @@ Promise.any([
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0" data-flagged-tally="1">0/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">2/2</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/2</td>
@@ -26381,6 +27029,10 @@ return weakref.deref() === O;
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -26540,6 +27192,10 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -26695,6 +27351,10 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0" data-flagged-tally="1">0/9</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">9/9</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">9/9</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">9/9</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">9/9</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">9/9</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/9</td>
@@ -26859,6 +27519,10 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -27020,6 +27684,10 @@ return a === 1 &amp;&amp; i === 1;
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -27181,6 +27849,10 @@ return i === 1;
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -27345,6 +28017,10 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -27506,6 +28182,10 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -27667,6 +28347,10 @@ return i === 1;
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -27831,6 +28515,10 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -27992,6 +28680,10 @@ return a === 1 &amp;&amp; i === 1;
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -28153,6 +28845,10 @@ return i === 1;
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[30]</sup></a></td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -28312,6 +29008,10 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -28335,7 +29035,7 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr class="category"><td colspan="156"><span>2022 features</span></td>
+<tr class="category"><td colspan="160"><span>2022 features</span></td>
 </tr>
 <tr class="supertest" significance="0.5"><td id="test-instance_class_fields"><span><a class="anchor" href="#test-instance_class_fields">&#xA7;</a><a href="https://github.com/tc39/proposal-class-fields">instance class fields</a></span></td>
 <td class="tally obsolete" data-browser="tr" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
@@ -28469,6 +29169,10 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">6/6</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">6/6</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/6</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/6</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/6</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/6</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/6</td>
@@ -28629,7 +29333,11 @@ return new C().x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -28796,7 +29504,11 @@ return new C(42).x() === 42;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -28960,7 +29672,11 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -29124,7 +29840,11 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -29288,7 +30008,11 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -29449,7 +30173,11 @@ return new C().x === 42;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -29605,6 +30333,10 @@ return new C().x === 42;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="graalvm21" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/4</td>
@@ -29765,7 +30497,11 @@ return C.x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -29923,7 +30659,11 @@ return (class X { static name = &quot;name&quot;; }).name === &apos;name&apos;;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -30087,7 +30827,11 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -30248,7 +30992,11 @@ return C.x === 42;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -30404,6 +31152,10 @@ return C.x === 42;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">4/4</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">4/4</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/4</td>
@@ -30567,7 +31319,11 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -30731,7 +31487,11 @@ return new C().x() === 42;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -30898,7 +31658,11 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -31065,7 +31829,11 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -31229,7 +31997,11 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -31385,6 +32157,10 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="graalvm21" data-tally="0" data-flagged-tally="1">0/3</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/3</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/3</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/3</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/3</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/3</td>
@@ -31550,7 +32326,11 @@ return arr.at(0) === 1
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="no flagged" data-browser="graalvm21">Flag<a href="#graalvm-es2022-note"><sup>[40]</sup></a></td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -31716,7 +32496,11 @@ return str.at(0) === &apos;a&apos;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="no flagged" data-browser="graalvm21">Flag<a href="#graalvm-es2022-note"><sup>[40]</sup></a></td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -31898,7 +32682,11 @@ return [
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="no flagged" data-browser="graalvm21">Flag<a href="#graalvm-es2022-note"><sup>[40]</sup></a></td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -32054,6 +32842,10 @@ return [
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="0">0/2</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/2</td>
@@ -32211,7 +33003,11 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -32375,7 +33171,11 @@ try {
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -32537,7 +33337,11 @@ return ok;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -32692,7 +33496,11 @@ return ok;
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/16</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0">0/16</td>
 <td class="tally" data-browser="graalvm21" data-tally="0">0/16</td>
-<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/16</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0.4375" style="background-color:hsl(52,66%,50%)">7/16</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0.875" style="background-color:hsl(105,47%,50%)">14/16</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/16</td>
@@ -32851,7 +33659,11 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -33009,7 +33821,11 @@ return !(&apos;cause&apos; in Error.prototype);
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -33168,7 +33984,11 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -33326,7 +34146,11 @@ return !(&apos;cause&apos; in EvalError.prototype);
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -33485,7 +34309,11 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -33643,7 +34471,11 @@ return !(&apos;cause&apos; in RangeError.prototype);
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -33802,7 +34634,11 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -33960,7 +34796,11 @@ return !(&apos;cause&apos; in ReferenceError.prototype);
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -34119,7 +34959,11 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -34277,7 +35121,11 @@ return !(&apos;cause&apos; in SyntaxError.prototype);
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -34436,7 +35284,11 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -34594,7 +35446,11 @@ return !(&apos;cause&apos; in TypeError.prototype);
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -34753,7 +35609,11 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -34911,7 +35771,11 @@ return !(&apos;cause&apos; in URIError.prototype);
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -35070,7 +35934,11 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -35228,7 +36096,11 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -35384,6 +36256,10 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="0">0/2</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/2</td>
@@ -35541,7 +36417,11 @@ return new RegExp(&apos;a&apos;, &apos;d&apos;) instanceof RegExp;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -35714,7 +36594,11 @@ return true;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>

--- a/es5/index.html
+++ b/es5/index.html
@@ -251,6 +251,10 @@
 <th class="platform graalvm20_3_1 engine" data-browser="graalvm20_3_1"><a href="#graalvm20_3_1" class="browser-name"><abbr title="GraalVM JavaScript 20.3.1">GraalVM 20.3.1</abbr></a><a href="#graalvm-node-mode-note"><sup>[4]</sup></a></th>
 <th class="platform graalvm21 engine" data-browser="graalvm21"><a href="#graalvm21" class="browser-name"><abbr title="GraalVM JavaScript 21.0.0">GraalVM 21.0.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[4]</sup></a></th>
 <th class="platform hermes0_7_0 engine" data-browser="hermes0_7_0"><a href="#hermes0_7_0" class="browser-name"><abbr title="Hermes 0.7.0">Hermes 0.7.0</abbr></a></th>
+<th class="platform hermes0_8_1 engine" data-browser="hermes0_8_1"><a href="#hermes0_8_1" class="browser-name"><abbr title="Hermes 0.8.1">Hermes 0.8.1</abbr></a></th>
+<th class="platform hermes0_9_0 engine" data-browser="hermes0_9_0"><a href="#hermes0_9_0" class="browser-name"><abbr title="Hermes 0.9.0">Hermes 0.9.0</abbr></a></th>
+<th class="platform hermes0_10_0 engine" data-browser="hermes0_10_0"><a href="#hermes0_10_0" class="browser-name"><abbr title="Hermes 0.10.0">Hermes 0.10.0</abbr></a></th>
+<th class="platform hermes0_11_0 engine" data-browser="hermes0_11_0"><a href="#hermes0_11_0" class="browser-name"><abbr title="Hermes 0.11.0">Hermes 0.11.0</abbr></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios10_3 mobile obsolete" data-browser="ios10_3"><a href="#ios10_3" class="browser-name"><abbr title="iOS Safari">iOS &gt;=10.3 &lt;11</abbr></a></th>
@@ -404,6 +408,10 @@
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">5/5</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">5/5</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">5/5</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">5/5</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">5/5</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">5/5</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">5/5</td>
@@ -556,6 +564,10 @@ return ({ get x(){ return 1 } }).x === 1;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -710,6 +722,10 @@ return value === 1;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -862,6 +878,10 @@ return { a: true, }.a === true;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1014,6 +1034,10 @@ return [1,].length === 1;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1166,6 +1190,10 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1189,7 +1217,7 @@ return ({ if: 1 }).if === 1;
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr><th colspan="150" class="separator"></th>
+<tr><th colspan="154" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-Object_static_methods"><span><a class="anchor" href="#test-Object_static_methods">&#xA7;</a>Object static methods</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0.07692307692307693" style="background-color:hsl(9,82%,50%)">1/13</td>
@@ -1317,6 +1345,10 @@ return ({ if: 1 }).if === 1;
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">13/13</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">13/13</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">13/13</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">13/13</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">13/13</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">13/13</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">13/13</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">13/13</td>
@@ -1471,6 +1503,10 @@ return typeof Object.create === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1625,6 +1661,10 @@ return typeof Object.defineProperty === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1779,6 +1819,10 @@ return typeof Object.defineProperties === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1933,6 +1977,10 @@ return typeof Object.getPrototypeOf === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2087,6 +2135,10 @@ return typeof Object.keys === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2241,6 +2293,10 @@ return typeof Object.seal === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2395,6 +2451,10 @@ return typeof Object.freeze === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2549,6 +2609,10 @@ return typeof Object.preventExtensions === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2703,6 +2767,10 @@ return typeof Object.isSealed === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2857,6 +2925,10 @@ return typeof Object.isFrozen === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3011,6 +3083,10 @@ return typeof Object.isExtensible === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3165,6 +3241,10 @@ return typeof Object.getOwnPropertyDescriptor === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3319,6 +3399,10 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3468,6 +3552,10 @@ return typeof Object.getOwnPropertyNames === 'function';
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">12/12</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">12/12</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">12/12</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">12/12</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">12/12</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">12/12</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">12/12</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.9166666666666666" style="background-color:hsl(110,45%,50%)">11/12</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">12/12</td>
@@ -3622,6 +3710,10 @@ return typeof Array.isArray === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3776,6 +3868,10 @@ return typeof Array.prototype.indexOf === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3930,6 +4026,10 @@ return typeof Array.prototype.lastIndexOf === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -4084,6 +4184,10 @@ return typeof Array.prototype.every === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -4238,6 +4342,10 @@ return typeof Array.prototype.some === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -4392,6 +4500,10 @@ return typeof Array.prototype.forEach === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -4546,6 +4658,10 @@ return typeof Array.prototype.map === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -4700,6 +4816,10 @@ return typeof Array.prototype.filter === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -4854,6 +4974,10 @@ return typeof Array.prototype.reduce === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5008,6 +5132,10 @@ return typeof Array.prototype.reduceRight === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5202,6 +5330,10 @@ return true;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5366,6 +5498,10 @@ try {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5515,6 +5651,10 @@ try {
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">3/3</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">3/3</td>
@@ -5669,6 +5809,10 @@ return "foobar"[3] === "b";
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5847,6 +5991,10 @@ return typeof String.prototype.split === 'function'
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -6001,6 +6149,10 @@ return typeof String.prototype.trim === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -6150,6 +6302,10 @@ return typeof String.prototype.trim === 'function';
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">3/3</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">3/3</td>
@@ -6304,6 +6460,10 @@ return typeof Date.prototype.toISOString === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -6458,6 +6618,10 @@ return typeof Date.now === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -6620,6 +6784,10 @@ try {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -6774,6 +6942,10 @@ return typeof Function.prototype.bind === 'function';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -6928,6 +7100,10 @@ return typeof JSON === 'object';
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -6951,7 +7127,7 @@ return typeof JSON === 'object';
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr><th colspan="150" class="separator"></th>
+<tr><th colspan="154" class="separator"></th>
 </tr>
 <tr class="supertest" significance="0.25"><td id="test-Immutable_globals"><span><a class="anchor" href="#test-Immutable_globals">&#xA7;</a>Immutable globals</span></td>
 <td class="tally" data-browser="es5shim" data-tally="0">0/3</td>
@@ -7079,6 +7255,10 @@ return typeof JSON === 'object';
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">3/3</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">3/3</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">3/3</td>
@@ -7234,6 +7414,10 @@ return result;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -7389,6 +7573,10 @@ return result;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -7544,6 +7732,10 @@ return result;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -7692,7 +7884,11 @@ return result;
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/3</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0">0/3</td>
 <td class="tally" data-browser="graalvm21" data-tally="0">0/3</td>
-<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/3</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">3/3</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -7850,7 +8046,11 @@ return (-6.9e-11).toExponential(4) === '-6.9000e-11' // Edge <= 17
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -8016,7 +8216,11 @@ try {
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -8182,7 +8386,11 @@ try {
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
-<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -8332,6 +8540,10 @@ try {
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">8/8</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">8/8</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0.875" style="background-color:hsl(105,47%,50%)">7/8</td>
@@ -8494,6 +8706,10 @@ try {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -8648,6 +8864,10 @@ return parseInt('010') === 10;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -8800,6 +9020,10 @@ return !Function().propertyIsEnumerable(&apos;prototype&apos;);
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -8952,6 +9176,10 @@ return (function(){ return Object.prototype.toString.call(arguments) === &apos;[
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -9105,6 +9333,10 @@ return _\u200c\u200d;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -9259,6 +9491,10 @@ return true;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -9419,6 +9655,10 @@ return result;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -9577,6 +9817,10 @@ catch(e) {
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -9726,6 +9970,10 @@ catch(e) {
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">19/19</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">19/19</td>
 <td class="tally" data-browser="hermes0_7_0" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0.5789473684210527" style="background-color:hsl(69,60%,50%)">11/19</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">19/19</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">19/19</td>
@@ -9883,6 +10131,10 @@ return true;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_8_1">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_9_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_10_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_11_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -10036,6 +10288,10 @@ return this === void undefined &amp;&amp; (function(){ return this === void unde
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -10191,6 +10447,10 @@ return (function(){ return typeof this === &apos;string&apos; }).call(&apos;&apo
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -10360,6 +10620,10 @@ return test(String, &apos;&apos;)
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -10515,6 +10779,10 @@ return true;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_8_1">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_9_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_10_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_11_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -10668,6 +10936,10 @@ try { eval(&apos;__i_dont_exist = 1&apos;); } catch (err) { return err instanceo
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_8_1">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_9_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_10_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_11_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -10825,6 +11097,10 @@ return true;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_8_1">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_9_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_10_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_11_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -10982,6 +11258,10 @@ return true;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -11141,6 +11421,10 @@ return true;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_8_1">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_9_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_10_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_11_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -11297,6 +11581,10 @@ return true;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -11451,6 +11739,10 @@ return true;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -11606,6 +11898,10 @@ return true;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -11765,6 +12061,10 @@ return (function(x){
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -11918,6 +12218,10 @@ try { eval(&apos;var __some_unique_variable;&apos;); __some_unique_variable; } c
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes<a href="#hermes-eval-lexical-scope-success-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="hermes0_8_1">Yes<a href="#hermes-eval-lexical-scope-success-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="hermes0_9_0">Yes<a href="#hermes-eval-lexical-scope-success-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="hermes0_10_0">Yes<a href="#hermes-eval-lexical-scope-success-note"><sup>[10]</sup></a></td>
+<td class="yes" data-browser="hermes0_11_0">Yes<a href="#hermes-eval-lexical-scope-success-note"><sup>[10]</sup></a></td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -12071,6 +12375,10 @@ try { eval(&apos;var x; delete x;&apos;); } catch (err) { return err instanceof 
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_8_1">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_9_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_10_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_11_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -12224,6 +12532,10 @@ try { delete Object.prototype; } catch (err) { return err instanceof TypeError; 
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -12377,6 +12689,10 @@ try { eval(&apos;with({}){}&apos;); } catch (err) { return err instanceof Syntax
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -12530,6 +12846,10 @@ try { eval(&apos;function f(x, x) { }&apos;); } catch (err) { return err instanc
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="no" data-browser="hermes0_7_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_8_1">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_9_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_10_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_11_0">No<a href="#hermes-eval-strict-mode-note"><sup>[8]</sup></a></td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -12683,6 +13003,10 @@ return typeof foo === &apos;function&apos;;
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
 <td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>

--- a/esintl/index.html
+++ b/esintl/index.html
@@ -243,6 +243,11 @@
 <th class="platform graalvm20_3 engine obsolete" data-browser="graalvm20_3"><a href="#graalvm20_3" class="browser-name"><abbr title="GraalVM JavaScript 20.3.0">GraalVM 20.3.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
 <th class="platform graalvm20_3_1 engine" data-browser="graalvm20_3_1"><a href="#graalvm20_3_1" class="browser-name"><abbr title="GraalVM JavaScript 20.3.1">GraalVM 20.3.1</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
 <th class="platform graalvm21 engine" data-browser="graalvm21"><a href="#graalvm21" class="browser-name"><abbr title="GraalVM JavaScript 21.0.0">GraalVM 21.0.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
+<th class="platform hermes0_7_0 engine" data-browser="hermes0_7_0"><a href="#hermes0_7_0" class="browser-name"><abbr title="Hermes 0.7.0">Hermes 0.7.0</abbr></a></th>
+<th class="platform hermes0_8_1 engine" data-browser="hermes0_8_1"><a href="#hermes0_8_1" class="browser-name"><abbr title="Hermes 0.8.1">Hermes 0.8.1</abbr></a></th>
+<th class="platform hermes0_9_0 engine" data-browser="hermes0_9_0"><a href="#hermes0_9_0" class="browser-name"><abbr title="Hermes 0.9.0">Hermes 0.9.0</abbr></a></th>
+<th class="platform hermes0_10_0 engine" data-browser="hermes0_10_0"><a href="#hermes0_10_0" class="browser-name"><abbr title="Hermes 0.10.0">Hermes 0.10.0</abbr></a></th>
+<th class="platform hermes0_11_0 engine" data-browser="hermes0_11_0"><a href="#hermes0_11_0" class="browser-name"><abbr title="Hermes 0.11.0">Hermes 0.11.0</abbr></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios10_3 mobile obsolete" data-browser="ios10_3"><a href="#ios10_3" class="browser-name"><abbr title="iOS Safari">iOS &gt;=10.3 &lt;11</abbr></a></th>
@@ -381,6 +386,11 @@
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">2/2</td>
@@ -518,6 +528,11 @@ return typeof Intl === &apos;object&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -655,6 +670,11 @@ return Intl.constructor === Object;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -789,6 +809,11 @@ return Intl.constructor === Object;
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">5/5</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">5/5</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">5/5</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/5</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/5</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/5</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/5</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
@@ -926,6 +951,11 @@ return typeof Intl.Collator === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1063,6 +1093,11 @@ return new Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1200,6 +1235,11 @@ return Intl.Collator() instanceof Intl.Collator;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1359,6 +1399,11 @@ try {
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1513,6 +1558,11 @@ try {
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1647,6 +1697,11 @@ try {
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">1/1</td>
@@ -1784,6 +1839,11 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1918,6 +1978,11 @@ return typeof Intl.Collator().compare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">1/1</td>
@@ -2055,6 +2120,11 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2189,6 +2259,11 @@ return typeof Intl.Collator().resolvedOptions === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">6/6</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">6/6</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">6/6</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/6</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/6</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/6</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/6</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0.8333333333333334" style="background-color:hsl(100,49%,50%)">5/6</td>
@@ -2326,6 +2401,11 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2463,6 +2543,11 @@ return typeof Intl.NumberFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="unknown" data-browser="hermes0_8_1">?</td>
+<td class="unknown" data-browser="hermes0_9_0">?</td>
+<td class="unknown" data-browser="hermes0_10_0">?</td>
+<td class="unknown" data-browser="hermes0_11_0">?</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2600,6 +2685,11 @@ return new Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2737,6 +2827,11 @@ return Intl.NumberFormat() instanceof Intl.NumberFormat;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -2896,6 +2991,11 @@ try {
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3050,6 +3150,11 @@ try {
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3184,6 +3289,11 @@ try {
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">7/7</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">7/7</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">7/7</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/7</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/7</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/7</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/7</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0.8571428571428571" style="background-color:hsl(102,48%,50%)">6/7</td>
@@ -3321,6 +3431,11 @@ return typeof Intl.DateTimeFormat === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3458,6 +3573,11 @@ return new Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3595,6 +3715,11 @@ return Intl.DateTimeFormat() instanceof Intl.DateTimeFormat;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3754,6 +3879,11 @@ try {
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -3908,6 +4038,11 @@ try {
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4046,6 +4181,11 @@ return tz !== void undefined &amp;&amp; tz.length &gt; 0;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -4191,6 +4331,11 @@ try {
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -4325,6 +4470,11 @@ try {
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">1/1</td>
@@ -4462,6 +4612,11 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -4596,6 +4751,11 @@ return typeof String.prototype.localeCompare === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">1/1</td>
@@ -4733,6 +4893,11 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -4867,6 +5032,11 @@ return typeof Number.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">1/1</td>
@@ -5004,6 +5174,11 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5138,6 +5313,11 @@ return typeof Array.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">1/1</td>
@@ -5275,6 +5455,11 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5409,6 +5594,11 @@ return typeof Object.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">1/1</td>
@@ -5546,6 +5736,11 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5680,6 +5875,11 @@ return typeof Date.prototype.toLocaleString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">1/1</td>
@@ -5817,6 +6017,11 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -5951,6 +6156,11 @@ return typeof Date.prototype.toLocaleDateString === &apos;function&apos;;
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">1/1</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">1/1</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">1/1</td>
@@ -6088,6 +6298,11 @@ return typeof Date.prototype.toLocaleTimeString === &apos;function&apos;;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -256,6 +256,11 @@
 <th class="platform graalvm20_3 engine obsolete" data-browser="graalvm20_3"><a href="#graalvm20_3" class="browser-name"><abbr title="GraalVM JavaScript 20.3.0">GraalVM 20.3.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
 <th class="platform graalvm20_3_1 engine" data-browser="graalvm20_3_1"><a href="#graalvm20_3_1" class="browser-name"><abbr title="GraalVM JavaScript 20.3.1">GraalVM 20.3.1</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
 <th class="platform graalvm21 engine" data-browser="graalvm21"><a href="#graalvm21" class="browser-name"><abbr title="GraalVM JavaScript 21.0.0">GraalVM 21.0.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[3]</sup></a></th>
+<th class="platform hermes0_7_0 engine" data-browser="hermes0_7_0"><a href="#hermes0_7_0" class="browser-name"><abbr title="Hermes 0.7.0">Hermes 0.7.0</abbr></a></th>
+<th class="platform hermes0_8_1 engine" data-browser="hermes0_8_1"><a href="#hermes0_8_1" class="browser-name"><abbr title="Hermes 0.8.1">Hermes 0.8.1</abbr></a></th>
+<th class="platform hermes0_9_0 engine" data-browser="hermes0_9_0"><a href="#hermes0_9_0" class="browser-name"><abbr title="Hermes 0.9.0">Hermes 0.9.0</abbr></a></th>
+<th class="platform hermes0_10_0 engine" data-browser="hermes0_10_0"><a href="#hermes0_10_0" class="browser-name"><abbr title="Hermes 0.10.0">Hermes 0.10.0</abbr></a></th>
+<th class="platform hermes0_11_0 engine" data-browser="hermes0_11_0"><a href="#hermes0_11_0" class="browser-name"><abbr title="Hermes 0.11.0">Hermes 0.11.0</abbr></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios10_3 mobile obsolete" data-browser="ios10_3"><a href="#ios10_3" class="browser-name"><abbr title="iOS Safari">iOS &gt;=10.3 &lt;11</abbr></a></th>
@@ -283,7 +288,7 @@
       </thead>
       <tbody>
         <!-- TABLE BODY -->
-      <tr class="category"><td colspan="151"><span>Stage 3</span></td>
+      <tr class="category"><td colspan="156"><span>Stage 3</span></td>
 </tr>
 <tr significance="1"><td id="test-Realms"><span><a class="anchor" href="#test-Realms">&#xA7;</a><a href="https://github.com/tc39/proposal-realms">Realms</a></span><script data-source="
 return typeof Realm === &quot;function&quot;
@@ -418,6 +423,11 @@ return typeof Realm === &quot;function&quot;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -568,6 +578,11 @@ return typeof Realm === &quot;function&quot;
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="1">2/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="1">2/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="1">2/2</td>
@@ -727,6 +742,11 @@ return RegExp.lastMatch === 'x';
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -888,6 +908,11 @@ return true;
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -1045,6 +1070,11 @@ try {
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -1195,6 +1225,11 @@ try {
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/2</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/2</td>
@@ -1349,6 +1384,11 @@ return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1503,6 +1543,11 @@ return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1526,7 +1571,7 @@ return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
 <td class="no" data-browser="opera_mobile67">No</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
 </tr>
-<tr class="category"><td colspan="151"><span>Stage 2</span></td>
+<tr class="category"><td colspan="156"><span>Stage 2</span></td>
 </tr>
 <tr significance="0.25"><td id="test-Generator_function.sent_Meta_Property"><span><a class="anchor" href="#test-Generator_function.sent_Meta_Property">&#xA7;</a><a href="https://github.com/tc39/proposal-function.sent">Generator function.sent Meta Property</a></span><script data-source="
 var result;
@@ -1664,6 +1709,11 @@ return result === &apos;tromple&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1814,6 +1864,11 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/1</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0">0/1</td>
 <td class="tally" data-browser="graalvm21" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/1</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/1</td>
@@ -1975,6 +2030,11 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2125,6 +2185,11 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/4</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="graalvm21" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/4</td>
@@ -2284,6 +2349,11 @@ try {
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2447,6 +2517,11 @@ try {
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2605,6 +2680,11 @@ try {
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2763,6 +2843,11 @@ try {
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2913,6 +2998,11 @@ try {
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="0" data-flagged-tally="0.14285714285714285">0/7</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0" data-flagged-tally="0.14285714285714285">0/7</td>
 <td class="tally" data-browser="graalvm21" data-tally="0" data-flagged-tally="0.14285714285714285">0/7</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/7</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/7</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/7</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/7</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/7</td>
@@ -3069,6 +3159,11 @@ return set.size === 2
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3226,6 +3321,11 @@ return set.size === 3
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3382,6 +3482,11 @@ return set.size === 2
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3538,6 +3643,11 @@ return set.size === 2
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3691,6 +3801,11 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no flagged obsolete" data-browser="graalvm20_3">Flag<a href="#graalvm-es2021-note"><sup>[8]</sup></a></td>
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-es2021-note"><sup>[8]</sup></a></td>
 <td class="no flagged" data-browser="graalvm21">Flag<a href="#graalvm-es2021-note"><sup>[8]</sup></a></td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3844,6 +3959,11 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3997,6 +4117,11 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4147,6 +4272,11 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/2</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/2</td>
@@ -4303,6 +4433,11 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4459,6 +4594,11 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4609,6 +4749,11 @@ return buffer1.byteLength === 0
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/2</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0">0/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/2</td>
@@ -4765,6 +4910,11 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4922,6 +5072,11 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5076,6 +5231,11 @@ return !Array.isTemplateObject([])
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5226,6 +5386,11 @@ return !Array.isTemplateObject([])
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/35</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0">0/35</td>
 <td class="tally" data-browser="graalvm21" data-tally="0">0/35</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/35</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/35</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/35</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/35</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/35</td>
@@ -5379,6 +5544,11 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5534,6 +5704,11 @@ return instance[Symbol.iterator]() === instance;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5690,6 +5865,11 @@ return &apos;next&apos; in iterator
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5851,6 +6031,11 @@ return &apos;next&apos; in iterator
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6004,6 +6189,11 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6157,6 +6347,11 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6310,6 +6505,11 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6463,6 +6663,11 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6616,6 +6821,11 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6769,6 +6979,11 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6924,6 +7139,11 @@ return result === &apos;123&apos;;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -7077,6 +7297,11 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -7230,6 +7455,11 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -7383,6 +7613,11 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -7536,6 +7771,11 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -7690,6 +7930,11 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -7843,6 +8088,11 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -7996,6 +8246,11 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -8151,6 +8406,11 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -8316,6 +8576,11 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -8481,6 +8746,11 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -8646,6 +8916,11 @@ toArray(iterator).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -8807,6 +9082,11 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -8968,6 +9248,11 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -9123,6 +9408,11 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -9284,6 +9574,11 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -9439,6 +9734,11 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -9600,6 +9900,11 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -9756,6 +10061,11 @@ let result = &apos;&apos;;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -9917,6 +10227,11 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -10072,6 +10387,11 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -10227,6 +10547,11 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -10388,6 +10713,11 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -10543,6 +10873,11 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -10696,6 +11031,11 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
 <td class="unknown" data-browser="graalvm21">?</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>

--- a/non-standard/index.html
+++ b/non-standard/index.html
@@ -229,6 +229,11 @@
 <th class="platform graalvm20_3 engine obsolete" data-browser="graalvm20_3"><a href="#graalvm20_3" class="browser-name"><abbr title="GraalVM JavaScript 20.3.0">GraalVM 20.3.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[4]</sup></a></th>
 <th class="platform graalvm20_3_1 engine" data-browser="graalvm20_3_1"><a href="#graalvm20_3_1" class="browser-name"><abbr title="GraalVM JavaScript 20.3.1">GraalVM 20.3.1</abbr></a><a href="#graalvm-node-mode-note"><sup>[4]</sup></a></th>
 <th class="platform graalvm21 engine" data-browser="graalvm21"><a href="#graalvm21" class="browser-name"><abbr title="GraalVM JavaScript 21.0.0">GraalVM 21.0.0</abbr></a><a href="#graalvm-node-mode-note"><sup>[4]</sup></a></th>
+<th class="platform hermes0_7_0 engine" data-browser="hermes0_7_0"><a href="#hermes0_7_0" class="browser-name"><abbr title="Hermes 0.7.0">Hermes 0.7.0</abbr></a></th>
+<th class="platform hermes0_8_1 engine" data-browser="hermes0_8_1"><a href="#hermes0_8_1" class="browser-name"><abbr title="Hermes 0.8.1">Hermes 0.8.1</abbr></a></th>
+<th class="platform hermes0_9_0 engine" data-browser="hermes0_9_0"><a href="#hermes0_9_0" class="browser-name"><abbr title="Hermes 0.9.0">Hermes 0.9.0</abbr></a></th>
+<th class="platform hermes0_10_0 engine" data-browser="hermes0_10_0"><a href="#hermes0_10_0" class="browser-name"><abbr title="Hermes 0.10.0">Hermes 0.10.0</abbr></a></th>
+<th class="platform hermes0_11_0 engine" data-browser="hermes0_11_0"><a href="#hermes0_11_0" class="browser-name"><abbr title="Hermes 0.11.0">Hermes 0.11.0</abbr></a></th>
 <th class="platform android4_4 mobile obsolete" data-browser="android4_4"><a href="#android4_4" class="browser-name"><abbr title="Android Browser 4.4 (KitKat)">AN 4.4</abbr></a></th>
 <th class="platform android4_4_3 mobile obsolete" data-browser="android4_4_3"><a href="#android4_4_3" class="browser-name"><abbr title="Android Browser 4.4.3 (KitKat)">AN 4.4.3</abbr></a></th>
 <th class="platform ios10_3 mobile obsolete" data-browser="ios10_3"><a href="#ios10_3" class="browser-name"><abbr title="iOS Safari">iOS &gt;=10.3 &lt;11</abbr></a></th>
@@ -370,6 +375,11 @@
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/57</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0">0/57</td>
 <td class="tally" data-browser="graalvm21" data-tally="0">0/57</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/57</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/57</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/57</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/57</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/57</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/57</td>
@@ -518,6 +528,11 @@ return typeof SIMD !== &apos;undefined&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -658,6 +673,11 @@ return typeof SIMD.Float32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -798,6 +818,11 @@ return typeof SIMD.Int32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -938,6 +963,11 @@ return typeof SIMD.Int16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1078,6 +1108,11 @@ return typeof SIMD.Int8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1218,6 +1253,11 @@ return typeof SIMD.Uint32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1358,6 +1398,11 @@ return typeof SIMD.Uint16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1498,6 +1543,11 @@ return typeof SIMD.Uint8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1638,6 +1688,11 @@ return typeof SIMD.Bool32x4 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1778,6 +1833,11 @@ return typeof SIMD.Bool16x8 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -1918,6 +1978,11 @@ return typeof SIMD.Bool8x16 === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2060,6 +2125,11 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2202,6 +2272,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2344,6 +2419,11 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2486,6 +2566,11 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2628,6 +2713,11 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2770,6 +2860,11 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -2912,6 +3007,11 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3054,6 +3154,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3196,6 +3301,11 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3338,6 +3448,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3480,6 +3595,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3622,6 +3742,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3764,6 +3889,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -3906,6 +4036,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4048,6 +4183,11 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4190,6 +4330,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4332,6 +4477,11 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4474,6 +4624,11 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4616,6 +4771,11 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4758,6 +4918,11 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -4900,6 +5065,11 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5042,6 +5212,11 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5184,6 +5359,11 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5326,6 +5506,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5468,6 +5653,11 @@ return simdBoolTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5610,6 +5800,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5752,6 +5947,11 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -5894,6 +6094,11 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6036,6 +6241,11 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6178,6 +6388,11 @@ return simdAllTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6320,6 +6535,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6462,6 +6682,11 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6604,6 +6829,11 @@ return simdIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6746,6 +6976,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -6888,6 +7123,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -7030,6 +7270,11 @@ return simdFloatTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -7172,6 +7417,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -7314,6 +7564,11 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -7456,6 +7711,11 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -7598,6 +7858,11 @@ return simd32bitFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -7740,6 +8005,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -7882,6 +8152,11 @@ return simdSmallIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -8024,6 +8299,11 @@ return simdFloatIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -8166,6 +8446,11 @@ return simdBoolIntTypes.every(function(type){
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -8308,6 +8593,11 @@ return [&apos;Float32x4&apos;,&apos;Int32x4&apos;,&apos;Int8x16&apos;,&apos;Uint
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -8448,6 +8738,11 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -8471,7 +8766,7 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="no" data-browser="opera_mobile67">No</td>
 <td class="no" data-browser="opera_mobile68">No</td>
 </tr>
-<tr><th colspan="138" class="separator"></th>
+<tr><th colspan="143" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-decompilation"><span><a class="anchor" href="#test-decompilation">&#xA7;</a>decompilation</span></td>
 <td class="tally obsolete" data-browser="konq4_13" data-tally="0">0/4</td>
@@ -8587,6 +8882,11 @@ return typeof SIMD.Float32x4.fromInt32x4 === &apos;function&apos; &amp;&amp; typ
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="0">0/4</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0">0/4</td>
 <td class="tally" data-browser="graalvm21" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0">0/4</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/4</td>
@@ -8727,6 +9027,11 @@ return typeof uneval === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -8875,6 +9180,11 @@ return &apos;toSource&apos; in Object.prototype
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -9015,6 +9325,11 @@ return uneval({ toSource: function() { return &quot;pwnd!&quot; } }) === &quot;p
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -9241,6 +9556,11 @@ return true;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -9382,6 +9702,11 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -9405,7 +9730,7 @@ return eval(&quot;x&quot;, { x: 2 }) === 2;
 <td class="no" data-browser="opera_mobile67">No</td>
 <td class="no" data-browser="opera_mobile68">No</td>
 </tr>
-<tr><th colspan="138" class="separator"></th>
+<tr><th colspan="143" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-function_caller_property"><span><a class="anchor" href="#test-function_caller_property">&#xA7;</a>function &quot;caller&quot; property <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/caller" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 return &apos;caller&apos; in function(){};
@@ -9526,6 +9851,11 @@ return 'caller' in function(){};
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -9672,6 +10002,11 @@ return (function () {}).arity === 0 &&
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -9820,6 +10155,11 @@ return f(1, 'boo');
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -9962,6 +10302,11 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -9985,7 +10330,7 @@ return typeof Function.prototype.isGenerator === 'function';
 <td class="no" data-browser="opera_mobile67">No</td>
 <td class="no" data-browser="opera_mobile68">No</td>
 </tr>
-<tr><th colspan="138" class="separator"></th>
+<tr><th colspan="143" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-class_extends_null"><span><a class="anchor" href="#test-class_extends_null">&#xA7;</a><a href="https://github.com/tc39/ecma262/issues/543">class extends null</a></span><script data-source="
 class C extends null {}
@@ -10105,6 +10450,11 @@ return new C instanceof C;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -10249,6 +10599,11 @@ return typeof ({}).__count__ === 'number' &&
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -10391,6 +10746,11 @@ return typeof ({}).__parent__ !== 'undefined';
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -10543,6 +10903,11 @@ return executed;
 <td class="no flagged obsolete" data-browser="graalvm20_3">Flag<a href="#graalvm-nashorn-compat-note"><sup>[7]</sup></a></td>
 <td class="no flagged" data-browser="graalvm20_3_1">Flag<a href="#graalvm-nashorn-compat-note"><sup>[7]</sup></a></td>
 <td class="no flagged" data-browser="graalvm21">Flag<a href="#graalvm-nashorn-compat-note"><sup>[7]</sup></a></td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -10685,6 +11050,11 @@ return typeof Array.slice === 'function' && Array.slice('abc').length === 3;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -10827,6 +11197,11 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -10850,7 +11225,7 @@ return typeof String.slice === 'function' && String.slice(123, 1) === "23";
 <td class="no" data-browser="opera_mobile67">No</td>
 <td class="no" data-browser="opera_mobile68">No</td>
 </tr>
-<tr><th colspan="138" class="separator"></th>
+<tr><th colspan="143" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Array_comprehensions_(JS_1.8_style)"><span><a class="anchor" href="#test-Array_comprehensions_(JS_1.8_style)">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Predefined_Core_Objects#Array_comprehensions">Array comprehensions (JS 1.8 style)</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Array_comprehensions#Differences_to_the_older_JS1.7JS1.8_comprehensions" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="
 var obj = { 2: true, &quot;foo&quot;: true, 4: true };
@@ -10971,6 +11346,11 @@ return a instanceof Array &amp;&amp; a[0] === 4 &amp;&amp; a[1] === 8;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -11111,6 +11491,11 @@ return [for (a of [1, 2, 3]) a * a] + &apos;&apos; === &apos;1,4,9&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -11251,6 +11636,11 @@ return (function(x)x)(1) === 1;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -11391,6 +11781,11 @@ return typeof &lt;foo/&gt; === &quot;xml&quot;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -11535,6 +11930,11 @@ return str === &quot;foobarbaz&quot;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -11676,6 +12076,11 @@ return arr[1] === arr;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -11699,7 +12104,7 @@ return arr[1] === arr;
 <td class="no" data-browser="opera_mobile67">No</td>
 <td class="no" data-browser="opera_mobile68">No</td>
 </tr>
-<tr><th colspan="138" class="separator"></th>
+<tr><th colspan="143" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Iterator"><span><a class="anchor" href="#test-Iterator">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators">Iterator</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 /* global Iterator */
@@ -11850,6 +12255,11 @@ catch(e) {
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -12030,6 +12440,11 @@ catch(e) {
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -12209,6 +12624,11 @@ global.test((function () {
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="unknown" data-browser="hermes0_7_0">?</td>
+<td class="unknown" data-browser="hermes0_8_1">?</td>
+<td class="unknown" data-browser="hermes0_9_0">?</td>
+<td class="unknown" data-browser="hermes0_10_0">?</td>
+<td class="unknown" data-browser="hermes0_11_0">?</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -12351,6 +12771,11 @@ return g.next() === 4 &amp;&amp; g.next() === 8;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -12498,6 +12923,11 @@ return passed;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -12521,7 +12951,7 @@ return passed;
 <td class="no" data-browser="opera_mobile67">No</td>
 <td class="no" data-browser="opera_mobile68">No</td>
 </tr>
-<tr><th colspan="138" class="separator"></th>
+<tr><th colspan="143" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-RegExp_x_flag"><span><a class="anchor" href="#test-RegExp_x_flag">&#xA7;</a>RegExp &quot;x&quot; flag</span><script data-source="function () {
 try {
@@ -12656,6 +13086,11 @@ try {
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -12796,6 +13231,11 @@ return /\\w/(&quot;x&quot;)[0] === &quot;x&quot;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -12937,6 +13377,11 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -12960,7 +13405,7 @@ return /(?P&lt;name&gt;a)(?P=name)/.test(&quot;aa&quot;) &amp;&amp;
 <td class="no" data-browser="opera_mobile67">No</td>
 <td class="no" data-browser="opera_mobile68">No</td>
 </tr>
-<tr><th colspan="138" class="separator"></th>
+<tr><th colspan="143" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-String.prototype.quote"><span><a class="anchor" href="#test-String.prototype.quote">&#xA7;</a>String.prototype.quote <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/quote" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof String.prototype.quote === &apos;function&apos; }">test(
 function () { return typeof String.prototype.quote === 'function' }())</script></td>
@@ -13077,6 +13522,11 @@ function () { return typeof String.prototype.quote === 'function' }())</script><
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -13215,6 +13665,11 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -13238,7 +13693,7 @@ function () { return 'foofoo'.replace('foo', 'bar', 'g') === 'barbar' }())</scri
 <td class="no" data-browser="opera_mobile67">No</td>
 <td class="no" data-browser="opera_mobile68">No</td>
 </tr>
-<tr><th colspan="138" class="separator"></th>
+<tr><th colspan="143" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Date.prototype.toLocaleFormat"><span><a class="anchor" href="#test-Date.prototype.toLocaleFormat">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat">Date.prototype.toLocaleFormat</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleFormat" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Date.prototype.toLocaleFormat === &apos;function&apos; }">test(
 function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</script></td>
@@ -13355,6 +13810,11 @@ function () { return typeof Date.prototype.toLocaleFormat === 'function' }())</s
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -13503,6 +13963,11 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -13526,7 +13991,7 @@ return !brokenOnFirefox && !brokenOnIE10 && !brokenOnChrome;
 <td class="no" data-browser="opera_mobile67">No</td>
 <td class="no" data-browser="opera_mobile68">No</td>
 </tr>
-<tr><th colspan="138" class="separator"></th>
+<tr><th colspan="143" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-Object.prototype.watch"><span><a class="anchor" href="#test-Object.prototype.watch">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch">Object.prototype.watch</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () { return typeof Object.prototype.watch === &apos;function&apos; }">test(
 function () { return typeof Object.prototype.watch === 'function' }())</script></td>
@@ -13643,6 +14108,11 @@ function () { return typeof Object.prototype.watch === 'function' }())</script><
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -13781,6 +14251,11 @@ function () { return typeof Object.prototype.unwatch === 'function' }())</script
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -13919,6 +14394,11 @@ function () { return typeof Object.prototype.eval === 'function' }())</script></
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -14059,6 +14539,11 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="unknown obsolete" data-browser="ios10_3">?</td>
@@ -14082,7 +14567,7 @@ return typeof Object.observe === &apos;function&apos;;
 <td class="no" data-browser="opera_mobile67">No</td>
 <td class="no" data-browser="opera_mobile68">No</td>
 </tr>
-<tr><th colspan="138" class="separator"></th>
+<tr><th colspan="143" class="separator"></th>
 </tr>
 <tr significance="1"><td id="test-error_stack"><span><a class="anchor" href="#test-error_stack">&#xA7;</a><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack">error &quot;stack&quot;</a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack" title="MDN documentation"><img src="../mdn.png" alt="MDN (Mozilla Development Network) logo" width="15" height="13"></a>&#xA0;</span><script data-source="function () {
 try {
@@ -14211,6 +14696,11 @@ try {
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="yes obsolete" data-browser="android4_4">Yes</td>
 <td class="yes obsolete" data-browser="android4_4_3">Yes</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>
@@ -14353,6 +14843,11 @@ return 'lineNumber' in new Error();
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -14495,6 +14990,11 @@ return 'columnNumber' in new Error();
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -14637,6 +15137,11 @@ return 'fileName' in new Error();
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -14779,6 +15284,11 @@ return 'description' in new Error();
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="no obsolete" data-browser="android4_4">No</td>
 <td class="no obsolete" data-browser="android4_4_3">No</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -14802,7 +15312,7 @@ return 'description' in new Error();
 <td class="no" data-browser="opera_mobile67">No</td>
 <td class="no" data-browser="opera_mobile68">No</td>
 </tr>
-<tr><th colspan="138" class="separator"></th>
+<tr><th colspan="143" class="separator"></th>
 </tr>
 <tr class="supertest" significance="1"><td id="test-global"><span><a class="anchor" href="#test-global">&#xA7;</a>global</span></td>
 <td class="tally obsolete" data-browser="konq4_13" data-tally="0">0/2</td>
@@ -14918,6 +15428,11 @@ return 'description' in new Error();
 <td class="tally obsolete" data-browser="graalvm20_3" data-tally="0.5">1/2</td>
 <td class="tally" data-browser="graalvm20_3_1" data-tally="0.5">1/2</td>
 <td class="tally" data-browser="graalvm21" data-tally="0.5">1/2</td>
+<td class="tally" data-browser="hermes0_7_0" data-tally="0.5">1/2</td>
+<td class="tally" data-browser="hermes0_8_1" data-tally="0.5">1/2</td>
+<td class="tally" data-browser="hermes0_9_0" data-tally="0.5">1/2</td>
+<td class="tally" data-browser="hermes0_10_0" data-tally="0.5">1/2</td>
+<td class="tally" data-browser="hermes0_11_0" data-tally="0.5">1/2</td>
 <td class="tally obsolete" data-browser="android4_4" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="android4_4_3" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="ios10_3" data-tally="0">0/2</td>
@@ -15060,6 +15575,11 @@ return typeof global === &apos;object&apos; &amp;&amp; global &amp;&amp; global 
 <td class="yes obsolete" data-browser="graalvm20_3">Yes</td>
 <td class="yes" data-browser="graalvm20_3_1">Yes</td>
 <td class="yes" data-browser="graalvm21">Yes</td>
+<td class="yes" data-browser="hermes0_7_0">Yes</td>
+<td class="yes" data-browser="hermes0_8_1">Yes</td>
+<td class="yes" data-browser="hermes0_9_0">Yes</td>
+<td class="yes" data-browser="hermes0_10_0">Yes</td>
+<td class="yes" data-browser="hermes0_11_0">Yes</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -15207,6 +15727,11 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="no obsolete" data-browser="ios10_3">No</td>
@@ -15352,6 +15877,11 @@ return Object.getOwnPropertyNames(P) + &apos;&apos; === &quot;a,a,b,b&quot;;
 <td class="no obsolete" data-browser="graalvm20_3">No</td>
 <td class="no" data-browser="graalvm20_3_1">No</td>
 <td class="no" data-browser="graalvm21">No</td>
+<td class="no" data-browser="hermes0_7_0">No</td>
+<td class="no" data-browser="hermes0_8_1">No</td>
+<td class="no" data-browser="hermes0_9_0">No</td>
+<td class="no" data-browser="hermes0_10_0">No</td>
+<td class="no" data-browser="hermes0_11_0">No</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
 <td class="yes obsolete" data-browser="ios10_3">Yes</td>


### PR DESCRIPTION
Adds results for [Hermes](https://hermesengine.dev/) versions:

0.7.0 (already mostly present)
0.8.0
0.9.0
0.10.0
0.11.0

I'm part of the React Native team at Meta, and we're looking to give more visibility to Hermes feature support as we move towards [Hermes as default](https://reactnative.dev/blog/2021/10/26/toward-hermes-being-the-default) for React Native. Thanks for providing this platform!

(NB: In practice, because Hermes is focused on bytecode performance over syntax support, JS support in React Native is heavily augmented by Babel - I'm planning to follow up this PR with the addition of "React Native" as a runtime from RN 0.68 - effectively this will be Hermes + RN's bundled Babel preset)

Preview: https://robhogan.github.io/compat-table/es6/#hermes0_11_0

CC @neildhar

(Currently in draft to give the Hermes team a chance to review footnotes, etc.)