### PR TITLE
Update Closure Compiler v20220601

### DIFF
--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -661,7 +661,7 @@ exports.tests = [
           tr: null,
           babel6corejs2: null,
           babel7corejs3: true,
-          closure: false,
+          closure: true,
           typescript1corejs2: null,
           chrome52: null,
           chrome55: true,

--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -360,6 +360,7 @@ exports.tests = [
          */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20180402: true,
           es7shim: true,
           typescript1corejs2: typescript.corejs,
@@ -1900,6 +1901,7 @@ exports.tests = [
      */},
     res: {
       babel7corejs3: true,
+      closure: false,
       closure20180319: true,
       typescript1corejs2: typescript.downlevelIteration,
       ie11: false,
@@ -3065,6 +3067,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20180402: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
@@ -3113,6 +3116,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20180402: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
@@ -3163,6 +3167,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20180402: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
@@ -3205,6 +3210,7 @@ exports.tests = [
      */},
     res: {
       babel7corejs3: true,
+      closure: false,
       closure20181008: true,
       closure20200315: false,
       closure20200517: true,
@@ -3388,6 +3394,7 @@ exports.tests = [
         */},
         res: {
           babel6corejs2: true,
+          closure: false,
           closure20180805: true,
           chrome62: chrome.harmony,
           chrome63: true,
@@ -3434,6 +3441,7 @@ exports.tests = [
         */},
         res: {
           babel6corejs2: true,
+          closure: false,
           closure20180910: true,
           chrome62: chrome.harmony,
           chrome63: true,
@@ -3476,6 +3484,7 @@ exports.tests = [
         */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20190215: true,
           typescript2_5corejs2: true,
           ie11: false,
@@ -3512,6 +3521,7 @@ exports.tests = [
         */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20190215: true,
           typescript2_5corejs2: true,
           ie11: false,
@@ -3552,6 +3562,7 @@ exports.tests = [
         */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20190215: true,
           typescript2_5corejs2: true,
           ie11: false,
@@ -3589,6 +3600,7 @@ exports.tests = [
         res : {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure: false,
           closure20190301: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
@@ -3620,6 +3632,7 @@ exports.tests = [
         res : {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure: false,
           closure20190301: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
@@ -3861,6 +3874,7 @@ exports.tests = [
           return eval("'\u2028'") === "\u2028";
         */},
         res : {
+          closure: false,
           closure20190215: true,
           babel7corejs2: true,
           ie11: false,
@@ -3888,6 +3902,7 @@ exports.tests = [
           return eval("'\u2029'") === "\u2029";
         */},
         res : {
+          closure: false,
           closure20190215: true,
           babel7corejs2: true,
           ie11: false,
@@ -3924,6 +3939,7 @@ exports.tests = [
     res: {
       babel6corejs2: false,
       babel7corejs3: babel.corejs,
+      closure: false,
       closure20190325: true,
       typescript1corejs2: typescript.fallthrough,
       typescript3_2corejs3: typescript.corejs,
@@ -3998,6 +4014,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20190709: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
@@ -4041,6 +4058,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20190709: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
@@ -4084,6 +4102,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20190325: {
             val: false,
             note_id: 'closure-string-trimstart',
@@ -4117,6 +4136,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20190325: {
             val: false,
             note_id: 'closure-string-trimend',
@@ -4165,6 +4185,7 @@ exports.tests = [
         res: {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure: false,
           closure20190301: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
@@ -4201,6 +4222,7 @@ exports.tests = [
       */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20190301: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
@@ -4280,6 +4302,7 @@ exports.tests = [
         */},
         res: {
           babel6corejs2: babel.corejs,
+          closure: false,
           closure20200101: true,
           typescript1corejs2: typescript.corejs,
           ie11: false,
@@ -4317,6 +4340,7 @@ exports.tests = [
         res: {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure: false,
           closure20200101: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
@@ -4590,6 +4614,7 @@ exports.tests = [
     res: {
       babel6corejs2: false,
       babel7corejs3: babel.corejs,
+      closure: false,
       closure20191027: true,
       typescript1corejs2: typescript.fallthrough,
       typescript3_2corejs3: typescript.corejs,
@@ -4624,6 +4649,7 @@ exports.tests = [
       res: {
         babel6corejs2: false,
         babel7corejs3: babel.corejs,
+        closure: false,
         closure20200101: true,
         typescript1corejs2: typescript.fallthrough,
         typescript3_2corejs3: typescript.corejs,
@@ -4672,6 +4698,7 @@ exports.tests = [
       res: {
         babel6corejs2: false,
         babel7corejs3: babel.corejs,
+        closure: false,
         closure20200101: true,
         typescript1corejs2: typescript.fallthrough,
         typescript3_2corejs3: typescript.corejs,
@@ -4724,6 +4751,7 @@ exports.tests = [
         */},
         res : {
           babel7corejs2: true,
+          closure: false,
           closure20200927: true,
           typescript3_7corejs3: true,
           ie11: false,
@@ -4754,6 +4782,7 @@ exports.tests = [
         */},
         res : {
           babel7corejs2: true,
+          closure: false,
           closure20200927: true,
           typescript3_7corejs3: true,
           ie11: false,
@@ -4784,6 +4813,7 @@ exports.tests = [
         */},
         res : {
           babel7corejs2: true,
+          closure: false,
           closure20200927: true,
           typescript3_7corejs3: true,
           ie11: false,
@@ -4816,6 +4846,7 @@ exports.tests = [
         */},
         res : {
           babel7corejs2: true,
+          closure: false,
           closure20200927: true,
           typescript3_7corejs3: true,
           ie11: false,
@@ -4848,6 +4879,7 @@ exports.tests = [
         */},
         res : {
           babel7corejs3: true,
+          closure: false,
           closure20200927: true,
           ie11: false,
           firefox10: false,
@@ -4917,6 +4949,7 @@ exports.tests = [
     res: {
       babel6corejs2: false,
       babel7corejs3: babel.corejs,
+      closure: false,
       closure20210808: true,
       typescript1corejs2: typescript.fallthrough,
       typescript3_2corejs3: typescript.corejs,
@@ -4964,6 +4997,7 @@ exports.tests = [
         res: {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure: false,
           closure20210808: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
@@ -4999,6 +5033,7 @@ exports.tests = [
         res: {
           babel6corejs2: false,
           babel7corejs3: babel.corejs,
+          closure: false,
           closure20210808: true,
           typescript1corejs2: typescript.fallthrough,
           typescript3_2corejs3: typescript.corejs,
@@ -5114,6 +5149,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5144,6 +5180,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5174,6 +5211,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5208,6 +5246,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5238,6 +5277,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5268,6 +5308,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5302,6 +5343,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5332,6 +5374,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5362,6 +5405,7 @@ exports.tests = [
       */},
         res: {
           babel7corejs2: true,
+          closure: false,
           closure20210808: true,
           ie11: false,
           firefox60: false,
@@ -5395,6 +5439,7 @@ exports.tests = [
     */},
     res : {
       babel7corejs2: true,
+      closure: false,
       closure20210808: true,
       typescript1corejs2: false,
       typescript2_7corejs2: true,

--- a/data-es2016plus.js
+++ b/data-es2016plus.js
@@ -5941,6 +5941,12 @@ exports.tests = [
           && arr.at(-4) === undefined;
       */},
         res: {
+          closure: false,
+          closure20220502: {
+            val: false,
+            note_id: 'closure-at-method',
+            note_html: 'Requires native support for <code>Math.trunc</code>'
+          },
           ie11: false,
           firefox68: false,
           firefox85: firefox.nightly,
@@ -5974,6 +5980,11 @@ exports.tests = [
           && str.at(-4) === undefined;
       */},
         res: {
+          closure: false,
+          closure20220502: {
+            val: false,
+            note_id: 'closure-at-method'
+          },
           ie11: false,
           firefox68: false,
           firefox85: firefox.nightly,
@@ -6022,6 +6033,12 @@ exports.tests = [
          });
       */},
         res: {
+          closure: false,
+          closure20220502: {
+            val: false,
+            note_id: 'closure-typed-array',
+            note_html: 'Requires native support for typed arrays'
+          },
           ie11: false,
           firefox68: false,
           firefox85: firefox.nightly,

--- a/data-es6.js
+++ b/data-es6.js
@@ -12941,6 +12941,7 @@ exports.tests = [
         return get + '' === "length,constructor,1,2,3,length,constructor,2,1";
       */},
       res: {
+        closure: true,
         ejs: true,
         ie11: false,
         edge13: true,

--- a/environments.json
+++ b/environments.json
@@ -277,7 +277,7 @@
     "short": "Closure 2020.03",
     "family": "Closure",
     "platformtype": "compiler",
-    "obsolete": true,
+    "obsolete": "very",
     "test_suites": [
       "es6",
       "es2016plus",
@@ -359,6 +359,18 @@
   "closure20211107": {
     "full": "Closure Compiler >=v20211107",
     "short": "Closure 2021.11",
+    "family": "Closure",
+    "platformtype": "compiler",
+    "obsolete": true,
+    "test_suites": [
+      "es6",
+      "es2016plus",
+      "esnext"
+    ]
+  },
+  "closure20220502": {
+    "full": "Closure Compiler >=v20220502",
+    "short": "Closure 2022.05",
     "family": "Closure",
     "platformtype": "compiler",
     "obsolete": false,

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -24489,8 +24489,8 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
@@ -24649,8 +24649,8 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
@@ -24809,8 +24809,8 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
@@ -24971,8 +24971,8 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
@@ -25133,8 +25133,8 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
@@ -25456,9 +25456,9 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
@@ -25775,9 +25775,9 @@ Promise.any([
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
@@ -25939,9 +25939,9 @@ Promise.any([
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
@@ -26732,9 +26732,9 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
@@ -26893,9 +26893,9 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
@@ -27054,9 +27054,9 @@ return i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
@@ -27218,9 +27218,9 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
@@ -27379,9 +27379,9 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
@@ -27540,9 +27540,9 @@ return i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
@@ -27704,9 +27704,9 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
@@ -27865,9 +27865,9 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
@@ -28026,9 +28026,9 @@ return i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
@@ -28185,9 +28185,9 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>

--- a/es2016plus/index.html
+++ b/es2016plus/index.html
@@ -128,14 +128,14 @@
 <th class="platform babel6corejs2 compiler obsolete" data-browser="babel6corejs2"><a href="#babel6corejs2" class="browser-name"><abbr title="Babel 6.5 + core-js 2.5">Babel 6 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs2 compiler obsolete" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
-<th class="platform closure20200315 compiler obsolete" data-browser="closure20200315"><a href="#closure20200315" class="browser-name"><abbr title="Closure Compiler &gt;=v20200315 &lt;v20200517">Closure 2020.03</abbr></a></th>
 <th class="platform closure20200517 compiler obsolete" data-browser="closure20200517"><a href="#closure20200517" class="browser-name"><abbr title="Closure Compiler &gt;=v20200517 &lt;v20200614">Closure 2020.05</abbr></a></th>
 <th class="platform closure20200614 compiler obsolete" data-browser="closure20200614"><a href="#closure20200614" class="browser-name"><abbr title="Closure Compiler &gt;=v20200614 &lt;v20200927">Closure 2020.06</abbr></a></th>
 <th class="platform closure20200927 compiler obsolete" data-browser="closure20200927"><a href="#closure20200927" class="browser-name"><abbr title="Closure Compiler &gt;=v20200927 &lt;v20210808">Closure 2020.09</abbr></a></th>
 <th class="platform closure20210808 compiler obsolete" data-browser="closure20210808"><a href="#closure20210808" class="browser-name"><abbr title="Closure Compiler v20210808">Closure 2021.08</abbr></a></th>
 <th class="platform closure20210906 compiler obsolete" data-browser="closure20210906"><a href="#closure20210906" class="browser-name"><abbr title="Closure Compiler v20210906">Closure 2021.09</abbr></a></th>
 <th class="platform closure20211006 compiler obsolete" data-browser="closure20211006"><a href="#closure20211006" class="browser-name"><abbr title="Closure Compiler v20211006">Closure 2021.10</abbr></a></th>
-<th class="platform closure20211107 compiler" data-browser="closure20211107"><a href="#closure20211107" class="browser-name"><abbr title="Closure Compiler &gt;=v20211107">Closure 2021.11</abbr></a></th>
+<th class="platform closure20211107 compiler obsolete" data-browser="closure20211107"><a href="#closure20211107" class="browser-name"><abbr title="Closure Compiler &gt;=v20211107">Closure 2021.11</abbr></a></th>
+<th class="platform closure20220502 compiler" data-browser="closure20220502"><a href="#closure20220502" class="browser-name"><abbr title="Closure Compiler &gt;=v20220502">Closure 2022.05</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_9corejs2 compiler obsolete" data-browser="typescript2_9corejs2"><a href="#typescript2_9corejs2" class="browser-name"><abbr title="TypeScript 2.9 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript3_2corejs2 compiler obsolete" data-browser="typescript3_2corejs2"><a href="#typescript3_2corejs2" class="browser-name"><abbr title="TypeScript 3.2 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -289,14 +289,14 @@
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20211107" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20220502" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
@@ -447,14 +447,14 @@ return 2 ** 3 === 8 &amp;&amp; -(5 ** 2) === -25 &amp;&amp; (-5) ** 2 === 25;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -605,14 +605,14 @@ var a = 2; a **= 3; return a === 8;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -768,14 +768,14 @@ return true;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -923,14 +923,14 @@ return true;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="closure20211107" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="closure20220502" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">4/4</td>
@@ -1084,14 +1084,14 @@ return [1, 2, 3].includes(1)
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1243,14 +1243,14 @@ return [,].includes()
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1423,14 +1423,14 @@ return 24;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1586,14 +1586,14 @@ return new TypedArray([1, 2, 3]).includes(1)
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -1753,14 +1753,14 @@ return true;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1924,14 +1924,14 @@ return iter[&apos;throw&apos;]().value === &apos;bar&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -2087,14 +2087,14 @@ return true;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2246,14 +2246,14 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -2406,14 +2406,14 @@ return x === 1 &amp;&amp; y === 2 &amp;&amp; z + &apos;&apos; === &apos;3,4&apos
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -2571,14 +2571,14 @@ return passed;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2738,14 +2738,14 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2895,14 +2895,14 @@ return (get + &apos;&apos; === &quot;length,1,2&quot;);
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally" data-browser="closure20211107" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
+<td class="tally" data-browser="closure20220502" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">4/4</td>
@@ -3056,14 +3056,14 @@ return Array.isArray(v) &amp;&amp; String(v) === &quot;foo,bar,baz&quot;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -3221,14 +3221,14 @@ return Array.isArray(e)
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -3387,14 +3387,14 @@ return D.a.value === 1 &amp;&amp; D.a.enumerable === true &amp;&amp; D.a.configu
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -3548,14 +3548,14 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -3703,14 +3703,14 @@ return !Object.getOwnPropertyDescriptors(P).hasOwnProperty(&apos;a&apos;);
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -3866,14 +3866,14 @@ return &apos;hello&apos;.padStart(10) === &apos;     hello&apos;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -4029,14 +4029,14 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -4184,14 +4184,14 @@ return &apos;hello&apos;.padEnd(10) === &apos;hello     &apos;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -4342,14 +4342,14 @@ return typeof function f( a, b, ){} === &apos;function&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -4500,14 +4500,14 @@ return Math.min(1,2,3,) === 1;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -4655,14 +4655,14 @@ return Math.min(1,2,3,) === 1;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">4/16</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
-<td class="tally obsolete" data-browser="closure20200517" data-tally="0.625" style="background-color:hsl(75,58%,50%)">10/16</td>
-<td class="tally obsolete" data-browser="closure20200614" data-tally="0.6875" style="background-color:hsl(82,55%,50%)">11/16</td>
-<td class="tally obsolete" data-browser="closure20200927" data-tally="0.6875" style="background-color:hsl(82,55%,50%)">11/16</td>
-<td class="tally obsolete" data-browser="closure20210808" data-tally="0.6875" style="background-color:hsl(82,55%,50%)">11/16</td>
-<td class="tally obsolete" data-browser="closure20210906" data-tally="0.6875" style="background-color:hsl(82,55%,50%)">11/16</td>
-<td class="tally obsolete" data-browser="closure20211006" data-tally="0.6875" style="background-color:hsl(82,55%,50%)">11/16</td>
-<td class="tally" data-browser="closure20211107" data-tally="0.6875" style="background-color:hsl(82,55%,50%)">11/16</td>
+<td class="tally obsolete" data-browser="closure20200517" data-tally="0.6875" style="background-color:hsl(82,55%,50%)">11/16</td>
+<td class="tally obsolete" data-browser="closure20200614" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally obsolete" data-browser="closure20200927" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally obsolete" data-browser="closure20210808" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally obsolete" data-browser="closure20210906" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally obsolete" data-browser="closure20211006" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
+<td class="tally" data-browser="closure20220502" data-tally="0.75" style="background-color:hsl(90,53%,50%)">12/16</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.5625" style="background-color:hsl(67,61%,50%)">9/16</td>
@@ -4824,14 +4824,14 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -4993,14 +4993,14 @@ p.catch(function(result) {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -5152,14 +5152,14 @@ try { Function(&quot;async\n function a(){await 0}&quot;)(); } catch(e) { return
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200315">No</td>
-<td class="no obsolete" data-browser="closure20200517">No</td>
-<td class="no obsolete" data-browser="closure20200614">No</td>
-<td class="no obsolete" data-browser="closure20200927">No</td>
-<td class="no obsolete" data-browser="closure20210808">No</td>
-<td class="no obsolete" data-browser="closure20210906">No</td>
-<td class="no obsolete" data-browser="closure20211006">No</td>
-<td class="no" data-browser="closure20211107">No</td>
+<td class="yes obsolete" data-browser="closure20200517">Yes</td>
+<td class="yes obsolete" data-browser="closure20200614">Yes</td>
+<td class="yes obsolete" data-browser="closure20200927">Yes</td>
+<td class="yes obsolete" data-browser="closure20210808">Yes</td>
+<td class="yes obsolete" data-browser="closure20210906">Yes</td>
+<td class="yes obsolete" data-browser="closure20211006">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -5311,14 +5311,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
-<td class="no" data-browser="closure20211107">No</td>
+<td class="no obsolete" data-browser="closure20211107">No</td>
+<td class="no" data-browser="closure20220502">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -5476,14 +5476,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -5643,14 +5643,14 @@ return !a.hasOwnProperty(&quot;prototype&quot;);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -5802,14 +5802,14 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -5966,14 +5966,14 @@ try { Function(&quot;(async function a(){ await; }())&quot;)(); } catch(e) { ret
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -6125,14 +6125,14 @@ try { Function(&quot;(async function a(b = await Promise.resolve()){}())&quot;)(
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -6294,14 +6294,14 @@ p.then(function(result) {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -6463,14 +6463,14 @@ p.then(function(result) {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -6632,14 +6632,14 @@ var p = new C().a();
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -6799,14 +6799,14 @@ p.then(function(result) {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-regenerator-note"><sup>[14]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-downlevel-iteration-note"><sup>[9]</sup></a></td>
@@ -6959,14 +6959,14 @@ return asyncFunctionProto !== function(){}.prototype
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
-<td class="no" data-browser="closure20211107">No</td>
+<td class="no obsolete" data-browser="closure20211107">No</td>
+<td class="no" data-browser="closure20220502">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -7117,14 +7117,14 @@ return Object.getPrototypeOf(async function (){})[Symbol.toStringTag] === &quot;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
-<td class="no" data-browser="closure20211107">No</td>
+<td class="no obsolete" data-browser="closure20211107">No</td>
+<td class="no" data-browser="closure20220502">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -7284,14 +7284,14 @@ p.then(function(result) {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
-<td class="no" data-browser="closure20211107">No</td>
+<td class="no obsolete" data-browser="closure20211107">No</td>
+<td class="no" data-browser="closure20220502">No</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="no obsolete" data-browser="typescript2_9corejs2">No</td>
 <td class="no obsolete" data-browser="typescript3_2corejs2">No</td>
@@ -7439,14 +7439,14 @@ p.then(function(result) {
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/17</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/17</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/17</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/17</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/17</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/17</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/17</td>
@@ -7597,14 +7597,14 @@ return typeof SharedArrayBuffer === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7755,14 +7755,14 @@ return SharedArrayBuffer[Symbol.species] === SharedArrayBuffer;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -7913,14 +7913,14 @@ return &apos;byteLength&apos; in SharedArrayBuffer.prototype;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8071,14 +8071,14 @@ return typeof SharedArrayBuffer.prototype.slice === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8229,14 +8229,14 @@ return SharedArrayBuffer.prototype[Symbol.toStringTag] === &apos;SharedArrayBuff
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8387,14 +8387,14 @@ return typeof Atomics.add === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8545,14 +8545,14 @@ return typeof Atomics.and === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8703,14 +8703,14 @@ return typeof Atomics.compareExchange === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -8861,14 +8861,14 @@ return typeof Atomics.exchange === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9019,14 +9019,14 @@ return typeof Atomics.wait === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9177,14 +9177,14 @@ return typeof Atomics.notify === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9335,14 +9335,14 @@ return typeof Atomics.isLockFree === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9493,14 +9493,14 @@ return typeof Atomics.load === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9651,14 +9651,14 @@ return typeof Atomics.or === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9809,14 +9809,14 @@ return typeof Atomics.store === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -9967,14 +9967,14 @@ return typeof Atomics.sub === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -10125,14 +10125,14 @@ return typeof Atomics.xor === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -10288,14 +10288,14 @@ return &quot;&#x17F;&quot;.match(/\w/iu) &amp;&amp; !&quot;&#x17F;&quot;.match(/
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -10449,14 +10449,14 @@ return (function(){
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -10606,14 +10606,14 @@ return (function(){
 <td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
-<td class="tally obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
-<td class="tally not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
+<td class="tally not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="1">16/16</td>
@@ -10769,14 +10769,14 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -10933,14 +10933,14 @@ return prop.get === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11097,14 +11097,14 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11260,14 +11260,14 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11424,14 +11424,14 @@ return prop.set === bar &amp;&amp; !prop.writable &amp;&amp; prop.configurable
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11588,14 +11588,14 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11753,14 +11753,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -11918,14 +11918,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12084,14 +12084,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12247,14 +12247,14 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12409,14 +12409,14 @@ return b.__lookupGetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12574,14 +12574,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12739,14 +12739,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -12905,14 +12905,14 @@ return foo() === &quot;bar&quot;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13068,14 +13068,14 @@ return true;
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13230,14 +13230,14 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="yes obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -13385,14 +13385,14 @@ return b.__lookupSetter__(&quot;foo&quot;) === void undefined
 <td class="tally obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
-<td class="tally not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
+<td class="tally not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
 <td class="tally obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage." data-tally="0">0/4</td>
@@ -13547,14 +13547,14 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13709,14 +13709,14 @@ return def + &apos;&apos; === &quot;foo&quot;;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -13876,14 +13876,14 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14043,14 +14043,14 @@ return gopd + &apos;&apos; === &quot;foo&quot; &amp;&amp; gpo;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14202,14 +14202,14 @@ return i === 0;
 <td class="unknown obsolete not-applicable" data-browser="babel6corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="babel7corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="yes not-applicable" data-browser="babel7corejs3" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">Yes</td>
-<td class="unknown obsolete not-applicable" data-browser="closure20200315" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200517" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200614" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20200927" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210808" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20210906" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="closure20211006" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
-<td class="unknown not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown obsolete not-applicable" data-browser="closure20211107" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
+<td class="unknown not-applicable" data-browser="closure20220502" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript1corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript2_9corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
 <td class="unknown obsolete not-applicable" data-browser="typescript3_2corejs2" title="This feature is optional on non-browser platforms, and doesn&apos;t contribute to the platform&apos;s support percentage.">?</td>
@@ -14359,14 +14359,14 @@ return i === 0;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -14518,14 +14518,14 @@ return a === 1 &amp;&amp; rest.a === void undefined &amp;&amp; rest.b === 2 &amp
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200315">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200517">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200614">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200927">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="closure20210808">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -14678,14 +14678,14 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200315">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200517">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200614">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="closure20200927">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="no obsolete" data-browser="closure20210808">No<a href="#closure-object-assign-note"><sup>[22]</sup></a></td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -14833,14 +14833,14 @@ return O !== spread &amp;&amp; (O.a + O.b + O.c) === 6;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20211107" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20220502" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
@@ -15017,14 +15017,14 @@ function check() {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -15193,14 +15193,14 @@ function check() {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -15371,14 +15371,14 @@ function check() {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -15530,14 +15530,14 @@ return regex.test(&apos;foo\nbar&apos;);
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
-<td class="no" data-browser="closure20211107">No</td>
+<td class="no obsolete" data-browser="closure20211107">No</td>
+<td class="no" data-browser="closure20220502">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -15695,14 +15695,14 @@ return result.groups.year === &apos;2016&apos;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -15854,14 +15854,14 @@ return /(?&lt;=a)b/.test(&apos;ab&apos;) &amp;&amp; /(?&lt;!a)b/.test(&apos;cb&a
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="no" data-browser="babel7corejs3">No</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16013,14 +16013,14 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16168,14 +16168,14 @@ return regexGreekSymbol.test(&apos;&#x3C0;&apos;);
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">2/2</td>
@@ -16333,14 +16333,14 @@ iterator.next().then(function(step){
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -16508,14 +16508,14 @@ asyncIterable[Symbol.asyncIterator] = function(){
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -16678,14 +16678,14 @@ return false;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -16843,14 +16843,14 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -17000,14 +17000,14 @@ return tag`\01\1\xg\xAg\u0\u0g\u00g\u000g\u{g\u{0\u{110000}${0}\0`;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20211107" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20220502" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/3</td>
@@ -17158,14 +17158,14 @@ return Symbol(&apos;foo&apos;).description === &apos;foo&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -17316,14 +17316,14 @@ return Symbol(&apos;&apos;).description === &apos;&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -17475,14 +17475,14 @@ return Symbol.prototype.hasOwnProperty(&apos;description&apos;)
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -17634,14 +17634,14 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -17789,14 +17789,14 @@ return object.foo === 42 &amp;&amp; object.bar === 23;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">4/4</td>
-<td class="tally" data-browser="closure20211107" data-tally="1">4/4</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="1">4/4</td>
+<td class="tally" data-browser="closure20220502" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">4/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">4/4</td>
@@ -17947,14 +17947,14 @@ return &apos; \t \n abc   \t\n&apos;.trimLeft() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -18105,14 +18105,14 @@ return &apos; \t \n abc   \t\n&apos;.trimRight() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -18263,14 +18263,14 @@ return &apos; \t \n abc   \t\n&apos;.trimStart() === &apos;abc   \t\n&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -18421,14 +18421,14 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -18576,14 +18576,14 @@ return &apos; \t \n abc   \t\n&apos;.trimEnd() === &apos; \t \n abc&apos;;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
-<td class="tally" data-browser="closure20211107" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
+<td class="tally" data-browser="closure20220502" data-tally="0.6666666666666666" style="background-color:hsl(80,56%,50%)">2/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.3333333333333333" style="background-color:hsl(40,71%,50%)">1/3</td>
@@ -18734,14 +18734,14 @@ return [1, [2, 3], [4, [5, 6]]].flat().join(&apos;&apos;) === &apos;12345,6&apos
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -18894,14 +18894,14 @@ return [{a: 1, b: 2}, {a: 3, b: 4}].flatMap(function (it) {
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -19053,14 +19053,14 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -19210,14 +19210,14 @@ return Array.prototype[Symbol.unscopables].flat
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">3/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">3/3</td>
-<td class="tally" data-browser="closure20211107" data-tally="1">3/3</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="1">3/3</td>
+<td class="tally" data-browser="closure20220502" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">3/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">3/3</td>
@@ -19374,14 +19374,14 @@ return false;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -19539,14 +19539,14 @@ return false;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -19708,14 +19708,14 @@ return it.throw().value;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -19863,14 +19863,14 @@ return it.throw().value;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/7</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/7</td>
@@ -20023,14 +20023,14 @@ return fn + &apos;&apos; === str;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -20182,14 +20182,14 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -20341,14 +20341,14 @@ return NATIVE_EVAL_RE.test(eval + &apos;&apos;);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -20500,14 +20500,14 @@ return eval(&apos;(&apos; + str + &apos;)&apos;) + &apos;&apos; === str;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -20659,14 +20659,14 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -20818,14 +20818,14 @@ return eval(&apos;(/\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/)&apo
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -20977,14 +20977,14 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -21132,14 +21132,14 @@ return eval(&apos;({ /\x2A before \x2A/&apos; + str + &apos;/\x2A after \x2A/ }.
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">2/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -21290,14 +21290,14 @@ return eval(&quot;&apos;\u2028&apos;&quot;) === &quot;\u2028&quot;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -21448,14 +21448,14 @@ return eval(&quot;&apos;\u2029&apos;&quot;) === &quot;\u2029&quot;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -21607,14 +21607,14 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -21764,14 +21764,14 @@ return JSON.stringify(&apos;\uDF06\uD834&apos;) === &quot;\&quot;\\udf06\\ud834\
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.5" style="background-color:hsl(60,64%,50%)">1/2</td>
@@ -21932,14 +21932,14 @@ return a === &apos;1a2b&apos;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes<a href="#typescript-core-js-note"><sup>[6]</sup></a></td>
@@ -22095,14 +22095,14 @@ try {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -22250,14 +22250,14 @@ try {
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/8</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/8</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/8</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/8</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/8</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/8</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/8</td>
@@ -22408,14 +22408,14 @@ return (1n + 2n) === 3n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -22566,14 +22566,14 @@ return BigInt(&quot;3&quot;) === 3n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -22724,14 +22724,14 @@ return typeof BigInt.asUintN === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -22882,14 +22882,14 @@ return typeof BigInt.asIntN === &apos;function&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -23043,14 +23043,14 @@ return view[0] === -0x8000000000000000n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -23204,14 +23204,14 @@ return view[0] === 0n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -23365,14 +23365,14 @@ return view.getBigInt64(0) === 1n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -23526,14 +23526,14 @@ return view.getBigUint64(0) === 1n;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -23695,14 +23695,14 @@ Promise.allSettled([
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -23850,14 +23850,14 @@ Promise.allSettled([
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -24010,14 +24010,14 @@ return typeof globalThis === &apos;object&apos; &amp;&amp; globalThis &amp;&amp;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -24174,14 +24174,14 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -24329,14 +24329,14 @@ return descriptor.value === actualGlobal &amp;&amp; !descriptor.enumerable &amp;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.8" style="background-color:hsl(96,50%,50%)">4/5</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">5/5</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">5/5</td>
-<td class="tally" data-browser="closure20211107" data-tally="1">5/5</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="1">5/5</td>
+<td class="tally" data-browser="closure20220502" data-tally="1">5/5</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/5</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/5</td>
@@ -24489,14 +24489,14 @@ return foo?.baz === 42 &amp;&amp; bar?.baz === void undefined;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24649,14 +24649,14 @@ return foo?.[&apos;baz&apos;] === 42 &amp;&amp; bar?.[&apos;baz&apos;] === void 
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24809,14 +24809,14 @@ return foo?.baz() === 42 &amp;&amp; bar?.baz() === void undefined;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -24971,14 +24971,14 @@ return foo.baz?.() === 42 &amp;&amp; bar.baz?.() === void undefined &amp;&amp; b
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -25133,14 +25133,14 @@ return fn?.(...[], 1) === void undefined &amp;&amp; fn?.(...[], ...[]) === void 
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -25296,14 +25296,14 @@ return (null ?? 42) === 42 &amp;&amp;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="yes obsolete" data-browser="closure20200315">Yes</td>
 <td class="yes obsolete" data-browser="closure20200517">Yes</td>
 <td class="yes obsolete" data-browser="closure20200614">Yes</td>
 <td class="yes obsolete" data-browser="closure20200927">Yes</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -25456,14 +25456,14 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -25611,14 +25611,14 @@ return &apos;q=query+string+parameters&apos;.replaceAll(&apos;+&apos;, &apos; &a
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">2/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="1">2/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="1">2/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -25775,14 +25775,14 @@ Promise.any([
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -25939,14 +25939,14 @@ Promise.any([
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[24]</sup></a></td>
@@ -26094,14 +26094,14 @@ Promise.any([
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -26254,14 +26254,14 @@ return weakref.deref() === O;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -26413,14 +26413,14 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -26568,14 +26568,14 @@ return Object.getPrototypeOf(fr) === FinalizationRegistry.prototype;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">9/9</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">9/9</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="1">9/9</td>
-<td class="tally" data-browser="closure20211107" data-tally="1">9/9</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="1">9/9</td>
+<td class="tally" data-browser="closure20220502" data-tally="1">9/9</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/9</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/9</td>
@@ -26732,14 +26732,14 @@ return a === 2 &amp;&amp; b === 2 &amp;&amp; c === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -26893,14 +26893,14 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -27054,14 +27054,14 @@ return i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -27218,14 +27218,14 @@ return typeof a === &apos;undefined&apos; &amp;&amp; b === 0 &amp;&amp; c === 2;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -27379,14 +27379,14 @@ return typeof a === &apos;undefined&apos; &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -27540,14 +27540,14 @@ return i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -27704,14 +27704,14 @@ return a === 2 &amp;&amp; b === 0 &amp;&amp; c === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -27865,14 +27865,14 @@ return a === 1 &amp;&amp; i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -28026,14 +28026,14 @@ return i === 1;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -28185,14 +28185,14 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="yes obsolete" data-browser="closure20210808">Yes</td>
 <td class="yes obsolete" data-browser="closure20210906">Yes</td>
 <td class="yes obsolete" data-browser="closure20211006">Yes</td>
-<td class="yes" data-browser="closure20211107">Yes</td>
+<td class="yes obsolete" data-browser="closure20211107">Yes</td>
+<td class="yes" data-browser="closure20220502">Yes</td>
 <td class="no obsolete" data-browser="typescript1corejs2">No</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -28342,14 +28342,14 @@ return 1_000_000.000_001 === 1000000.000001 &amp;&amp;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">6/6</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">6/6</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/6</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/6</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/6</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/6</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.16666666666666666" style="background-color:hsl(20,78%,50%)">1/6</td>
@@ -28503,14 +28503,14 @@ return new C().x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -28670,14 +28670,14 @@ return new C(42).x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -28834,14 +28834,14 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -28998,14 +28998,14 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -29162,14 +29162,14 @@ return new C().x() === 42 &amp;&amp; new C().x(null) === void 0;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -29323,14 +29323,14 @@ return new C().x === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -29478,14 +29478,14 @@ return new C().x === 42;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0.75" style="background-color:hsl(90,53%,50%)">3/4</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0.25" style="background-color:hsl(30,75%,50%)">1/4</td>
@@ -29639,14 +29639,14 @@ return C.x === &apos;x&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -29797,14 +29797,14 @@ return (class X { static name = &quot;name&quot;; }).name === &apos;name&apos;;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -29961,14 +29961,14 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -30122,14 +30122,14 @@ return C.x === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -30277,14 +30277,14 @@ return C.x === 42;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/4</td>
@@ -30441,14 +30441,14 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -30605,14 +30605,14 @@ return new C().x() === 42;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -30772,14 +30772,14 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -30939,14 +30939,14 @@ return new C().x() === 42 &amp;&amp; y;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -31103,14 +31103,14 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -31258,14 +31258,14 @@ return A.check(new A) &amp;&amp; !A.check({});
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/3</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">3/3</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/3</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/3</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/3</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/3</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/3</td>
@@ -31424,14 +31424,14 @@ return arr.at(0) === 1
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
+<td class="no obsolete" data-browser="closure20210808">No</td>
+<td class="no obsolete" data-browser="closure20210906">No</td>
+<td class="no obsolete" data-browser="closure20211006">No</td>
+<td class="no obsolete" data-browser="closure20211107">No</td>
+<td class="no" data-browser="closure20220502">No<a href="#closure-at-method-note"><sup>[39]</sup></a></td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -31489,9 +31489,9 @@ return arr.at(0) === 1
 <td class="unknown obsolete" data-browser="safari13">?</td>
 <td class="unknown obsolete" data-browser="safari13_1">?</td>
 <td class="unknown obsolete" data-browser="safari14">?</td>
-<td class="no flagged obsolete" data-browser="safari14_1">Flag<a href="#safari-at-method-note"><sup>[39]</sup></a></td>
-<td class="no flagged" data-browser="safari15">Flag<a href="#safari-at-method-note"><sup>[39]</sup></a></td>
-<td class="no flagged" data-browser="safari15_2">Flag<a href="#safari-at-method-note"><sup>[39]</sup></a></td>
+<td class="no flagged obsolete" data-browser="safari14_1">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
+<td class="no flagged" data-browser="safari15">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
+<td class="no flagged" data-browser="safari15_2">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera73">No</td>
@@ -31549,7 +31549,7 @@ return arr.at(0) === 1
 <td class="unknown obsolete" data-browser="graalvm20_1">?</td>
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
-<td class="no flagged" data-browser="graalvm21">Flag<a href="#graalvm-es2022-note"><sup>[40]</sup></a></td>
+<td class="no flagged" data-browser="graalvm21">Flag<a href="#graalvm-es2022-note"><sup>[41]</sup></a></td>
 <td class="unknown" data-browser="hermes0_7_0">?</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
@@ -31561,7 +31561,7 @@ return arr.at(0) === 1
 <td class="unknown" data-browser="ios13">?</td>
 <td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown" data-browser="ios14">?</td>
-<td class="no flagged unstable" data-browser="ios15">Flag<a href="#safari-at-method-note"><sup>[39]</sup></a></td>
+<td class="no flagged unstable" data-browser="ios15">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
 <td class="unknown" data-browser="samsung12">?</td>
 <td class="unknown" data-browser="samsung13">?</td>
 <td class="no" data-browser="samsung14">No</td>
@@ -31590,14 +31590,14 @@ return str.at(0) === &apos;a&apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
+<td class="no obsolete" data-browser="closure20210808">No</td>
+<td class="no obsolete" data-browser="closure20210906">No</td>
+<td class="no obsolete" data-browser="closure20211006">No</td>
+<td class="no obsolete" data-browser="closure20211107">No</td>
+<td class="no" data-browser="closure20220502">No<a href="#closure-at-method-note"><sup>[39]</sup></a></td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -31655,9 +31655,9 @@ return str.at(0) === &apos;a&apos;
 <td class="unknown obsolete" data-browser="safari13">?</td>
 <td class="unknown obsolete" data-browser="safari13_1">?</td>
 <td class="unknown obsolete" data-browser="safari14">?</td>
-<td class="no flagged obsolete" data-browser="safari14_1">Flag<a href="#safari-at-method-note"><sup>[39]</sup></a></td>
-<td class="no flagged" data-browser="safari15">Flag<a href="#safari-at-method-note"><sup>[39]</sup></a></td>
-<td class="no flagged" data-browser="safari15_2">Flag<a href="#safari-at-method-note"><sup>[39]</sup></a></td>
+<td class="no flagged obsolete" data-browser="safari14_1">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
+<td class="no flagged" data-browser="safari15">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
+<td class="no flagged" data-browser="safari15_2">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera73">No</td>
@@ -31715,7 +31715,7 @@ return str.at(0) === &apos;a&apos;
 <td class="unknown obsolete" data-browser="graalvm20_1">?</td>
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
-<td class="no flagged" data-browser="graalvm21">Flag<a href="#graalvm-es2022-note"><sup>[40]</sup></a></td>
+<td class="no flagged" data-browser="graalvm21">Flag<a href="#graalvm-es2022-note"><sup>[41]</sup></a></td>
 <td class="unknown" data-browser="hermes0_7_0">?</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
@@ -31727,7 +31727,7 @@ return str.at(0) === &apos;a&apos;
 <td class="unknown" data-browser="ios13">?</td>
 <td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown" data-browser="ios14">?</td>
-<td class="no flagged unstable" data-browser="ios15">Flag<a href="#safari-at-method-note"><sup>[39]</sup></a></td>
+<td class="no flagged unstable" data-browser="ios15">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
 <td class="unknown" data-browser="samsung12">?</td>
 <td class="unknown" data-browser="samsung13">?</td>
 <td class="no" data-browser="samsung14">No</td>
@@ -31772,14 +31772,14 @@ return [
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
-<td class="unknown obsolete" data-browser="closure20200517">?</td>
-<td class="unknown obsolete" data-browser="closure20200614">?</td>
-<td class="unknown obsolete" data-browser="closure20200927">?</td>
-<td class="unknown obsolete" data-browser="closure20210808">?</td>
-<td class="unknown obsolete" data-browser="closure20210906">?</td>
-<td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="no obsolete" data-browser="closure20200517">No</td>
+<td class="no obsolete" data-browser="closure20200614">No</td>
+<td class="no obsolete" data-browser="closure20200927">No</td>
+<td class="no obsolete" data-browser="closure20210808">No</td>
+<td class="no obsolete" data-browser="closure20210906">No</td>
+<td class="no obsolete" data-browser="closure20211006">No</td>
+<td class="no obsolete" data-browser="closure20211107">No</td>
+<td class="no" data-browser="closure20220502">No<a href="#closure-typed-array-note"><sup>[42]</sup></a></td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -31837,9 +31837,9 @@ return [
 <td class="unknown obsolete" data-browser="safari13">?</td>
 <td class="unknown obsolete" data-browser="safari13_1">?</td>
 <td class="unknown obsolete" data-browser="safari14">?</td>
-<td class="no flagged obsolete" data-browser="safari14_1">Flag<a href="#safari-at-method-note"><sup>[39]</sup></a></td>
-<td class="no flagged" data-browser="safari15">Flag<a href="#safari-at-method-note"><sup>[39]</sup></a></td>
-<td class="no flagged" data-browser="safari15_2">Flag<a href="#safari-at-method-note"><sup>[39]</sup></a></td>
+<td class="no flagged obsolete" data-browser="safari14_1">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
+<td class="no flagged" data-browser="safari15">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
+<td class="no flagged" data-browser="safari15_2">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
 <td class="yes unstable" data-browser="safaritp">Yes</td>
 <td class="yes unstable" data-browser="webkit">Yes</td>
 <td class="no obsolete" data-browser="opera73">No</td>
@@ -31897,7 +31897,7 @@ return [
 <td class="unknown obsolete" data-browser="graalvm20_1">?</td>
 <td class="unknown obsolete" data-browser="graalvm20_3">?</td>
 <td class="unknown" data-browser="graalvm20_3_1">?</td>
-<td class="no flagged" data-browser="graalvm21">Flag<a href="#graalvm-es2022-note"><sup>[40]</sup></a></td>
+<td class="no flagged" data-browser="graalvm21">Flag<a href="#graalvm-es2022-note"><sup>[41]</sup></a></td>
 <td class="unknown" data-browser="hermes0_7_0">?</td>
 <td class="unknown obsolete" data-browser="android4_4">?</td>
 <td class="unknown obsolete" data-browser="android4_4_3">?</td>
@@ -31909,7 +31909,7 @@ return [
 <td class="unknown" data-browser="ios13">?</td>
 <td class="unknown" data-browser="ios13_4">?</td>
 <td class="unknown" data-browser="ios14">?</td>
-<td class="no flagged unstable" data-browser="ios15">Flag<a href="#safari-at-method-note"><sup>[39]</sup></a></td>
+<td class="no flagged unstable" data-browser="ios15">Flag<a href="#safari-at-method-note"><sup>[40]</sup></a></td>
 <td class="unknown" data-browser="samsung12">?</td>
 <td class="unknown" data-browser="samsung13">?</td>
 <td class="no" data-browser="samsung14">No</td>
@@ -31927,14 +31927,14 @@ return [
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -32085,14 +32085,14 @@ return Object.hasOwn({ x: 2 }, &quot;x&quot;) === true;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -32249,14 +32249,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[5]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -32411,14 +32411,14 @@ return ok;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -32431,9 +32431,9 @@ return ok;
 <td class="no" data-browser="ie11">No</td>
 <td class="no obsolete" data-browser="firefox78">No</td>
 <td class="no obsolete" data-browser="firefox89">No</td>
-<td class="no flagged obsolete" data-browser="firefox90">Flag<a href="#ff-static-init-blocks-note"><sup>[41]</sup></a></td>
-<td class="no flagged" data-browser="firefox91">Flag<a href="#ff-static-init-blocks-note"><sup>[41]</sup></a></td>
-<td class="no flagged obsolete" data-browser="firefox92">Flag<a href="#ff-static-init-blocks-note"><sup>[41]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox90">Flag<a href="#ff-static-init-blocks-note"><sup>[43]</sup></a></td>
+<td class="no flagged" data-browser="firefox91">Flag<a href="#ff-static-init-blocks-note"><sup>[43]</sup></a></td>
+<td class="no flagged obsolete" data-browser="firefox92">Flag<a href="#ff-static-init-blocks-note"><sup>[43]</sup></a></td>
 <td class="yes obsolete" data-browser="firefox93">Yes</td>
 <td class="yes obsolete" data-browser="firefox94">Yes</td>
 <td class="yes obsolete" data-browser="firefox95">Yes</td>
@@ -32451,9 +32451,9 @@ return ok;
 <td class="no obsolete" data-browser="chrome88">No</td>
 <td class="no obsolete" data-browser="chrome89">No</td>
 <td class="no obsolete" data-browser="chrome90">No</td>
-<td class="no flagged obsolete" data-browser="chrome91">Flag<a href="#ch-static-init-blocks-note"><sup>[42]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome92">Flag<a href="#ch-static-init-blocks-note"><sup>[42]</sup></a></td>
-<td class="no flagged obsolete" data-browser="chrome93">Flag<a href="#ch-static-init-blocks-note"><sup>[42]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome91">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome92">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
+<td class="no flagged obsolete" data-browser="chrome93">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
 <td class="yes obsolete" data-browser="chrome94">Yes</td>
 <td class="yes obsolete" data-browser="chrome95">Yes</td>
 <td class="yes obsolete" data-browser="chrome96">Yes</td>
@@ -32467,9 +32467,9 @@ return ok;
 <td class="no obsolete" data-browser="edge88">No</td>
 <td class="no obsolete" data-browser="edge89">No</td>
 <td class="no obsolete" data-browser="edge90">No</td>
-<td class="no flagged obsolete" data-browser="edge91">Flag<a href="#ch-static-init-blocks-note"><sup>[42]</sup></a></td>
-<td class="no flagged obsolete" data-browser="edge92">Flag<a href="#ch-static-init-blocks-note"><sup>[42]</sup></a></td>
-<td class="no flagged obsolete" data-browser="edge93">Flag<a href="#ch-static-init-blocks-note"><sup>[42]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge91">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge92">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
+<td class="no flagged obsolete" data-browser="edge93">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
 <td class="yes" data-browser="edge94">Yes</td>
 <td class="yes" data-browser="edge95">Yes</td>
 <td class="yes unstable" data-browser="edge96">Yes</td>
@@ -32485,9 +32485,9 @@ return ok;
 <td class="no obsolete" data-browser="opera74">No</td>
 <td class="no obsolete" data-browser="opera75">No</td>
 <td class="no obsolete" data-browser="opera76">No</td>
-<td class="no flagged obsolete" data-browser="opera77">Flag<a href="#ch-static-init-blocks-note"><sup>[42]</sup></a></td>
-<td class="no flagged obsolete" data-browser="opera78">Flag<a href="#ch-static-init-blocks-note"><sup>[42]</sup></a></td>
-<td class="no flagged" data-browser="opera79">Flag<a href="#ch-static-init-blocks-note"><sup>[42]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera77">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera78">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
+<td class="no flagged" data-browser="opera79">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
 <td class="yes" data-browser="opera80">Yes</td>
 <td class="yes unstable" data-browser="opera81">Yes</td>
 <td class="no obsolete" data-browser="rhino1_7_13">No</td>
@@ -32521,7 +32521,7 @@ return ok;
 <td class="no" data-browser="node14_6">No</td>
 <td class="no obsolete" data-browser="node15_0">No</td>
 <td class="no obsolete" data-browser="node16_0">No</td>
-<td class="no flagged obsolete" data-browser="node16_9">Flag<a href="#ch-static-init-blocks-note"><sup>[42]</sup></a></td>
+<td class="no flagged obsolete" data-browser="node16_9">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
 <td class="yes" data-browser="node16_11">Yes</td>
 <td class="yes obsolete" data-browser="node17_0">Yes</td>
 <td class="yes" data-browser="node17_2">Yes</td>
@@ -32555,8 +32555,8 @@ return ok;
 <td class="no unstable" data-browser="samsung15">No</td>
 <td class="no obsolete" data-browser="opera_mobile62">No</td>
 <td class="no obsolete" data-browser="opera_mobile63">No</td>
-<td class="no flagged obsolete" data-browser="opera_mobile64">Flag<a href="#ch-static-init-blocks-note"><sup>[42]</sup></a></td>
-<td class="no flagged obsolete" data-browser="opera_mobile65">Flag<a href="#ch-static-init-blocks-note"><sup>[42]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera_mobile64">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
+<td class="no flagged obsolete" data-browser="opera_mobile65">Flag<a href="#ch-static-init-blocks-note"><sup>[44]</sup></a></td>
 <td class="yes obsolete" data-browser="opera_mobile66">Yes</td>
 <td class="yes" data-browser="opera_mobile67">Yes</td>
 <td class="yes" data-browser="opera_mobile68">Yes</td>
@@ -32566,14 +32566,14 @@ return ok;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/16</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/16</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/16</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/16</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/16</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/16</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/16</td>
@@ -32725,14 +32725,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -32883,14 +32883,14 @@ return !(&apos;cause&apos; in Error.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -33042,14 +33042,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -33200,14 +33200,14 @@ return !(&apos;cause&apos; in EvalError.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -33359,14 +33359,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -33517,14 +33517,14 @@ return !(&apos;cause&apos; in RangeError.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -33676,14 +33676,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -33834,14 +33834,14 @@ return !(&apos;cause&apos; in ReferenceError.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -33993,14 +33993,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -34151,14 +34151,14 @@ return !(&apos;cause&apos; in SyntaxError.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -34310,14 +34310,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -34468,14 +34468,14 @@ return !(&apos;cause&apos; in TypeError.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -34627,14 +34627,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -34785,14 +34785,14 @@ return !(&apos;cause&apos; in URIError.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -34944,14 +34944,14 @@ return error.hasOwnProperty(&apos;cause&apos;) &amp;&amp; error.cause === &apos;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -35102,14 +35102,14 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -35257,14 +35257,14 @@ return !(&apos;cause&apos; in AggregateError.prototype);
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -35415,14 +35415,14 @@ return new RegExp(&apos;a&apos;, &apos;d&apos;) instanceof RegExp;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -35588,14 +35588,14 @@ return true;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -35742,7 +35742,7 @@ return true;
     </table>
     <div id="footnotes">
       <!-- FOOTNOTES -->
-    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="chrome-experimental-note">  <sup>[4]</sup> The feature has to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="babel-core-js-note">  <sup>[5]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="typescript-downlevel-iteration-note">  <sup>[9]</sup> Requires the <code>downlevelIteration</code> compile option.</p><p id="strict-fn-non-strict-params-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[12]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[13]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="babel-regenerator-note">  <sup>[14]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="fx-shared-memory-esr-disable-note">  <sup>[15]</sup> The feature was intentionally disabled to prepare for Firefox 78 ESR</p><p id="fx-shared-memory-cors-isolation-note">  <sup>[16]</sup> The feature is available with <a href="https://hacks.mozilla.org/2020/07/safely-reviving-shared-memory/">properly set CORS isolation headers</a> or via enabling <code>dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled</code> setting under <code>about:config</code></p><p id="edg-shared-memory-spectre-note">  <sup>[17]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="sf-shared-memory-spectre-note">  <sup>[18]</sup> The feature was <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-sharedmem-note">  <sup>[19]</sup> The feature has to be enabled via &quot;Experimental enabled SharedArrayBuffer support in JavaScript.&quot; setting under <code>about:flags</code></p><p id="chr-shared-memory-spectre-note">  <sup>[20]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-harmony-note">  <sup>[21]</sup> The feature has to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="closure-object-assign-note">  <sup>[22]</sup> Requires native support for <code>Object.assign</code></p><p id="chrome-promise-note">  <sup>[23]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-promise-finally&quot;</code> flag</p><p id="typescript-es6-note">  <sup>[24]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="flatten-compat-issue-note">  <sup>[25]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="graalvm-es2020-note">  <sup>[26]</sup> The feature can be enabled via <code>--js.ecmascript-version=2020</code> flag</p><p id="chrome-optional-chaining-note">  <sup>[27]</sup> The feature has to be enabled via <code>--js-flags=&quot;--harmony-optional-chaining&quot;</code> flag</p><p id="chrome-nullish-note">  <sup>[28]</sup> The feature has to be enabled via <code>--js-flags=&quot;--harmony-nullish&quot;</code> flag</p><p id="chrome-string-prototype-replace-all-note">  <sup>[29]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-string-replaceall&quot;</code> flag</p><p id="graalvm-es2021-note">  <sup>[30]</sup> The feature can be enabled via <code>--js.ecmascript-version=2021</code> flag</p><p id="firefox-nightly-note">  <sup>[31]</sup> The feature is available only in Firefox Nightly builds.</p><p id="chrome-promise-any-note">  <sup>[32]</sup> Available behind the <a href="https://bugs.chromium.org/p/v8/issues/detail?id=9808"><code>--js-flags=&quot;--harmony-promise-any&quot;</code></a> flag in V8.</p><p id="firefox-weakrefs-note">  <sup>[33]</sup> The feature has to be enabled via <code>javascript.options.experimental.weakrefs</code> setting under <code>about:config</code>.</p><p id="chrome-weakrefs-note">  <sup>[34]</sup> Available behind the <a href="https://bugs.chromium.org/p/v8/issues/detail?id=8179"><code>--js-flags=&quot;--harmony-weak-refs --expose-gc&quot;</code></a> flag in V8.</p><p id="chrome-logical-assignment-note">  <sup>[35]</sup> Available behind the <a href="https://github.com/v8/v8/commit/b151d8db22be308738192497a68c2c7c0d8d4070"><code>--js-flags=&quot;--logical-assignment&quot;</code></a> flag in V8.</p><p id="firefox-private-class-fields-note">  <sup>[36]</sup> The feature has to be enabled via <code>javascript.options.experimental.fields</code> setting under <code>about:config</code>. Private fields are supported by parser, but behave as public fields.</p><p id="fx-private-fields-note">  <sup>[37]</sup> The feature has to be enabled via <code>javascript.options.experimental.private_fields</code> setting under <code>about:config</code>.</p><p id="ff-private-instance-methods-and-accessors-note">  <sup>[38]</sup> The feature has to be enabled via <code>javascript.options.experimental.private_fields</code> and <code>javascript.options.experimental.private_methods</code> settings under <code>about:config</code>.</p><p id="safari-at-method-note">  <sup>[39]</sup> The feature has to be enabled via <code>jscOptions=--useAtMethod=true</code> flag.</p><p id="graalvm-es2022-note">  <sup>[40]</sup> The feature can be enabled via <code>--js.ecmascript-version=2022</code> flag</p><p id="ff-static-init-blocks-note">  <sup>[41]</sup> The feature has to be enabled via <code>javascript.options.experimental.class_static_blocks=true</code> flag.</p><p id="ch-static-init-blocks-note">  <sup>[42]</sup> The feature has to be enabled via <code>harmony_class_static_blocks</code> flag.</p></div>
+    <p id="harmony-flag-old-note">  <sup>[1]</sup> Flagged features have to be enabled via <code>--harmony</code> flag</p><p id="harmony-flag-note">  <sup>[2]</sup> Flagged features have to be enabled via <code>--harmony</code> or <code>--es_staging</code> flag</p><p id="graalvm-node-mode-note">  <sup>[3]</sup> Executed in Node.js/JVM mode via <code>graalvm/bin/node --jvm</code>.</p><p id="chrome-experimental-note">  <sup>[4]</sup> The feature has to be enabled via &quot;Experimental Javascript features&quot; setting under <code>about:flags</code></p><p id="babel-core-js-note">  <sup>[5]</sup> This feature is supported when using Babel with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="typescript-core-js-note">  <sup>[6]</sup> This feature is supported when using TypeScript with <a href="https://github.com/zloirock/core-js">core-js</a>.</p><p id="new-gen-fn-note">  <sup>[7]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#67-new--generatorfunction">TC39 meeting notes from July 28, 2015.</a></p><p id="gen-throw-note">  <sup>[8]</sup> <a href="https://github.com/tc39/ecma262/issues/293">&apos;Semantics of yield* in throw case&apos; GitHub issue in ECMA-262 repo.</a></p><p id="typescript-downlevel-iteration-note">  <sup>[9]</sup> Requires the <code>downlevelIteration</code> compile option.</p><p id="strict-fn-non-strict-params-note">  <sup>[10]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-29.md#611-the-scope-of-use-strict-with-respect-to-destructuring-in-parameter-lists">TC39 meeting notes from July 29, 2015.</a></p><p id="nested-rest-destruct-decl-note">  <sup>[11]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="nested-rest-destruct-params-note">  <sup>[12]</sup> <a href="https://github.com/rwaldron/tc39-notes/blob/master/es7/2015-07/july-28.md#66-bindingrestelement-should-allow-a-bindingpattern-ala-assignmentrestelement">TC39 meeting notes from July 28, 2015.</a></p><p id="proxy-enumerate-removed-note">  <sup>[13]</sup> <a href="https://github.com/tc39/ecma262/pull/367">&apos;Normative: Remove [[Enumerate]] and associated reflective capabilities&apos; GitHub Pull Request in ECMA-262 repo.</a></p><p id="babel-regenerator-note">  <sup>[14]</sup> This feature requires native generators or <code>regenerator-runtime</code>, it&apos;s a part of <code>babel-polyfill</code> or <code>babel-runtime</code>.</p><p id="fx-shared-memory-esr-disable-note">  <sup>[15]</sup> The feature was intentionally disabled to prepare for Firefox 78 ESR</p><p id="fx-shared-memory-cors-isolation-note">  <sup>[16]</sup> The feature is available with <a href="https://hacks.mozilla.org/2020/07/safely-reviving-shared-memory/">properly set CORS isolation headers</a> or via enabling <code>dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled</code> setting under <code>about:config</code></p><p id="edg-shared-memory-spectre-note">  <sup>[17]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="sf-shared-memory-spectre-note">  <sup>[18]</sup> The feature was <a href="https://webkit.org/blog/8048/what-spectre-and-meltdown-mean-for-webkit/">temporarily disabled</a> to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-sharedmem-note">  <sup>[19]</sup> The feature has to be enabled via &quot;Experimental enabled SharedArrayBuffer support in JavaScript.&quot; setting under <code>about:flags</code></p><p id="chr-shared-memory-spectre-note">  <sup>[20]</sup> The feature was temporarily disabled to mitigate the Meltdown and Spectre CPU bugs.</p><p id="chrome-harmony-note">  <sup>[21]</sup> The feature has to be enabled via <code>--js-flags=&quot;--harmony&quot;</code> flag</p><p id="closure-object-assign-note">  <sup>[22]</sup> Requires native support for <code>Object.assign</code></p><p id="chrome-promise-note">  <sup>[23]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-promise-finally&quot;</code> flag</p><p id="typescript-es6-note">  <sup>[24]</sup> TypeScript&apos;s compiler will accept code using this feature if the <code>--target ES6</code> flag is set, but passes it through unmodified and does not supply a runtime polyfill.</p><p id="flatten-compat-issue-note">  <sup>[25]</sup> Name of <code>Array.prototype.flatten()</code> changed to <code>Array.prototype.flat()</code> due to <a href="https://github.com/tc39/proposal-flatMap/pull/56">web compatibility issues.</a></p><p id="graalvm-es2020-note">  <sup>[26]</sup> The feature can be enabled via <code>--js.ecmascript-version=2020</code> flag</p><p id="chrome-optional-chaining-note">  <sup>[27]</sup> The feature has to be enabled via <code>--js-flags=&quot;--harmony-optional-chaining&quot;</code> flag</p><p id="chrome-nullish-note">  <sup>[28]</sup> The feature has to be enabled via <code>--js-flags=&quot;--harmony-nullish&quot;</code> flag</p><p id="chrome-string-prototype-replace-all-note">  <sup>[29]</sup> The feature is considered unstable, but can be enabled via <code>--js-flags=&quot;--harmony-string-replaceall&quot;</code> flag</p><p id="graalvm-es2021-note">  <sup>[30]</sup> The feature can be enabled via <code>--js.ecmascript-version=2021</code> flag</p><p id="firefox-nightly-note">  <sup>[31]</sup> The feature is available only in Firefox Nightly builds.</p><p id="chrome-promise-any-note">  <sup>[32]</sup> Available behind the <a href="https://bugs.chromium.org/p/v8/issues/detail?id=9808"><code>--js-flags=&quot;--harmony-promise-any&quot;</code></a> flag in V8.</p><p id="firefox-weakrefs-note">  <sup>[33]</sup> The feature has to be enabled via <code>javascript.options.experimental.weakrefs</code> setting under <code>about:config</code>.</p><p id="chrome-weakrefs-note">  <sup>[34]</sup> Available behind the <a href="https://bugs.chromium.org/p/v8/issues/detail?id=8179"><code>--js-flags=&quot;--harmony-weak-refs --expose-gc&quot;</code></a> flag in V8.</p><p id="chrome-logical-assignment-note">  <sup>[35]</sup> Available behind the <a href="https://github.com/v8/v8/commit/b151d8db22be308738192497a68c2c7c0d8d4070"><code>--js-flags=&quot;--logical-assignment&quot;</code></a> flag in V8.</p><p id="firefox-private-class-fields-note">  <sup>[36]</sup> The feature has to be enabled via <code>javascript.options.experimental.fields</code> setting under <code>about:config</code>. Private fields are supported by parser, but behave as public fields.</p><p id="fx-private-fields-note">  <sup>[37]</sup> The feature has to be enabled via <code>javascript.options.experimental.private_fields</code> setting under <code>about:config</code>.</p><p id="ff-private-instance-methods-and-accessors-note">  <sup>[38]</sup> The feature has to be enabled via <code>javascript.options.experimental.private_fields</code> and <code>javascript.options.experimental.private_methods</code> settings under <code>about:config</code>.</p><p id="closure-at-method-note">  <sup>[39]</sup> Requires native support for <code>Math.trunc</code></p><p id="safari-at-method-note">  <sup>[40]</sup> The feature has to be enabled via <code>jscOptions=--useAtMethod=true</code> flag.</p><p id="graalvm-es2022-note">  <sup>[41]</sup> The feature can be enabled via <code>--js.ecmascript-version=2022</code> flag</p><p id="closure-typed-array-note">  <sup>[42]</sup> Requires native support for typed arrays</p><p id="ff-static-init-blocks-note">  <sup>[43]</sup> The feature has to be enabled via <code>javascript.options.experimental.class_static_blocks=true</code> flag.</p><p id="ch-static-init-blocks-note">  <sup>[44]</sup> The feature has to be enabled via <code>harmony_class_static_blocks</code> flag.</p></div>
   </div>
   <pre class="info-tooltip" style="display:none"></pre>
 </body>

--- a/esnext/index.html
+++ b/esnext/index.html
@@ -134,14 +134,14 @@
 <th class="platform babel6corejs2 compiler obsolete" data-browser="babel6corejs2"><a href="#babel6corejs2" class="browser-name"><abbr title="Babel 6.5 + core-js 2.5">Babel 6 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs2 compiler obsolete" data-browser="babel7corejs2"><a href="#babel7corejs2" class="browser-name"><abbr title="Babel 7 + core-js 2.5">Babel 7 +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform babel7corejs3 compiler" data-browser="babel7corejs3"><a href="#babel7corejs3" class="browser-name"><abbr title="Babel 7 + core-js 3">Babel 7 +<br><nobr>core-js 3</nobr></abbr></a></th>
-<th class="platform closure20200315 compiler obsolete" data-browser="closure20200315"><a href="#closure20200315" class="browser-name"><abbr title="Closure Compiler &gt;=v20200315 &lt;v20200517">Closure 2020.03</abbr></a></th>
 <th class="platform closure20200517 compiler obsolete" data-browser="closure20200517"><a href="#closure20200517" class="browser-name"><abbr title="Closure Compiler &gt;=v20200517 &lt;v20200614">Closure 2020.05</abbr></a></th>
 <th class="platform closure20200614 compiler obsolete" data-browser="closure20200614"><a href="#closure20200614" class="browser-name"><abbr title="Closure Compiler &gt;=v20200614 &lt;v20200927">Closure 2020.06</abbr></a></th>
 <th class="platform closure20200927 compiler obsolete" data-browser="closure20200927"><a href="#closure20200927" class="browser-name"><abbr title="Closure Compiler &gt;=v20200927 &lt;v20210808">Closure 2020.09</abbr></a></th>
 <th class="platform closure20210808 compiler obsolete" data-browser="closure20210808"><a href="#closure20210808" class="browser-name"><abbr title="Closure Compiler v20210808">Closure 2021.08</abbr></a></th>
 <th class="platform closure20210906 compiler obsolete" data-browser="closure20210906"><a href="#closure20210906" class="browser-name"><abbr title="Closure Compiler v20210906">Closure 2021.09</abbr></a></th>
 <th class="platform closure20211006 compiler obsolete" data-browser="closure20211006"><a href="#closure20211006" class="browser-name"><abbr title="Closure Compiler v20211006">Closure 2021.10</abbr></a></th>
-<th class="platform closure20211107 compiler" data-browser="closure20211107"><a href="#closure20211107" class="browser-name"><abbr title="Closure Compiler &gt;=v20211107">Closure 2021.11</abbr></a></th>
+<th class="platform closure20211107 compiler obsolete" data-browser="closure20211107"><a href="#closure20211107" class="browser-name"><abbr title="Closure Compiler &gt;=v20211107">Closure 2021.11</abbr></a></th>
+<th class="platform closure20220502 compiler" data-browser="closure20220502"><a href="#closure20220502" class="browser-name"><abbr title="Closure Compiler &gt;=v20220502">Closure 2022.05</abbr></a></th>
 <th class="platform typescript1corejs2 compiler obsolete" data-browser="typescript1corejs2"><a href="#typescript1corejs2" class="browser-name"><abbr title="TypeScript 1.8 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript2_9corejs2 compiler obsolete" data-browser="typescript2_9corejs2"><a href="#typescript2_9corejs2" class="browser-name"><abbr title="TypeScript 2.9 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
 <th class="platform typescript3_2corejs2 compiler obsolete" data-browser="typescript3_2corejs2"><a href="#typescript3_2corejs2" class="browser-name"><abbr title="TypeScript 3.2 + core-js 2.5">Type-<br>Script +<br><nobr>core-js 2</nobr></abbr></a></th>
@@ -296,14 +296,14 @@ return typeof Realm === &quot;function&quot;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -446,14 +446,14 @@ return typeof Realm === &quot;function&quot;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -605,14 +605,14 @@ return RegExp.lastMatch === 'x';
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -766,14 +766,14 @@ return true;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -923,14 +923,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="no" data-browser="babel7corejs3">No</td>
-<td class="no obsolete" data-browser="closure20200315">No</td>
 <td class="no obsolete" data-browser="closure20200517">No</td>
 <td class="no obsolete" data-browser="closure20200614">No</td>
 <td class="no obsolete" data-browser="closure20200927">No</td>
 <td class="no obsolete" data-browser="closure20210808">No</td>
 <td class="no obsolete" data-browser="closure20210906">No</td>
 <td class="no obsolete" data-browser="closure20211006">No</td>
-<td class="no" data-browser="closure20211107">No</td>
+<td class="no obsolete" data-browser="closure20211107">No</td>
+<td class="no" data-browser="closure20220502">No</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1073,14 +1073,14 @@ try {
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -1227,14 +1227,14 @@ return arr.findLast(function (o) { return o.x === 1; }) === arr[2];
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1381,14 +1381,14 @@ return arr.findLastIndex(function (o) { return o.x === 1; }) === 2;
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1542,14 +1542,14 @@ return result === &apos;tromple&apos;;
 <td class="yes obsolete" data-browser="babel6corejs2">Yes</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -1692,14 +1692,14 @@ return result === &apos;tromple&apos;;
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/1</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/1</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/1</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/1</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/1</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/1</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="1">1/1</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="1">1/1</td>
@@ -1853,14 +1853,14 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="no obsolete" data-browser="babel6corejs2">No<a href="#babel-decorators-legacy-note"><sup>[7]</sup></a></td>
 <td class="no obsolete" data-browser="babel7corejs2">No<a href="#babel-decorators-legacy-note"><sup>[7]</sup></a></td>
 <td class="no" data-browser="babel7corejs3">No<a href="#babel-decorators-legacy-note"><sup>[7]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="yes obsolete" data-browser="typescript1corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript2_9corejs2">Yes</td>
 <td class="yes obsolete" data-browser="typescript3_2corejs2">Yes</td>
@@ -2003,14 +2003,14 @@ return Object.getOwnPropertyDescriptor(A.prototype, &quot;B&quot;).configurable 
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="1">4/4</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">4/4</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/4</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/4</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/4</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/4</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/4</td>
@@ -2162,14 +2162,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2325,14 +2325,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2483,14 +2483,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2641,14 +2641,14 @@ try {
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="yes obsolete" data-browser="babel7corejs2">Yes</td>
 <td class="yes" data-browser="babel7corejs3">Yes</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -2791,14 +2791,14 @@ try {
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/7</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">7/7</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/7</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/7</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/7</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/7</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/7</td>
@@ -2947,14 +2947,14 @@ return set.size === 2
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -3104,14 +3104,14 @@ return set.size === 3
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -3260,14 +3260,14 @@ return set.size === 2
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -3416,14 +3416,14 @@ return set.size === 2
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -3569,14 +3569,14 @@ return new Set([1, 2, 3]).isDisjointFrom([4, 5, 6]);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -3722,14 +3722,14 @@ return new Set([1, 2, 3]).isSubsetOf([5, 4, 3, 2, 1]);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -3875,14 +3875,14 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -4025,14 +4025,14 @@ return new Set([5, 4, 3, 2, 1]).isSupersetOf([1, 2, 3]);
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="0">0/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -4181,14 +4181,14 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4337,14 +4337,14 @@ return buffer1.byteLength === 0
 <td class="unknown obsolete" data-browser="babel6corejs2">?</td>
 <td class="unknown obsolete" data-browser="babel7corejs2">?</td>
 <td class="unknown" data-browser="babel7corejs3">?</td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="unknown obsolete" data-browser="typescript1corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript2_9corejs2">?</td>
 <td class="unknown obsolete" data-browser="typescript3_2corejs2">?</td>
@@ -4487,14 +4487,14 @@ return buffer1.byteLength === 0
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/2</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">2/2</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/2</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/2</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/2</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/2</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/2</td>
@@ -4643,14 +4643,14 @@ return Array.from(map).join() === &apos;a,2,b,3&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -4800,14 +4800,14 @@ return map.get(a) === 2 &amp;&amp; map.get(b) === 3;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -4954,14 +4954,14 @@ return !Array.isTemplateObject([])
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -5104,14 +5104,14 @@ return !Array.isTemplateObject([])
 <td class="tally obsolete" data-browser="babel6corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="babel7corejs2" data-tally="0">0/35</td>
 <td class="tally" data-browser="babel7corejs3" data-tally="1">35/35</td>
-<td class="tally obsolete" data-browser="closure20200315" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20200517" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20200614" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20200927" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20210808" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20210906" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="closure20211006" data-tally="0">0/35</td>
-<td class="tally" data-browser="closure20211107" data-tally="0">0/35</td>
+<td class="tally obsolete" data-browser="closure20211107" data-tally="0">0/35</td>
+<td class="tally" data-browser="closure20220502" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript1corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript2_9corejs2" data-tally="0">0/35</td>
 <td class="tally obsolete" data-browser="typescript3_2corejs2" data-tally="0">0/35</td>
@@ -5257,14 +5257,14 @@ return [1, 2, 3].values() instanceof Iterator;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -5412,14 +5412,14 @@ return instance[Symbol.iterator]() === instance;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -5568,14 +5568,14 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -5729,14 +5729,14 @@ return &apos;next&apos; in iterator
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -5882,14 +5882,14 @@ return Array.from([1, 2, 3].values().asIndexedPairs()).join() === &apos;0,1,1,2,
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -6035,14 +6035,14 @@ return Array.from([1, 2, 3].values().drop(1)).join() === &apos;2,3&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -6188,14 +6188,14 @@ return [1, 2, 3].values().every(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -6341,14 +6341,14 @@ return Array.from([1, 2, 3].values().filter(it =&gt; it % 2)).join() === &apos;1
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -6494,14 +6494,14 @@ return [1, 2, 3].values().find(it =&gt; it % 2) === 1;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -6647,14 +6647,14 @@ return Array.from([1, 2, 3].values().flatMap(it =&gt; [it, 0])).join() === &apos
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -6802,14 +6802,14 @@ return result === &apos;123&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -6955,14 +6955,14 @@ return Array.from([1, 2, 3].values().map(it =&gt; it * it)).join() === &apos;1,4
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -7108,14 +7108,14 @@ return [1, 2, 3].values().reduce((a, b) =&gt; a + b) === 6;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -7261,14 +7261,14 @@ return [1, 2, 3].values().some(it =&gt; typeof it === &apos;number&apos;);
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -7414,14 +7414,14 @@ return Array.from([1, 2, 3].values().take(2)).join() === &apos;1,2&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -7568,14 +7568,14 @@ return Array.isArray(array) &amp;&amp; array.join() === &apos;1,2,3&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -7721,14 +7721,14 @@ return Iterator.prototype[Symbol.toStringTag] === &apos;Iterator&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -7874,14 +7874,14 @@ return (async function*() {})() instanceof AsyncIterator;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -8029,14 +8029,14 @@ return instance[Symbol.asyncIterator]() === instance;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -8194,14 +8194,14 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -8359,14 +8359,14 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -8524,14 +8524,14 @@ toArray(iterator).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -8685,14 +8685,14 @@ toArray((async function*() { yield * [1, 2, 3] })().asIndexedPairs()).then(it =&
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -8846,14 +8846,14 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -9001,14 +9001,14 @@ toArray(async function*() { yield * [1, 2, 3] }().drop(1)).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -9162,14 +9162,14 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -9317,14 +9317,14 @@ toArray(async function*() { yield * [1, 2, 3] }().filter(it =&gt; it % 2)).then(
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -9478,14 +9478,14 @@ toArray(async function*() { yield * [1, 2, 3] }().flatMap(it =&gt; [it, 0])).the
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -9634,14 +9634,14 @@ let result = &apos;&apos;;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -9795,14 +9795,14 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -9950,14 +9950,14 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -10105,14 +10105,14 @@ toArray(async function*() { yield * [1, 2, 3] }().map(it =&gt; it * it)).then(it
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -10266,14 +10266,14 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -10421,14 +10421,14 @@ toArray(async function*() { yield * [1, 2, 3] }().take(2)).then(it =&gt; {
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
@@ -10574,14 +10574,14 @@ return AsyncIterator.prototype[Symbol.toStringTag] === &apos;AsyncIterator&apos;
 <td class="no obsolete" data-browser="babel6corejs2">No</td>
 <td class="no obsolete" data-browser="babel7corejs2">No</td>
 <td class="yes" data-browser="babel7corejs3">Yes<a href="#babel-core-js-note"><sup>[4]</sup></a></td>
-<td class="unknown obsolete" data-browser="closure20200315">?</td>
 <td class="unknown obsolete" data-browser="closure20200517">?</td>
 <td class="unknown obsolete" data-browser="closure20200614">?</td>
 <td class="unknown obsolete" data-browser="closure20200927">?</td>
 <td class="unknown obsolete" data-browser="closure20210808">?</td>
 <td class="unknown obsolete" data-browser="closure20210906">?</td>
 <td class="unknown obsolete" data-browser="closure20211006">?</td>
-<td class="unknown" data-browser="closure20211107">?</td>
+<td class="unknown obsolete" data-browser="closure20211107">?</td>
+<td class="unknown" data-browser="closure20220502">?</td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript1corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript2_9corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>
 <td class="no needs-polyfill-or-native obsolete" title="Requires native support or a polyfill." data-browser="typescript3_2corejs2">?<a href="#typescript-es6-note"><sup>[8]</sup></a></td>


### PR DESCRIPTION
- fix results for recently updated tests
- update results to v20220601: ES2022 `.at()` methods
- add closure:false to fix undefined results