### PR TITLE
Add an 'updateResult' utility function to upsert values into `data-*` files

### DIFF
--- a/duktape.js
+++ b/duktape.js
@@ -106,7 +106,7 @@ function runTest(parents, test, sublevel) {
             if (expect === success) {
                 // Matches.
             } else {
-                updateResult(parents[0], parents.slice(1).concat([test.name]), dukKey, success ? 'true' : 'false');
+                updateResult(parents[0], parents.slice(1).concat(test.name), dukKey, success ? 'true' : 'false');
                 testOutOfDate++;
                 console.log(testPath + ': test result added or updated, previously: ' + expect + ', new: ' + success);
             }

--- a/duktape.js
+++ b/duktape.js
@@ -1,7 +1,7 @@
 /*
  *  Node.js test runner for running data-*.js tests with Duktape 'duk' command.
  *
- *  Reports discrepancies to console; fix them manually in data-*.js files.
+ *  Reports discrepancies to console and updates them automatically in data-*.js files.
  *  Expects a './duk' command in the current directory.  Example:
  *
  *    $ cp /path/to/duk ./duk
@@ -10,6 +10,7 @@
 
 var fs = require('fs');
 var child_process = require('child_process');
+var updateResult = require("./update-result");
 
 var testCount = 0;
 var testSuccess = 0;
@@ -104,12 +105,10 @@ function runTest(parents, test, sublevel) {
 
             if (expect === success) {
                 // Matches.
-            } else if (expect === void 0 && !success) {
-                testOutOfDate++;
-                console.log(testPath + ': test result missing, res: ' + expect + ', actual: ' + success);
             } else {
+                updateResult(parents[0], parents.slice(1).concat([test.name]), dukKey, success ? 'true' : 'false');
                 testOutOfDate++;
-                console.log(testPath + ': test result out of date, res: ' + expect + ', actual: ' + success);
+                console.log(testPath + ': test result added or updated, previously: ' + expect + ', new: ' + success);
             }
         } else {
             testOutOfDate++;

--- a/hermes.js
+++ b/hermes.js
@@ -289,7 +289,7 @@ function runTest(parents, test, sublevel) {
                 if (expect === success) {
                     // Matches.
                 } else {
-                    updateResult(parents[0], parents.slice(1).concat([test.name]), hermesKey, success ? 'true' : 'false');
+                    updateResult(parents[0], parents.slice(1).concat(test.name), hermesKey, success ? 'true' : 'false');
                     testOutOfDate++;
                     console.log(testPath + ': test result added or updated, previously: ' + expect + ', new: ' + success);
                 }
@@ -309,7 +309,7 @@ function runTest(parents, test, sublevel) {
     }
 
     if (test.subtests) {
-        test.subtests.forEach(function (v) { runTest(parents.concat([test.name]), v, sublevel + 1); });
+        test.subtests.forEach(function (v) { runTest(parents.concat(test.name), v, sublevel + 1); });
     }
 }
 

--- a/hermes.js
+++ b/hermes.js
@@ -1,7 +1,7 @@
 /*
  *  Node.js test runner for running data-*.js tests with Hermes 'hermes' command.
  *
- *  Reports discrepancies to console; fix them manually in data-*.js files.
+ *  Reports discrepancies to console and updates them automatically in data-*.js files.
  *  Expects 'hermes' to be already built.  Example:
  *
  *  $ node hermes.js --hermes-bin /path/to/hermes --suite suitename
@@ -12,6 +12,7 @@
 var fs = require('fs');
 var child_process = require('child_process');
 var console = require('console');
+var updateResult = require('./update-result');
 
 var argv = require('yargs/yargs')(process.argv.slice(2))
     .option('hermes-bin', {
@@ -21,7 +22,7 @@ var argv = require('yargs/yargs')(process.argv.slice(2))
     .option('suite', {
         alias: 's',
         type: 'string',
-        choices: ['all', 'es5', 'es6', 'es2016plus'],
+        choices: ['all', 'es5', 'es6', 'es2016plus', 'esnext'],
         default: 'all'
     })
     .option('test-name', {
@@ -61,7 +62,7 @@ var hermesKey = (function () {
         encoding: 'utf-8'
     });
 
-    var m = /Hermes release version:\s+(\d)\.(\d)(?:\.(\d))?/.exec(stdout);
+    var m = /Hermes release version:\s+(\d+)\.(\d+)(?:\.(\d+))?/.exec(stdout);
     if (m) {
         return 'hermes' + m[1] + '_' + m[2] + (m[3] ? '_' + m[3] : '');
     }
@@ -78,7 +79,7 @@ var hermesKeyList = (function () {
             continue;
         }
         res.push(k);
-        if (k === hermesKey) {
+        if (k === hermesKey) {
             // Include versions up to 'hermesKey' but not newer.
             break;
         }
@@ -287,13 +288,10 @@ function runTest(parents, test, sublevel) {
 
                 if (expect === success) {
                     // Matches.
-                } else if (expect === void 0 && !success) {
-                    testOutOfDate++;
-                    console.log(testPath + ': test result missing, res: ' + expect + ', actual: ' + success);
-                    // if (testFailure >= 2) throw new Error(testCount)
                 } else {
+                    updateResult(parents[0], parents.slice(1).concat([test.name]), hermesKey, success ? 'true' : 'false');
                     testOutOfDate++;
-                    console.log(testPath + ': test result out of date, res: ' + expect + ', actual: ' + success);
+                    console.log(testPath + ': test result added or updated, previously: ' + expect + ', new: ' + success);
                 }
 
                 // if (test.name === 'repeated parameter names is a SyntaxError') {
@@ -311,9 +309,7 @@ function runTest(parents, test, sublevel) {
     }
 
     if (test.subtests) {
-        var newParents = parents.slice(0);
-        newParents.push(test.name);
-        test.subtests.forEach(function (v) { runTest(newParents, v, sublevel + 1); });
+        test.subtests.forEach(function (v) { runTest(parents.concat([test.name]), v, sublevel + 1); });
     }
 }
 

--- a/jerryscript.js
+++ b/jerryscript.js
@@ -1,7 +1,7 @@
 /*
  *  Node.js test runner for running data-*.js tests with JerryScript 'jerry' command.
  *
- *  Reports discrepancies to console; fix them manually in data-*.js files.
+ *  Reports discrepancies to console and updates them automatically in data-*.js files.
  *  Expects 'jerry' to be already built.  Example:
  *
  *    $ node jerryscript.js /path/to/jerry [suitename]
@@ -10,6 +10,7 @@
 var fs = require('fs');
 var child_process = require('child_process');
 var console = require('console');
+var updateResult = require("./update-result");
 
 var testCount = 0;
 var testSuccess = 0;
@@ -197,12 +198,10 @@ function runTest(parents, test, sublevel) {
 
             if (expect === success) {
                 // Matches.
-            } else if (expect === void 0 && !success) {
-                testOutOfDate++;
-                console.log(testPath + ': test result missing, res: ' + expect + ', actual: ' + success);
             } else {
+                updateResult(parents[0], parents.slice(1).concat([test.name]), jerryKey, success ? 'true' : 'false');
                 testOutOfDate++;
-                console.log(testPath + ': test result out of date, res: ' + expect + ', actual: ' + success);
+                console.log(testPath + ': test result added or updated, previously: ' + expect + ', new: ' + success);
             }
         } else {
             testOutOfDate++;

--- a/jerryscript.js
+++ b/jerryscript.js
@@ -199,7 +199,7 @@ function runTest(parents, test, sublevel) {
             if (expect === success) {
                 // Matches.
             } else {
-                updateResult(parents[0], parents.slice(1).concat([test.name]), jerryKey, success ? 'true' : 'false');
+                updateResult(parents[0], parents.slice(1).concat(test.name), jerryKey, success ? 'true' : 'false');
                 testOutOfDate++;
                 console.log(testPath + ': test result added or updated, previously: ' + expect + ', new: ' + success);
             }

--- a/nashorn.js
+++ b/nashorn.js
@@ -118,7 +118,7 @@ function runTest(parents, test, sublevel) {
             if (expect === success) {
                 // Matches.
             } else {
-                updateResult(parents[0], parents.slice(1).concat([test.name]), 'nashorn' + jjsKey, success ? 'true' : 'false');
+                updateResult(parents[0], parents.slice(1).concat(test.name), 'nashorn' + jjsKey, success ? 'true' : 'false');
                 testOutOfDate++;
                 console.log(testPath + ': test result added or updated, previously: ' + expect + ', new: ' + success);
             }

--- a/nashorn.js
+++ b/nashorn.js
@@ -5,7 +5,7 @@
  *  If the environment variable JAVA_HOME is defined it will use it to
  *  construct the path to 'jjs' as $JAVA_HOME/bin/jjs
  *
- *  Reports discrepancies to console; fix them manually in data-*.js files.
+ *  Reports discrepancies to console and updates them automatically in data-*.js files.
  *  Expects a 'jjs' command in the path.  Example:
  *
  *    $ node nashorn.js
@@ -14,6 +14,7 @@
 var fs = require('fs');
 var path = require('path');
 var child_process = require('child_process');
+var updateResult = require("./update-result");
 
 var testCount = 0;
 var testSuccess = 0;
@@ -116,12 +117,10 @@ function runTest(parents, test, sublevel) {
 
             if (expect === success) {
                 // Matches.
-            } else if (expect === void 0 && !success) {
-                testOutOfDate++;
-                console.log(testPath + ': test result missing, res: ' + expect + ', actual: ' + success);
             } else {
+                updateResult(parents[0], parents.slice(1).concat([test.name]), 'nashorn' + jjsKey, success ? 'true' : 'false');
                 testOutOfDate++;
-                console.log(testPath + ': test result out of date, res: ' + expect + ', actual: ' + success);
+                console.log(testPath + ': test result added or updated, previously: ' + expect + ', new: ' + success);
             }
         } else {
             testOutOfDate++;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "private": true,
   "dependencies": {
     "@babel/standalone": "latest",
+    "acorn": "8.7.1",
     "chalk": "^1.1.3",
     "cheerio": "^0.20.0",
     "core-js-bundle": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "dependencies": {
     "@babel/standalone": "latest",
-    "acorn": "8.7.1",
+    "acorn": "^8.7.1",
     "chalk": "^1.1.3",
     "cheerio": "^0.20.0",
     "core-js-bundle": "^3.0.0",

--- a/rhino.js
+++ b/rhino.js
@@ -5,7 +5,7 @@
  *  If the environment variable JAVA_HOME is defined it will use it to
  *  construct the path to 'java' as $JAVA_HOME/bin/java
  *
- *  Reports discrepancies to console; fix them manually in data-*.js files.
+ *  Reports discrepancies to console and updates them automatically in data-*.js files.
  *  Expects a 'rhino.jar' file in this directory.  Example:
  *
  *    $ node rhino.js
@@ -14,6 +14,7 @@
 var fs = require('fs');
 var path = require('path');
 var child_process = require('child_process');
+var updateResult = require("./update-result");
 
 var testCount = 0;
 var testSuccess = 0;
@@ -119,12 +120,10 @@ function runTest(parents, test, sublevel) {
 
             if (expect === success) {
                 // Matches.
-            } else if (expect === void 0 && !success) {
-                testOutOfDate++;
-                console.log(testPath + ': test result missing, res: ' + expect + ', actual: ' + success);
             } else {
+                updateResult(parents[0], parents.slice(1).concat([test.name]), 'rhino' + rhinoKey, success ? 'true' : 'false');
                 testOutOfDate++;
-                console.log(testPath + ': test result out of date, res: ' + expect + ', actual: ' + success);
+                console.log(testPath + ': test result added or updated, previously: ' + expect + ', new: ' + success);
             }
         } else {
             testOutOfDate++;

--- a/rhino.js
+++ b/rhino.js
@@ -121,7 +121,7 @@ function runTest(parents, test, sublevel) {
             if (expect === success) {
                 // Matches.
             } else {
-                updateResult(parents[0], parents.slice(1).concat([test.name]), 'rhino' + rhinoKey, success ? 'true' : 'false');
+                updateResult(parents[0], parents.slice(1).concat(test.name), 'rhino' + rhinoKey, success ? 'true' : 'false');
                 testOutOfDate++;
                 console.log(testPath + ': test result added or updated, previously: ' + expect + ', new: ' + success);
             }

--- a/update-result.js
+++ b/update-result.js
@@ -76,9 +76,9 @@ function updateResult(suite, testPath, resultKey, result) {
   );
   fs.writeFileSync(
     suiteFile,
-    srcString.substring(0, resNode.start) +
+    srcString.slice(0, resNode.start) +
       newRawResString +
-      srcString.substring(resNode.end)
+      srcString.slice(resNode.end)
   );
 }
 
@@ -93,18 +93,18 @@ function generateNewRawResString(
   var existingValue = maybeGetPropertyValue(resNode, resultKey);
   if (existingValue) {
     newResRaw =
-      srcString.substring(resNode.start, existingValue.start) +
+      srcString.slice(resNode.start, existingValue.start) +
       result +
-      srcString.substring(existingValue.end, resNode.end);
+      srcString.slice(existingValue.end, resNode.end);
   } else {
-    var indent = new Array(indentLength).fill(" ").join("");
+    var indent = " ".repeat(indentLength);
     if (resNode.properties.length === 0) {
       newResRaw =
         "{\n" + indent + "  " + resultKey + ": " + result + "\n" + indent + "}";
     } else {
       var lastProperty = resNode.properties[resNode.properties.length - 1];
       newResRaw =
-        srcString.substring(resNode.start, lastProperty.end) +
+        srcString.slice(resNode.start, lastProperty.end) +
         ",\n" +
         indent +
         "  " +

--- a/update-result.js
+++ b/update-result.js
@@ -22,7 +22,6 @@ function updateResult(suite, testPath, resultKey, result) {
   var testNodes = parseSourceForRootTestNodes(srcString);
   var testNode;
   var testNameNode;
-  var readableTestPath = [];
   for (var i = 0; i < testPath.length; i++) {
     if (!testNodes || testNodes.type !== "ArrayExpression") {
       throw new Error(
@@ -48,15 +47,12 @@ function updateResult(suite, testPath, resultKey, result) {
       );
     }
     testNameNode = maybeGetPropertyValue(testNode, "name");
-    readableTestPath.push(
-      testNameNode ? testNameNode.value : ["MISSING TEST NAME"]
-    );
     testNodes = maybeGetPropertyValue(testNode, "subtests");
   }
   var resNode = maybeGetPropertyValue(testNode, "res");
   if (!resNode) {
     throw new Error(
-      'Missing "res" property on "' + readableTestPath.join('" / "') + '"'
+      'Missing "res" property on "' + testPath.join('" / "') + '"'
     );
   }
 

--- a/update-result.js
+++ b/update-result.js
@@ -1,0 +1,161 @@
+"use strict";
+
+var fs = require("fs");
+var path = require("path");
+var acorn = require("acorn");
+
+/**
+ * Parses a `data-` file, updates/inserts a new value eg "resultKey: result" into the named test's `res` property,
+ * and saves the file in place, ready to be reviewed and committed.
+ *
+ * Usage:
+ * updateResult("es5", ["Root test name", "Subtest name"], "graalvm19", "true");
+ *
+ * @param {string} suite Suite name corresponding to results in ./data-{suite}.js
+ * @param {string[]} testPath Array of test names, from top-level to the test to update
+ * @param {string} resultKey Key for the engine/runtime under test. Alphanumeric + underscores
+ * @param {string} result The *raw* string to insert as the value - eg for a fail, use 'false'
+ */
+function updateResult(suite, testPath, resultKey, result) {
+  var suiteFile = path.join(__dirname, "data-" + suite + ".js");
+  var srcString = fs.readFileSync(suiteFile, "utf8");
+  var testNodes = parseSourceForRootTestNodes(srcString);
+  var testNode;
+  var testNameNode;
+  var readableTestPath = [];
+  for (var i = 0; i < testPath.length; i++) {
+    if (!testNodes || testNodes.type !== "ArrayExpression") {
+      throw new Error(
+        "Expected subtests at " +
+          suite +
+          ', test "' +
+          testPath.slice(0, i + 1).join('" / "') +
+          '"'
+      );
+    }
+    testNode = testNodes.elements.find(function (testNode) {
+      return getTestName(testNode) === testPath[i];
+    });
+    if (!testNode) {
+      throw new Error(
+        'No subtest with name "' +
+          testPath[i] +
+          '" in ' +
+          suite +
+          ', test "' +
+          testPath.slice(0, i + 1).join('" / "') +
+          '"'
+      );
+    }
+    testNameNode = maybeGetPropertyValue(testNode, "name");
+    readableTestPath.push(
+      testNameNode ? testNameNode.value : ["MISSING TEST NAME"]
+    );
+    testNodes = maybeGetPropertyValue(testNode, "subtests");
+  }
+  var resNode = maybeGetPropertyValue(testNode, "res");
+  if (!resNode) {
+    throw new Error(
+      'Missing "res" property on "' + readableTestPath.join('" / "') + '"'
+    );
+  }
+
+  // Determine the indentation of the line the object begins (ie, left of "{")
+  var startOfLine = srcString.lastIndexOf("\n", resNode.start) + 1;
+  var indentLength = 0;
+  while (srcString[startOfLine + indentLength] === " ") {
+    indentLength++;
+  }
+
+  var newRawResString = generateNewRawResString(
+    srcString,
+    indentLength,
+    resNode,
+    resultKey,
+    result
+  );
+  fs.writeFileSync(
+    suiteFile,
+    srcString.substring(0, resNode.start) +
+      newRawResString +
+      srcString.substring(resNode.end)
+  );
+}
+
+function generateNewRawResString(
+  srcString,
+  indentLength,
+  resNode,
+  resultKey,
+  result
+) {
+  var newResRaw;
+  var existingValue = maybeGetPropertyValue(resNode, resultKey);
+  if (existingValue) {
+    newResRaw =
+      srcString.substring(resNode.start, existingValue.start) +
+      result +
+      srcString.substring(existingValue.end, resNode.end);
+  } else {
+    var indent = new Array(indentLength).fill(" ").join("");
+    if (resNode.properties.length === 0) {
+      newResRaw =
+        "{\n" + indent + "  " + resultKey + ": " + result + "\n" + indent + "}";
+    } else {
+      var lastProperty = resNode.properties[resNode.properties.length - 1];
+      newResRaw =
+        srcString.substring(resNode.start, lastProperty.end) +
+        ",\n" +
+        indent +
+        "  " +
+        resultKey +
+        ": " +
+        result +
+        "\n" +
+        indent +
+        "}";
+    }
+  }
+  return newResRaw;
+}
+
+function parseSourceForRootTestNodes(srcString) {
+  var bodyNodes = acorn.parse(srcString, { ecmaVersion: "2015" }).body;
+  var testsArrayNode = bodyNodes.find(function (bodyNode) {
+    return (
+      bodyNode.type === "ExpressionStatement" &&
+      bodyNode.expression.type === "AssignmentExpression" &&
+      bodyNode.expression.left.type === "MemberExpression" &&
+      bodyNode.expression.left.object.type === "Identifier" &&
+      bodyNode.expression.left.object.name === "exports" &&
+      bodyNode.expression.left.property.type === "Identifier" &&
+      bodyNode.expression.left.property.name === "tests" &&
+      bodyNode.expression.right.type === "ArrayExpression"
+    );
+  });
+
+  if (!testsArrayNode) {
+    throw new Error(
+      "Could not find exported tests in input file. Expected an assignment of the form export.tests = []"
+    );
+  }
+
+  return testsArrayNode.expression.right;
+}
+
+function maybeGetPropertyValue(node, propertyName) {
+  var property = node.properties.find(function (propertyNode) {
+    return propertyNode.key.name === propertyName;
+  });
+  if (!property || !property.value) {
+    return null;
+  }
+  return property.value;
+}
+
+function getTestName(testNode) {
+  var nameNode = maybeGetPropertyValue(testNode, "name");
+  return nameNode ? nameNode.value : null;
+}
+
+module.exports = updateResult;

--- a/update-result.js
+++ b/update-result.js
@@ -21,7 +21,6 @@ function updateResult(suite, testPath, resultKey, result) {
   var srcString = fs.readFileSync(suiteFile, "utf8");
   var testNodes = parseSourceForRootTestNodes(srcString);
   var testNode;
-  var testNameNode;
   for (var i = 0; i < testPath.length; i++) {
     if (!testNodes || testNodes.type !== "ArrayExpression") {
       throw new Error(
@@ -46,7 +45,6 @@ function updateResult(suite, testPath, resultKey, result) {
           '"'
       );
     }
-    testNameNode = maybeGetPropertyValue(testNode, "name");
     testNodes = maybeGetPropertyValue(testNode, "subtests");
   }
   var resNode = maybeGetPropertyValue(testNode, "res");


### PR DESCRIPTION
As far as I could tell, the current accepted practice to update `data-` files is to use a script to suggest the changes to a console and then to make manual updates. 

This is a lot of work for new runtimes, and doesn't lend well to automating as part of a runtime release process.

This is a simple utility to parse and update `res` objects in place. It may be called from the test runner scripts - I used it to generate https://github.com/kangax/compat-table/pull/1808.

Because it uses an actual parser it should be robust to syntax gotchas like code-in-strings, but it makes a few basic assumptions that hold for the data files as they are now, like:
 - Data files have an `exports.tests = [ /* ... */ ]` section
 - Tests must have an object-literal `res` property, or an array-literal `subtests` property.